### PR TITLE
resolve failure to update locale

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,13 @@ RUN apt update && \
     apt -y upgrade && \
     apt -y autoremove && \
     apt -y autoclean && \
-    apt install -y default-jdk-headless && \
-    rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/*
+    apt install -y default-jdk-headless locales && \
+    sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && \
+    locale-gen && \
+    rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/* 
 
-ENV LANGUAGE=en_US.UTF-8
-ENV LANG=en_US.UTF-8
-ENV LC_ALL=en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
 
 CMD ["postgres", "-c", "config_file=/etc/postgresql/postgresql.conf"]


### PR DESCRIPTION
The following error pops up in the [recent Dockerbuild](https://github.com/supabase/postgres/runs/5742056109?check_suite_focus=true):
```
#8 3698.5 perl: warning: Setting locale failed.
#8 3698.5 perl: warning: Please check that your locale settings:
#8 3698.5 	LANGUAGE = (unset),
#8 3698.5 	LC_ALL = (unset),
#8 3698.5 	LANG = "en_US.utf8"
#8 3698.5     are supported and installed on your system.
#8 3698.5 perl: warning: Falling back to the standard locale ("C").
```

which then prevents the PG image from going up properly:
```
supabase-db        | bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
supabase-db        | The files belonging to this database system will be owned by user "postgres".
supabase-db        | This user must also own the server process.
supabase-db        | 
supabase-db        | initdb: error: invalid locale settings; check LANG and LC_* environment variables
supabase-db exited with code 1
```
Proposed fix is taken from this [stack overflow question](https://stackoverflow.com/questions/28405902/how-to-set-the-locale-inside-a-debian-ubuntu-docker-container#28406007).

