### PR TITLE
only run CI GA when there is a change in common.vars.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - develop
+    paths:
+      - common.vars*
 
 jobs:
   build:


### PR DESCRIPTION
A change in `common.vars.json` would signify a bump in the version. Right now, any change in the `develop` branch even from just the README would trigger a build of the AMI. This would cause the [GA to immediately fail](https://github.com/supabase/postgres/actions/runs/1543232332) as the image name already exists.