### PR TITLE
chore: set max_slot_wal_keep_size to 1024 mb

### DIFF
--- a/ansible/files/postgresql_config/postgresql.conf.j2
+++ b/ansible/files/postgresql_config/postgresql.conf.j2
@@ -298,7 +298,7 @@ max_wal_senders = 10		# max number of walsender processes
 max_replication_slots = 5	# max number of replication slots
 				# (change requires restart)
 #wal_keep_size = 0		# in megabytes; 0 disables
-#max_slot_wal_keep_size = -1	# in megabytes; -1 disables
+max_slot_wal_keep_size = 1024   # in megabytes; -1 disables
 #wal_sender_timeout = 60s	# in milliseconds; 0 disables
 #track_commit_timestamp = off	# collect timestamp of transaction commit
 				# (change requires restart)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore

## What is the new behavior?

Set `max_slot_wal_keep_size` to 1024 mb to for better Realtime Security (WALRUS) WAL management.

## Additional context

Related issue: https://github.com/supabase/walrus/issues/12
