### PR TITLE
fix to latest failing dockerbuild

### DIFF
--- a/.github/workflows/dockerhub-release.yml
+++ b/.github/workflows/dockerhub-release.yml
@@ -26,7 +26,17 @@ jobs:
         with:
           platforms: amd64,arm64
 
-      - uses: docker/setup-buildx-action@v1
+      - name: Set up Docker Context for Buildx
+        id: buildx-context
+        run: |
+          docker context create builders
+          
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+          endpoint: builders
 
       - uses: docker/login-action@v1
         with:


### PR DESCRIPTION
Error found: `error: could not create a builder instance with TLS data loaded from environment`

Fix taken from here:
https://github.com/docker/setup-buildx-action/issues/105