### PR TITLE
chore: switch back to supabase_admin for metrics collection

### DIFF
--- a/ansible/files/postgres_exporter.service.j2
+++ b/ansible/files/postgres_exporter.service.j2
@@ -9,8 +9,7 @@ StandardOutput=append:/var/log/postgres_exporter.stdout
 StandardError=append:/var/log/postgres_exporter.error
 Restart=always
 RestartSec=3
-Environment="DATA_SOURCE_URI=localhost/postgres?sslmode=disable"
-Environment="DATA_SOURCE_USER=supabase_metrics"
+Environment="DATA_SOURCE_NAME=host=localhost dbname=postgres sslmode=disable user=supabase_admin pg_stat_statements.track=none"
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible/files/queries.yml.j2
+++ b/ansible/files/queries.yml.j2
@@ -201,9 +201,7 @@ supabase_usage_metrics:
   query: |
       select sum(calls) as user_queries_total
       from extensions.pg_stat_statements
-               join pg_roles on userid = oid
-      where rolname <> 'supabase_metrics'
-        and query not like 'SELECT%FROM net.http_request_queue%'
+      where query not like 'SELECT%FROM net.http_request_queue%'
         and query not like 'DELETE FROM net.http_request_queue%'
         and query <> 'SELECT version()'
         -- the rest of these would get removed once we implement a more minimal healthcheck endpoint for postgrest

--- a/ansible/tasks/internal/supautils.yml
+++ b/ansible/tasks/internal/supautils.yml
@@ -28,7 +28,7 @@
   lineinfile:
     path: /etc/postgresql/postgresql.conf
     state: present
-    line: supautils.reserved_roles = 'supabase_admin, supabase_metrics, supabase_auth_admin, supabase_storage_admin, dashboard_user, pgbouncer, service_role, authenticator, authenticated, anon'
+    line: supautils.reserved_roles = 'supabase_admin, supabase_auth_admin, supabase_storage_admin, dashboard_user, pgbouncer, service_role, authenticator, authenticated, anon'
 
 - name: supautils - set supautils.reserved_memberships
   become: yes

--- a/ansible/tasks/setup-fail2ban.yml
+++ b/ansible/tasks/setup-fail2ban.yml
@@ -26,7 +26,6 @@
     line: "{{ item.line }}"
   loop:
     - { line: '              ^.*,.*,.*,.*,"<HOST>:.*password authentication failed for user ""supabase_admin".*$' }
-    - { line: '              ^.*,.*,.*,.*,"<HOST>:.*password authentication failed for user ""supabase_metrics".*$' }
     - { line: '              ^.*,.*,.*,.*,"<HOST>:.*password authentication failed for user ""supabase_auth_admin".*$' }
     - { line: '              ^.*,.*,.*,.*,"<HOST>:.*password authentication failed for user ""supabase_storage_admin".*$' }
     - { line: '              ^.*,.*,.*,.*,"<HOST>:.*password authentication failed for user ""authenticator".*$' }


### PR DESCRIPTION
Instead of using a separate user, disable stats tracking for
statements executed by the exporter.