### PR TITLE
Upgrade libgraphqlparser for bugfixes on master

### DIFF
--- a/ansible/tasks/postgres-extensions/19-pg_graphql.yml
+++ b/ansible/tasks/postgres-extensions/19-pg_graphql.yml
@@ -15,7 +15,7 @@
   git:
     repo: https://github.com/graphql/libgraphqlparser.git
     dest: /tmp/libgraphqlparser
-    version: "{{ libgraphqlparser_release }}"
+    version: "{{ libgraphqlparser_commit_sha }}"
   become: yes
 
 - name: pg_graphql - compile libgraphqlparser

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -94,7 +94,7 @@ libsodium_release_checksum: sha1:795b73e3f92a362fabee238a71735579bf46bb97
 pgsodium_release: "2.0.1"
 pgsodium_release_checksum: sha1:b6ef733c9bbae590c1eee676fd0a97fd129893e0
 
-libgraphqlparser_commit_sha: 53b548a29ebd6119323b6eb2f6013d7c5fe807ec
+libgraphqlparser_commit_sha: 7e6c35c7b9e919d0c40b28020fb9358c3cf2679c
 
 pg_graphql_release: "v0.3.1"
 

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -94,7 +94,7 @@ libsodium_release_checksum: sha1:795b73e3f92a362fabee238a71735579bf46bb97
 pgsodium_release: "2.0.1"
 pgsodium_release_checksum: sha1:b6ef733c9bbae590c1eee676fd0a97fd129893e0
 
-libgraphqlparser_release: "v0.7.0"
+libgraphqlparser_commit_sha: 53b548a29ebd6119323b6eb2f6013d7c5fe807ec
 
 pg_graphql_release: "v0.3.1"
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Upgrades libgraphqlparesr, a dependency of pg_graphql, for bugfixes on master that are not in a release

unblocks https://github.com/supabase/pg_graphql/pull/179

Notes:
- this a pre-req of pg_graphql v0.3.2

Tasks
- [ ] the update needs to be applied to existing instances too. Sorry, I wasn't sure how to do that in helper-scripts