### PR TITLE
Fix: Use correct indentation for 'when' conditional statement

### DIFF
--- a/ansible/tasks/internal/admin-api.yml
+++ b/ansible/tasks/internal/admin-api.yml
@@ -20,12 +20,12 @@
 - name: Setting arch (x86)
   set_fact:
     arch: "x86"
-    when: platform == "amd64"
+  when: platform == "amd64"
 
 - name: Setting arch (arm)
   set_fact:
     arch: "arm64"
-    when: platform == "arm64"
+  when: platform == "arm64"
 
 - name: adminapi - download commit archive
   get_url:

--- a/ansible/tasks/setup-postgres.yml
+++ b/ansible/tasks/setup-postgres.yml
@@ -54,12 +54,12 @@
 - name: Setting CFLAGS (arm)
   set_fact:
     cflags: "-moutline-atomics -mtune=neoverse-n1 -fsigned-char"
-    when: platform == "arm64"
+  when: platform == "arm64"
 
 - name: Setting CFLAGS (x86)
   set_fact:
     cflags: "-fsigned-char"
-    when: platform == "amd64"
+  when: platform == "amd64"
 
 - name: Postgres - configure
   shell:


### PR DESCRIPTION
Signed-off-by: laks <lakshmipathi.g@giis.co.in>

## What kind of change does this PR introduce?

This PR fixes when conditional statement with `Setting arch` and `Setting CFLAGS` tasks

## What is the current behavior?

Uses wrong indentation and conditional statement is not executed properly.

## What is the new behavior?

`Setting arch` and `Setting CFLAGS` tasks uses correct platform. 

## Additional context

Add any other context or screenshots.
