### PR TITLE
Add pgsodium extension to supabase/postgres ansible build scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Unmodified Postgres with some useful plugins. Our goal with this repo is not to 
 | [plv8](https://github.com/plv8/plv8) | Write in Javascript functions in Postgres. |
 | [pg_plan_filter](https://github.com/pgexperts/pg_plan_filter) | Only allow statements that fulfill set criteria to be executed. |
 | [pg_net](https://github.com/supabase/pg_net) | Expose the SQL interface for async networking. |
+| [pg_sodium](https://github.com/michelp/pgsodium) | Modern encryption API using libsodium. |
 
 Can't find your favorite extension? Suggest for it to be added into future versions [here](https://github.com/supabase/supabase/discussions/679)!
 

--- a/ansible/tasks/postgres-extensions/16-pgsodium.yml
+++ b/ansible/tasks/postgres-extensions/16-pgsodium.yml
@@ -1,0 +1,55 @@
+# libsodium and pgsodium
+- name: libsodium - download libsodium
+  get_url:
+    url: "https://download.libsodium.org/libsodium/releases/libsodium-{{ libsodium_release }}.tar.gz"
+    dest: /tmp/libsodium-{{ libsodium_release }}.tar.gz
+    checksum: "{{ pg_sodium_release_checksum }}"
+
+- name: libsodium - unpack archive
+  unarchive:
+    remote_src: yes
+    src: /tmp/libsodium-{{ libsodium_release }}.tar.gz
+    dest: /tmp
+  become: yes
+
+- name: libsodium - configure
+  shell:
+    cmd: ./configure
+    chdir: /tmp/libsodium-{{ libsodium_release }}
+  become: yes
+
+- name: libsodium - build
+  make:
+    chdir: /tmp/libsodium-{{ libsodium_release }}
+  become: yes
+
+- name: libsodium - install
+  make:
+    chdir: /tmp/libsodium-{{ libsodium_release }}
+    target: install
+  become: yes
+
+- name: pgsodium - download pgsodium
+  get_url:
+    url: "https://github.com/michelp/pgsodium/archive/refs/tags/v1.3.0.tar.gz"
+    dest: /tmp/pgsodium-{{ pgsodium_release }}.tar.gz
+#    checksum: "{{ pg_sodium_release_checksum }}"
+
+- name: pgsodium - unpack archive
+  unarchive:
+    remote_src: yes
+    src: /tmp/pgsodium-{{ pgsodium_release }}.tar.gz
+    dest: /tmp
+  become: yes
+
+- name: pgsodium - build
+  make:
+    chdir: /tmp/pgsodium-{{ pgsodium_release }}
+  become: yes
+
+- name: pgsodium - install
+  make:
+    chdir: /tmp/pgsodium-{{ pgsodium_release }}
+    target: install
+  become: yes
+  

--- a/ansible/tasks/postgres-extensions/16-pgsodium.yml
+++ b/ansible/tasks/postgres-extensions/16-pgsodium.yml
@@ -3,7 +3,7 @@
   get_url:
     url: "https://download.libsodium.org/libsodium/releases/libsodium-{{ libsodium_release }}.tar.gz"
     dest: /tmp/libsodium-{{ libsodium_release }}.tar.gz
-    checksum: "{{ pg_sodium_release_checksum }}"
+    checksum: "{{ libsodium_release_checksum }}"
 
 - name: libsodium - unpack archive
   unarchive:
@@ -33,7 +33,7 @@
   get_url:
     url: "https://github.com/michelp/pgsodium/archive/refs/tags/v1.3.0.tar.gz"
     dest: /tmp/pgsodium-{{ pgsodium_release }}.tar.gz
-#    checksum: "{{ pg_sodium_release_checksum }}"
+    checksum: "{{ pgsodium_release_checksum }}"
 
 - name: pgsodium - unpack archive
   unarchive:

--- a/ansible/tasks/setup-extensions.yml
+++ b/ansible/tasks/setup-extensions.yml
@@ -42,3 +42,6 @@
 
 - name: Install pg_net
   import_tasks: tasks/postgres-extensions/15-pg_net.yml
+
+- name: Install pgsodium
+  import_tasks: tasks/postgres-extensions/16-pgsodium.yml

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -83,3 +83,9 @@ pg_net_release_checksum: sha1:22c40ae9039778a6bf7344e4357640edf8620a7e
 
 vector_x86_deb: 'https://packages.timber.io/vector/0.17.0/vector-0.17.0-amd64.deb'
 vector_arm_deb: 'https://packages.timber.io/vector/0.17.0/vector-0.17.0-arm64.deb'
+
+libsodium_release: "1.0.18"
+libsodium_release_checksum: sha1:795b73e3f92a362fabee238a71735579bf46bb97
+
+pgsodium_release: "1.3.0"
+pgsodium_release_checksum: sha1:d7b00ce0437b697a8a0076eeb80b17b7fef80fc2


### PR DESCRIPTION
## What kind of change does this PR introduce?

It installs libsodium and pgsodium into the supbase/postgres ansible task chain.

## What is the current behavior?

This is a new feature and not related to current behavior.

## What is the new behavior?

CREATE EXTENSION pgsodium;

## Additional context

This is just the base extension functions, changes to upstream supabase applications will depend on pgsodium (and libsodium).

Note that as installed here, pgsodium is not loaded at postgres boot and there is no root key.  All pgsodium functions are available but there is no key derivation or key ids in this mode.  Upstream applications can support key derivation by adding `pgsodium` to `shared_preload_libraries` and `pgsodium.getkey_script=...` to their `postgresql.conf`.
