### PR TITLE
fix: let docker use the right arch

### DIFF
--- a/.github/workflows/dockerhub-release.yml
+++ b/.github/workflows/dockerhub-release.yml
@@ -22,9 +22,6 @@ jobs:
           POSTGRES_VERSION=$(cat docker.vars.json | jq -r '.["postgres-version"]')
           echo "::set-output name=postgres_version::$POSTGRES_VERSION"
 
-          PLATFORM=$(cat docker.vars.json | jq -r '.["platform"]')
-          echo "::set-output name=platform::$PLATFORM"
-
       - uses: docker/setup-qemu-action@v1
         with:
           platforms: amd64,arm64
@@ -43,5 +40,4 @@ jobs:
           tags: supabase/postgres:latest,supabase/postgres:${{ steps.settings.outputs.docker_version }}
           platforms: linux/amd64,linux/arm64
           build-args: |
-            "PLATFORM=${{steps.settings.outputs.platform}}"
             "VERSION=${{steps.settings.outputs.postgres_version}}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-ARG PLATFORM
 ARG VERSION
 
-FROM --platform=$PLATFORM postgres:$VERSION
+FROM postgres:$VERSION
 
 COPY ansible/ /tmp/ansible/
 

--- a/docker.vars.json
+++ b/docker.vars.json
@@ -1,6 +1,4 @@
 {
-    "docker-version": "14.1.0.15",
-    "postgres-version": "14.1",
-    "platform": "linux/amd64"
-  }
-  
+  "docker-version": "14.1.0.15",
+  "postgres-version": "14.1"
+}


### PR DESCRIPTION
Let Docker use the right arch for `postgres:$VERSION`. Currently in the CI this is always `linux/amd64`.

This might help with #143.