### PR TITLE
Bump pg_graphql version to v0.2.0

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -96,7 +96,7 @@ pgsodium_release_checksum: sha1:b6ef733c9bbae590c1eee676fd0a97fd129893e0
 
 libgraphqlparser_release: "v0.7.0"
 
-pg_graphql_release: "v0.1.5"
+pg_graphql_release: "v0.2.0"
 
 osquery_deb: 'https://pkg.osquery.io/deb/osquery_5.1.0-1.linux_arm64.deb'
 osquery_deb_checksum: sha1:6b6fa49edcfad5d77aa1e59c75b8708de2f634ac


### PR DESCRIPTION
## What kind of change does this PR introduce?
Increases pg_graphql version to v0.2.0 resolving:

https://github.com/supabase/supabase/issues/6271
https://github.com/supabase/pg_graphql/issues/135
https://github.com/supabase/pg_graphql/issues/139
https://github.com/supabase/pg_graphql/issues/141
