### PR TITLE
chore: run logrotation every ten minutes

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -113,7 +113,7 @@
       shell:
         cmd: |
             cp  /usr/lib/systemd/system/logrotate.timer /etc/systemd/system/logrotate.timer
-            sed -i -e 's/daily/hourly/' /etc/systemd/system/logrotate.timer
+            sed -i -e 's;daily;*:0/10;' /etc/systemd/system/logrotate.timer
             systemctl reenable logrotate.timer
       become: yes
 

--- a/common.vars.json
+++ b/common.vars.json
@@ -1,3 +1,3 @@
 {
-  "postgres-version": "14.1.0.8"
+  "postgres-version": "14.1.0.9"
 }


### PR DESCRIPTION
With the greatly increased verbosity of PG logs with walrus, hourly
rotation can still lead to a tonne of disk space being used in the
meantime