### PR TITLE
add missing new extensions

### DIFF
--- a/ansible/tasks/setup-extensions.yml
+++ b/ansible/tasks/setup-extensions.yml
@@ -36,3 +36,9 @@
 
 - name: Install plv8
   import_tasks: tasks/postgres-extensions/13-plv8.yml
+
+- name: Install pg_plan_filter
+  import_tasks: tasks/postgres-extensions/14-pg_plan_filter.yml
+
+- name: Install pg_net
+  import_tasks: tasks/postgres-extensions/15-pg_net.yml


### PR DESCRIPTION
Without this, building would result in the following error:
`
amazon-ebs: fatal: [default]: FAILED! => {"changed": false, "msg": "Unable to start service postgresql: Job for postgresql.service failed because the control process exited with error code.\nSee \"systemctl status postgresql.service\" and \"journalctl -xe\" for details.\n"} 
`