### PR TITLE
Make Updates To AMI To Support pg_stat_monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Unmodified Postgres with some useful plugins. Our goal with this repo is not to 
 | [rum](https://github.com/postgrespro/rum) | [1.3.9](https://github.com/postgrespro/rum/releases/tag/1.3.9) | An alternative to the GIN index. |
 | [pg_hashids](https://github.com/iCyberon/pg_hashids) | [commit](https://github.com/iCyberon/pg_hashids/commit/83398bcbb616aac2970f5e77d93a3200f0f28e74) | Generate unique identifiers from numbers. |
 | [pgsodium](https://github.com/michelp/pgsodium) | [2.0.0](https://github.com/michelp/pgsodium/releases/tag/2.0.0) | Modern encryption API using libsodium. |
+| [pg_stat_monitor](https://github.com/percona/pg_stat_monitor) | [1.0.1](https://github.com/percona/pg_stat_monitor/releases/tag/1.0.1) | Query Performance Monitoring Tool for PostgreSQL
 
 
 Can't find your favorite extension? Suggest for it to be added into future releases [here](https://github.com/supabase/supabase/discussions/679)!

--- a/ansible/files/postgres_exporter.service.j2
+++ b/ansible/files/postgres_exporter.service.j2
@@ -9,7 +9,7 @@ StandardOutput=append:/var/log/postgres_exporter.stdout
 StandardError=append:/var/log/postgres_exporter.error
 Restart=always
 RestartSec=3
-Environment="DATA_SOURCE_NAME=host=localhost dbname=postgres sslmode=disable user=supabase_admin pg_stat_statements.track=none application_name=postgres_exporter"
+Environment="DATA_SOURCE_NAME=host=localhost dbname=postgres sslmode=disable user=supabase_admin pg_stat_monitor.track=none application_name=postgres_exporter"
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible/files/postgresql_config/postgresql.conf.j2
+++ b/ansible/files/postgresql_config/postgresql.conf.j2
@@ -720,7 +720,7 @@ default_text_search_config = 'pg_catalog.english'
 #local_preload_libraries = ''
 #session_preload_libraries = ''
 
-shared_preload_libraries = 'pg_stat_monitor, pg_stat_statements, pgaudit, plpgsql, plpgsql_check, pg_cron, pg_net, pgsodium, timescaledb'	# (change requires restart)
+shared_preload_libraries = 'pg_stat_monitor, pgaudit, plpgsql, plpgsql_check, pg_cron, pg_net, pgsodium, timescaledb'	# (change requires restart)
 jit_provider = 'llvmjit'		# JIT library to use
 
 # - Other Defaults -

--- a/ansible/files/postgresql_config/postgresql.conf.j2
+++ b/ansible/files/postgresql_config/postgresql.conf.j2
@@ -719,7 +719,7 @@ default_text_search_config = 'pg_catalog.english'
 
 #local_preload_libraries = ''
 #session_preload_libraries = ''
-shared_preload_libraries = 'pg_stat_statements, pgaudit, plpgsql, plpgsql_check, pg_cron, pg_net, pgsodium'	# (change requires restart)
+shared_preload_libraries = 'pg_stat_monitor, pgaudit, plpgsql, plpgsql_check, pg_cron, pg_net, pgsodium'	# (change requires restart)
 jit_provider = 'llvmjit'		# JIT library to use
 
 # - Other Defaults -

--- a/ansible/files/stat_extension.sql
+++ b/ansible/files/stat_extension.sql
@@ -1,2 +1,2 @@
 CREATE SCHEMA IF NOT exists extensions;
-CREATE EXTENSION IF NOT EXISTS pg_stat_statements with schema extensions;
+CREATE EXTENSION IF NOT EXISTS pg_stat_monitor with schema extensions;

--- a/ansible/tasks/internal/supautils.yml
+++ b/ansible/tasks/internal/supautils.yml
@@ -65,7 +65,7 @@
   lineinfile:
     path: /etc/postgresql/postgresql.conf
     state: present
-    # full list: supautils.privileged_extensions = 'address_standardizer, address_standardizer_data_us, adminpack, amcheck, autoinc, bloom, btree_gin, btree_gist, citext, cube, dblink, dict_int, dict_xsyn, earthdistance, file_fdw, fuzzystrmatch, hstore, http, insert_username, intagg, intarray, isn, lo, ltree, moddatetime, old_snapshot, pageinspect, pg_buffercache, pg_cron, pg_freespacemap, pg_graphql, pg_hashids, pg_net, pg_prewarm, pg_stat_statements, pg_surgery, pg_trgm, pg_visibility, pgaudit, pgcrypto, pgjwt, pgrouting, pgrowlocks, pgsodium, pgstattuple, pgtap, plcoffee, pljava, plls, plpgsql, plpgsql_check, plv8, postgis, postgis_raster, postgis_sfcgal, postgis_tiger_geocoder, postgis_topology, postgres_fdw, refint, rum, seg, sslinfo, supautils, tablefunc, tcn, tsm_system_rows, tsm_system_time, unaccent, uuid-ossp'
+    # full list: supautils.privileged_extensions = 'address_standardizer, address_standardizer_data_us, adminpack, amcheck, autoinc, bloom, btree_gin, btree_gist, citext, cube, dblink, dict_int, dict_xsyn, earthdistance, file_fdw, fuzzystrmatch, hstore, http, insert_username, intagg, intarray, isn, lo, ltree, moddatetime, old_snapshot, pageinspect, pg_buffercache, pg_cron, pg_freespacemap, pg_graphql, pg_hashids, pg_net, pg_prewarm, pg_stat_monitor, pg_surgery, pg_trgm, pg_visibility, pgaudit, pgcrypto, pgjwt, pgrouting, pgrowlocks, pgsodium, pgstattuple, pgtap, plcoffee, pljava, plls, plpgsql, plpgsql_check, plv8, postgis, postgis_raster, postgis_sfcgal, postgis_tiger_geocoder, postgis_topology, postgres_fdw, refint, rum, seg, sslinfo, supautils, tablefunc, tcn, tsm_system_rows, tsm_system_time, unaccent, uuid-ossp'
     #
     # omitted because may be unsafe: adminpack, amcheck, file_fdw, lo, old_snapshot, pageinspect, pg_buffercache, pg_freespacemap, pg_prewarm, pg_surgery, pg_visibility, pgstattuple
     #
@@ -73,7 +73,7 @@
     #
     # omitted because deprecated: intagg
     #
-    line: supautils.privileged_extensions = 'address_standardizer, address_standardizer_data_us, autoinc, bloom, btree_gin, btree_gist, citext, cube, dblink, dict_int, dict_xsyn, earthdistance, fuzzystrmatch, hstore, http, insert_username, intarray, isn, ltree, moddatetime, pg_cron, pg_graphql, pg_hashids, pg_net, pg_stat_statements, pg_trgm, pgaudit, pgcrypto, pgrouting, pgrowlocks, pgsodium, plcoffee, pljava, plls, plpgsql, plpgsql_check, plv8, postgis, postgis_raster, postgis_sfcgal, postgis_topology, postgres_fdw, refint, rum, seg, sslinfo, supautils, tablefunc, tcn, tsm_system_rows, tsm_system_time, unaccent, uuid-ossp'
+    line: supautils.privileged_extensions = 'address_standardizer, address_standardizer_data_us, autoinc, bloom, btree_gin, btree_gist, citext, cube, dblink, dict_int, dict_xsyn, earthdistance, fuzzystrmatch, hstore, http, insert_username, intarray, isn, ltree, moddatetime, pg_cron, pg_graphql, pg_hashids, pg_net, pg_stat_monitor, pg_trgm, pgaudit, pgcrypto, pgrouting, pgrowlocks, pgsodium, plcoffee, pljava, plls, plpgsql, plpgsql_check, plv8, postgis, postgis_raster, postgis_sfcgal, postgis_topology, postgres_fdw, refint, rum, seg, sslinfo, supautils, tablefunc, tcn, tsm_system_rows, tsm_system_time, unaccent, uuid-ossp'
 
 - name: supautils - set supautils.privileged_extensions_superuser
   become: yes

--- a/ansible/tasks/postgres-extensions/20-pg_stat_monitor.yml
+++ b/ansible/tasks/postgres-extensions/20-pg_stat_monitor.yml
@@ -6,12 +6,12 @@
     version: "{{ pg_stat_monitor_release }}"
     become: yes
 
-- name: pg_stat_monitor build and install
+- name: pg_stat_monitor build 
   make:
     chdir: /tmp/pg_stat_monitor
     params: USE_PGXS=1
 
-- name: pg_stat_monitor build and install
+- name: pg_stat_monitor install
   make:
     chdir: /tmp/pg_stat_monitor
     target: install

--- a/ansible/tasks/postgres-extensions/20-pg_stat_monitor.yml
+++ b/ansible/tasks/postgres-extensions/20-pg_stat_monitor.yml
@@ -1,0 +1,7 @@
+# pg_stat_monitor
+- name: pg_stat_monitor - download and install dependencies
+  apt:
+    pkg:
+      - percona-pg-stat-monitor14
+    update_cache: yes
+    install_recommends: no

--- a/ansible/tasks/postgres-extensions/20-pg_stat_monitor.yml
+++ b/ansible/tasks/postgres-extensions/20-pg_stat_monitor.yml
@@ -1,7 +1,18 @@
 # pg_stat_monitor
 - name: pg_stat_monitor - download and install dependencies
-  apt:
-    pkg:
-      - percona-pg-stat-monitor14
-    update_cache: yes
-    install_recommends: no
+  git:
+    repo: https://github.com/percona/pg_stat_monitor.git
+    dest: /tmp/pg_stat_monitor
+    version: "{{ pg_stat_monitor_release }}"
+    become: yes
+
+- name: pg_stat_monitor build and install
+  make:
+    chdir: /tmp/pg_stat_monitor
+    params: USE_PGXS=1
+
+- name: pg_stat_monitor build and install
+  make:
+    chdir: /tmp/pg_stat_monitor
+    target: install
+    params: USE_PGXS=1

--- a/ansible/tasks/setup-extensions.yml
+++ b/ansible/tasks/setup-extensions.yml
@@ -54,3 +54,6 @@
 
 - name: Install pg_graphql
   import_tasks: tasks/postgres-extensions/19-pg_graphql.yml
+
+- name: Install pg_stat_monitor
+  import_tasks: tasks/postgres-extensions/20-pg_stat_monitor.yml

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -98,5 +98,7 @@ libgraphqlparser_commit_sha: 3b64cd52d13621921990a5801ba019e8a9402599
 
 pg_graphql_release: "v0.3.1"
 
+pg_stat_monitor_release: "1.0.1"
+
 osquery_deb: 'https://pkg.osquery.io/deb/osquery_5.1.0-1.linux_arm64.deb'
 osquery_deb_checksum: sha1:6b6fa49edcfad5d77aa1e59c75b8708de2f634ac


### PR DESCRIPTION
## What kind of change does this PR introduce?

Removes pg_stat_statements and installs pg_stat_monitor.

## What is the current behavior?

We use pg_stat_statements.

## What is the new behavior?

We will instead use pg_stat_monitor

