### PR TITLE
feat: disable additional unnecessary services

### DIFF
--- a/ansible/tasks/internal/optimizations.yml
+++ b/ansible/tasks/internal/optimizations.yml
@@ -14,6 +14,7 @@
     - pgbouncer
     - fail2ban
     - man-db
+    - motd-news
 
 - name: Setup - install common dependencies
   apt:

--- a/ansible/tasks/internal/optimizations.yml
+++ b/ansible/tasks/internal/optimizations.yml
@@ -13,3 +13,20 @@
     - postgresql
     - pgbouncer
     - fail2ban
+    - man-db
+
+- name: Setup - install common dependencies
+  apt:
+    state: absent
+    pkg:
+      - snapd
+
+- name: ensure services are stopped and disabled for first boot
+  systemd:
+    enabled: no
+    name: '{{ item }}'
+    state: stopped
+    masked: yes
+  with_items:
+    - lvm2-monitor
+    - man-db


### PR DESCRIPTION
We're at ~55 seconds; hopefully this should shave off another ~15 seconds.

```
 4.354s snap.lxd.activate.service
 4.292s snapd.seeded.service
 4.259s lvm2-monitor.service
 1.797s man-db.service
 1.140s snapd.service
```