### PR TITLE
Ensure postgis dependencies do not get autoremoved

### DIFF
--- a/ansible/tasks/postgres-extensions/01-postgis.yml
+++ b/ansible/tasks/postgres-extensions/01-postgis.yml
@@ -16,6 +16,11 @@
     cache_valid_time: 3600
     install_recommends: no
 
+- name: postgis - ensure dependencies do not get autoremoved
+  shell:
+    cmd: "apt-mark manual libgeos* libproj* libgdal* libjson-c* libxml2* libboost* libcgal* libmpfr* libgmp*"
+  become: yes
+
 - name: postgis - download SFCGAL dependency
   get_url:
     url: "https://gitlab.com/Oslandia/SFCGAL/-/archive/v{{ sfcgal_release }}/SFCGAL-v{{ sfcgal_release }}.tar.gz"

--- a/ansible/tasks/postgres-extensions/01-postgis.yml
+++ b/ansible/tasks/postgres-extensions/01-postgis.yml
@@ -17,9 +17,14 @@
     install_recommends: no
 
 - name: postgis - ensure dependencies do not get autoremoved
-  shell:
-    cmd: "apt-mark manual libgeos* libproj* libgdal* libjson-c* libxml2* libboost* libcgal* libmpfr* libgmp*"
+  shell: |
+    set -e
+    apt-mark manual libgeos* libproj* libgdal* libjson-c* libxml2* libboost* libcgal* libmpfr* libgmp*
+    apt-mark auto libgeos*-dev libproj*-dev libgdal*-dev libjson-c*-dev libxml2*-dev libboost*-dev libcgal*-dev libmpfr*-dev libgmp*-dev
+
   become: yes
+  args:
+    executable: /bin/bash
 
 - name: postgis - download SFCGAL dependency
   get_url:


### PR DESCRIPTION
It was reported that the extensions `postgis_raster` could not be created and was returning the following error:
```
could not load library "/usr/lib/postgresql/lib/postgis_raster-3.so": libgdal.so.26: cannot open shared object file: No such file or directory
```

Upon further investigation, the extension `postgis_sfcgal` also could not be created:
```
could not load library "/usr/lib/postgresql/lib/postgis_sfcgal-3.so": libboost_serialization.so.1.71.0: cannot open shared object file: No such file or directory
```

The root cause was that their dependencies, namely `libgdal-dev`, `libboost-all-dev`, and `libcgal-dev`, were removed presumably by `apt autoremove` which is run multiple times during the build process. Solution put forward is to make use of `apt-mark manual` which then excludes these packages from the autoremoval process.