### PR TITLE
Do not run parallel jobs for Docker builds

### DIFF
--- a/.github/workflows/dockerhub-release.yml
+++ b/.github/workflows/dockerhub-release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-      - fix/docker_build
     paths:
       - docker.vars*
 
@@ -41,7 +40,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: supabase/postgres:${{ steps.settings.outputs.docker_version }}
+          tags: supabase/postgres:latest,supabase/postgres:${{ steps.settings.outputs.docker_version }}
           platforms: linux/amd64,linux/arm64
           build-args: |
             "PLATFORM=${{steps.settings.outputs.platform}}"

--- a/.github/workflows/dockerhub-release.yml
+++ b/.github/workflows/dockerhub-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - fix/docker_build
     paths:
       - docker.vars*
 
@@ -40,7 +41,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: supabase/postgres:latest,supabase/postgres:${{ steps.settings.outputs.docker_version }}
+          tags: supabase/postgres:${{ steps.settings.outputs.docker_version }}
           platforms: linux/amd64,linux/arm64
           build-args: |
             "PLATFORM=${{steps.settings.outputs.platform}}"

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -20,6 +20,9 @@
       tags:
         - install-supabase-internal
 
+    - set_fact:
+        parallel_jobs: 16
+
     - name: Install Postgres from source
       import_tasks: tasks/setup-postgres.yml
 

--- a/ansible/tasks/postgres-extensions/01-postgis.yml
+++ b/ansible/tasks/postgres-extensions/01-postgis.yml
@@ -49,7 +49,7 @@
 - name: postgis - build SFCGAL
   make:
     chdir: /tmp/SFCGAL-v{{ sfcgal_release }}
-    jobs: 16
+    jobs: "{{ parallel_jobs | default(omit) }}"
   become: yes
 
 - name: postgis - install SFCGAL
@@ -78,7 +78,7 @@
 - name: postgis - build
   make:
     chdir: /tmp/postgis-{{ postgis_release }}
-    jobs: 16
+    jobs: "{{ parallel_jobs | default(omit) }}"
   become: yes
 
 - name: postgis - install

--- a/ansible/tasks/postgres-extensions/02-pgrouting.yml
+++ b/ansible/tasks/postgres-extensions/02-pgrouting.yml
@@ -36,7 +36,7 @@
 - name: pgRouting - build
   make:
     chdir: /tmp/pgrouting-{{ pgrouting_release }}/build
-    jobs: 16
+    jobs: "{{ parallel_jobs | default(omit) }}"
   become: yes
 
 - name: pgRouting - install

--- a/ansible/tasks/setup-wal-g.yml
+++ b/ansible/tasks/setup-wal-g.yml
@@ -44,7 +44,7 @@
   make:
     chdir: /tmp/wal-g
     target: pg_build
-    jobs: 16
+    jobs: "{{ parallel_jobs | default(omit) }}"
     params:
       GOBIN: "/usr/local/bin"
       PATH: "{{ ansible_env.PATH }}:/usr/local/go/bin"


### PR DESCRIPTION
GA for Docker builds [failed](https://github.com/supabase/postgres/runs/5645929164?check_suite_focus=true) as the `jobs` parameter is unsupported:
```
"Unsupported parameters for (make) module: jobs Supported parameters include: chdir, file, make, params, target"
```

## Approach
* Set value of 16 for `parallel_jobs` when building with EC2 images.
* `parallel_jobs` is omitted for Docker builds.
*  Setting [{{ parallel_jobs | default(omit) }}](https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#making-variables-optional) for the `jobs` parameter, it is then made optional when running `make` if `parallel_jobs` is not defined, and therefore ignored during Docker builds.