### PR TITLE
pin plv8 to a commit

### DIFF
--- a/ansible/tasks/setup-extensions.yml
+++ b/ansible/tasks/setup-extensions.yml
@@ -279,7 +279,7 @@
   git:
     repo: https://github.com/plv8/plv8.git
     dest: /tmp/plv8
-    version: r3.0alpha
+    version: 3656177d384e3e02b74faa8e2931600f3690ab59
   become: yes
 
 - name: plv8 - build


### PR DESCRIPTION
plv8 was built from a specific branch and the latest commit from that branch doesn't work on graviton. There is an issue for this already. 

And it is better to pin to a specific commit when building anyway. 