### PR TITLE
Install wal2json install by commit sha

### DIFF
--- a/ansible/tasks/postgres-extensions/11-wal2json.yml
+++ b/ansible/tasks/postgres-extensions/11-wal2json.yml
@@ -1,25 +1,12 @@
 # wal2json
-- name: wal2json - download latest release
-  get_url:
-    url: "https://github.com/eulerto/wal2json/archive/refs/tags/wal2json_{{ wal2json_release }}.tar.gz"
-    dest: /tmp/wal2json-{{ wal2json_release }}.tar.gz
-    checksum: "{{ wal2json_release_checksum }}"
-    timeout: 60
-
-- name: wal2json - unpack archive
-  unarchive:
-    remote_src: yes
-    src: /tmp/wal2json-{{ wal2json_release }}.tar.gz
-    dest: /tmp
-  become: yes
-
-- name: wal2json - build
-  make:
-    chdir: /tmp/wal2json-wal2json_{{ wal2json_release }}
-  become: yes
+- name: wal2json - download by commit sha
+  git:
+    repo: https://github.com/eulerto/wal2json.git
+    dest: /tmp/wal2json
+    version: "{{ wal2json_commit_sha }}"
 
 - name: wal2json - install
   make:
-    chdir: /tmp/wal2json-wal2json_{{ wal2json_release }}
+    chdir: /tmp/wal2json
     target: install
   become: yes

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -67,8 +67,7 @@ pg_safeupdate_release_checksum: sha1:942dacd0ebce6123944212ffb3d6b5a0c09174f9
 
 timescaledb_release: "2.3.0"
 
-wal2json_release: "2_4"
-wal2json_release_checksum: sha1:9f5c8dec3c0a5c19b1b77273f67fd9b0b0ab6664
+wal2json_commit_sha: 53b548a29ebd6119323b6eb2f6013d7c5fe807ec
 
 supautils_release: "1.2.1"
 supautils_release_checksum: sha1:23ec7bb2323f9f4c81fd8dfdb1de5811918a1d30


### PR DESCRIPTION
Installs wal2json by a commit sha so we can get the latest few bugfixes that aren't in a release yet

Resolves #186