### PR TITLE
hardcode value instead of using $PGDATA

### DIFF
--- a/ansible/files/pgsodium_getkey_urandom.sh.j2
+++ b/ansible/files/pgsodium_getkey_urandom.sh.j2
@@ -1,5 +1,5 @@
 #!/bin/bash
-KEY_FILE=$PGDATA/pgsodium_root.key
+KEY_FILE=/var/lib/postgresql/pgsodium_root.key
 
 if [ ! -f "$KEY_FILE" ]; then
     head -c 32 /dev/urandom | od -A n -t x1 | tr -d ' \n' > $KEY_FILE


### PR DESCRIPTION
Error causing the build to fail is that the the pgsodium key is located in the wrong directory. This is because $PGDATA does not return anything causing the eventual location of the file to be in `/` as opposed to `/var/lib/postgresql/`. Attempting to start the DB afterward would result in the following error:
```
postgres[6395]: invalid secret key
```
Opted to hardcode the value instead to `/var/lib/postgresql/` which shouldn't be an issue as the machine and docker image both standardise to their root data directory to be `/var/lib/postgresql`.