### PR TITLE
Minor cleanup for packer/ansible tasks.

### DIFF
--- a/amazon-arm.json
+++ b/amazon-arm.json
@@ -1,19 +1,17 @@
 {
   "variables": {
-    "aws_access_key": "",
-    "aws_secret_key": "",
+    "profile": "{{env `AWS_PROFILE`}}",
     "region": "ap-northeast-1",
     "ami_regions": "eu-central-1,eu-west-1,eu-west-2,ap-south-1,ap-southeast-1,ap-southeast-2,us-west-1,us-east-1,ca-central-1,sa-east-1,ap-northeast-1,ap-northeast-2",
-    "ami": "ami-076d8ebdd0e1ec091",
-    "ami_name": "supabase-postgres-13.3.0",
+    "ami": "",
+    "ami_name": "",
     "environment": "prod",
     "ansible_arguments": "--skip-tags,update-only,--skip-tags,install-postgrest,--skip-tags,install-pgbouncer,--skip-tags,install-supabase-internal"
   },
   "builders": [
     {
       "type": "amazon-ebs",
-      "access_key": "{{user `aws_access_key`}}",
-      "secret_key": "{{user `aws_secret_key`}}",
+      "profile": "{{user `profile`}}",
       "region": "{{user `region`}}",
       "ami_regions": "{{user `ami_regions`}}",
       "source_ami": "{{user `ami`}}",

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -119,3 +119,12 @@
           - ec2-instance-connect
       tags:
         - aws-only
+
+    # Install this at the end to prevent it from kicking in during the apt process, causing conflicts
+    - name: Install security tools
+      become: yes
+      apt:
+        pkg:
+          - unattended-upgrades
+        update_cache: yes
+        cache_valid_time: 3600

--- a/ansible/tasks/setup-system.yml
+++ b/ansible/tasks/setup-system.yml
@@ -33,7 +33,6 @@
     pkg:
       - ufw
       - fail2ban
-      - unattended-upgrades
     update_cache: yes
     cache_valid_time: 3600
 


### PR DESCRIPTION
- use AWS profile instead of key/secret
- remove defaults for AMI/image name (fail early if not present)
- move unattended-upgrades to be installed at the end, to avoid flaky
  failures during the bake process