### PR TITLE
Recreate /var/log/postgresql after cleanup

### DIFF
--- a/ansible/tasks/setup-postgres.yml
+++ b/ansible/tasks/setup-postgres.yml
@@ -103,6 +103,14 @@
     owner: postgres
     group: postgres
 
+- name: Create logs dir
+  become: yes
+  file:
+    path: /var/log/postgresql
+    state: directory
+    owner: postgres
+    group: postgres
+
 # Move Postgres configuration files into /etc/postgresql
 # Add postgresql.conf
 - name: import postgresql.conf

--- a/ansible/tasks/setup-postgres.yml
+++ b/ansible/tasks/setup-postgres.yml
@@ -103,14 +103,6 @@
     owner: postgres
     group: postgres
 
-- name: Create logs dir
-  become: yes
-  file:
-    path: /var/log/postgresql
-    state: directory
-    owner: postgres
-    group: postgres
-
 # Move Postgres configuration files into /etc/postgresql
 # Add postgresql.conf
 - name: import postgresql.conf

--- a/scripts/91-log_cleanup.sh
+++ b/scripts/91-log_cleanup.sh
@@ -8,4 +8,5 @@ rm -rf /var/log/*
 touch /var/log/auth.log
 
 touch /var/log/pgbouncer.log
-chown postgres:postgres /var/log/pgbouncer.log
+mkdir /var/log/postgresql
+chown postgres:postgres /var/log/pgbouncer.log /var/log/postgresql


### PR DESCRIPTION
`/var/log/*` is cleared towards the end of the build. This wipes out `/var/log/postgresql` which is needed by the DB when starting. Without it an error occurs upon attempting to start up. As such, we recreate it similar to `/var/log/pgbouncer.log`.