### PR TITLE
Install AWS CLI

### DIFF
--- a/ansible/tasks/setup-misc.yml
+++ b/ansible/tasks/setup-misc.yml
@@ -95,3 +95,18 @@
     enabled: yes
     name: postgres_exporter
     daemon_reload: yes
+
+- name: AWS CLI
+  get_url:
+    url: "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-{{ aws_cli_release }}.zip"
+    dest: "/tmp/awscliv2.zip"
+
+- name: AWS CLI - expand
+  unarchive:
+    remote_src: yes
+    src: "/tmp/awscliv2.zip"
+    dest: "/tmp"
+
+- name: AWS CLI - install
+  shell: "/tmp/aws/install"
+  become: true

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -95,3 +95,5 @@ wal_g_release_checksum: sha1:e82d405121e0ccc322a323b9824e60c102b14004
 
 postgres_exporter_release: "0.9.0"
 postgres_exporter_release_checksum: sha256:d869c16791481dc8475487ad84ae4371a63f9b399898ca1c666eead5cccf7182
+
+aws_cli_release: "2.0.30"


### PR DESCRIPTION
Moving it to packer saves the time needed to install it when spinning up a new project.
