### PR TITLE
fix: postgres bin directory location for pgsodium extension when running a docker build

### DIFF
--- a/ansible/files/postgresql_config/postgresql.conf.j2
+++ b/ansible/files/postgresql_config/postgresql.conf.j2
@@ -723,8 +723,7 @@ shared_preload_libraries = 'pg_stat_statements, pgaudit, plpgsql, plpgsql_check,
 jit_provider = 'llvmjit'		# JIT library to use
 
 # - Other Defaults -
-
-pgsodium.getkey_script= '/usr/lib/postgresql/bin/pgsodium_getkey_urandom.sh'
+pgsodium.getkey_script= '{{ pg_bindir }}/pgsodium_getkey_urandom.sh'
 
 #dynamic_library_path = '$libdir'
 #gin_fuzzy_search_limit = 0

--- a/ansible/tasks/docker/setup.yml
+++ b/ansible/tasks/docker/setup.yml
@@ -27,8 +27,14 @@
 - set_fact:
     platform: "{{ platform_output.stdout }}"
 
+- name: pgsodium - store postgres bin directory
+  shell: pg_config --bindir
+  register: pg_bindir_output
+- set_fact: 
+    pg_bindir: "{{ pg_bindir_output.stdout }}"
+
 - name: Setup - import postgresql.conf
-  synchronize:
+  template:
     src: files/postgresql_config/postgresql.conf.j2
     dest: /etc/postgresql/postgresql.conf
 

--- a/ansible/tasks/postgres-extensions/18-pgsodium.yml
+++ b/ansible/tasks/postgres-extensions/18-pgsodium.yml
@@ -59,7 +59,7 @@
 - name: import pgsodium_getkey_urandom.sh
   template:
     src: files/pgsodium_getkey_urandom.sh.j2
-    dest: /usr/lib/postgresql/bin/pgsodium_getkey_urandom.sh
+    dest: "{{ pg_bindir }}/pgsodium_getkey_urandom.sh"
     owner: postgres
     group: postgres
     mode: 0700


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug Fix

## What is the current behavior?

docker build breaks on my system due to incorrect postgres `bin` directory location for `pgsodium` extension.

I faced the broken build while trying to create an arm based image for my M1 based laptop. Not sure if this is connected to #143. Current `arm` based docker image for supabase/postgres gives `x86` architecture.

## What is the new behavior?

build is successful with this change.

