### PR TITLE
fix: wrong link to pl/java

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Unmodified Postgres with some useful plugins. Our goal with this repo is not to 
 - ✅ [pgsql-http](https://github.com/pramsey/pgsql-http). HTTP client for Postgres.
 - ✅ [plpgsql_check](https://github.com/okbob/plpgsql_check). Linter tool for PL/pgSQL.
 - ✅ [plv8](https://github.com/plv8/plv8). Write in Javascript functions in Postgres.
-- ✅ [PL/Java](https://github.com/tada/pljaval). Write in Java functions in Postgres.
+- ✅ [PL/Java](https://github.com/tada/pljava). Write in Java functions in Postgres.
 - ✅ [pg_cron](https://github.com/citusdata/pg_cron). Run CRON jobs inside Postgres.
 - ✅ [pg-safeupdate](https://github.com/eradman/pg-safeupdate). Protect your data from accidental updates or deletes.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
doc change

## What is the current behavior?
N/A

## What is the new behavior?
N/A

## Additional context
Just fixes the 404 if one tries to learn more about PL/Java