### PR TITLE
eliminate two-step build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,4 +17,4 @@ jobs:
 
       - name: Build AMI
         run: |
-          packer build -timestamp-ui -color=false -on-error=abort -var "ansible_arguments=--tags,update-only,--tags,install-pgbouncer,--tags,install-supabase-internal" -var-file common.vars.json -var-file development-arm.vars.json amazon.json
+          packer build -timestamp-ui -color=false -on-error=abort -var-file common.vars.json -var-file development-arm.vars.json amazon.json

--- a/amazon.json
+++ b/amazon.json
@@ -47,13 +47,7 @@
       "type": "ansible",
       "user": "ubuntu",
       "playbook_file": "ansible/playbook.yml",
-      "extra_arguments": "--skip-tags,install-postgrest,--skip-tags,install-pgbouncer,--skip-tags,install-supabase-internal"
-    },
-    {
-      "type": "ansible",
-      "user": "ubuntu",
-      "playbook_file": "ansible/playbook.yml",
-      "extra_arguments": "{{user `ansible_arguments`}}"
+      "extra_arguments": "--skip-tags,install-postgrest"
     },
     {
       "execute_command": "echo 'packer' | sudo -S sh -c '{{ .Vars }} {{ .Path }}'",


### PR DESCRIPTION
Remove two-step build. Following `ansible_arguments` should be sufficient to build internal image in a single build.