### PR TITLE
bugfix: pg_graphql -> `v0.3.1`

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -96,7 +96,7 @@ pgsodium_release_checksum: sha1:b6ef733c9bbae590c1eee676fd0a97fd129893e0
 
 libgraphqlparser_release: "v0.7.0"
 
-pg_graphql_release: "v0.3.0"
+pg_graphql_release: "v0.3.1"
 
 osquery_deb: 'https://pkg.osquery.io/deb/osquery_5.1.0-1.linux_arm64.deb'
 osquery_deb_checksum: sha1:6b6fa49edcfad5d77aa1e59c75b8708de2f634ac

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "14.1.0.30"
+postgres-version = "14.1.0.32"


### PR DESCRIPTION
## What kind of change does this PR introduce?
Updates pg_graphql from `v0.3.0` > `v0.3.1` to fix a permissions error that occurs when executing SQL DDL without usage permission to the `graphql` schema.
