### PR TITLE
fix: only require PG optimizations on internal builds

### DIFF
--- a/ansible/files/postgresql_config/postgresql.service.j2
+++ b/ansible/files/postgresql_config/postgresql.service.j2
@@ -1,8 +1,10 @@
 [Unit]
 Description=PostgreSQL database server
 Documentation=man:postgres(1)
+{% if supabase_internal is defined %}
 Requires=generate-optimizations.service
 After=generate-optimizations.service
+{% endif %}
 
 [Service]
 Type=notify

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -15,11 +15,21 @@
     PATH: /usr/lib/postgresql/bin:{{ ansible_env.PATH }}
 
   tasks:
+    - set_fact:
+        supabase_internal: true
+      tags:
+        - install-supabase-internal
+
     - name: Install Postgres from source
       import_tasks: tasks/setup-postgres.yml
 
     - name: Install Postgres extensions
       import_tasks: tasks/setup-extensions.yml
+
+    - name: Install Supabase specific content
+      import_tasks: tasks/setup-supabase-internal.yml
+      tags:
+        - install-supabase-internal
 
     - name: Start Postgres Database
       systemd:
@@ -57,11 +67,6 @@
       import_tasks: tasks/setup-postgrest.yml
       tags:
         - install-postgrest
-        
-    - name: Install Supabase specific content
-      import_tasks: tasks/setup-supabase-internal.yml
-      tags:
-        - install-supabase-internal
 
     - name: Clean out build dependencies
       import_tasks: tasks/clean-build-dependencies.yml

--- a/common.vars.json
+++ b/common.vars.json
@@ -1,3 +1,3 @@
 {
-  "postgres-version": "14.1.0.15-rc1"
+  "postgres-version": "14.1.0.15-rc2"
 }


### PR DESCRIPTION
The optimizations are generated by the admin-api, which is only
installed on internal builds. Additionally, the installation of
Supabase internal content is moved up to before the PG db is started
to avoid failing on missing dependent tasks.