### PR TITLE
chore: revert pg_stat_monitor_changes

### DIFF
--- a/ansible/files/postgres_exporter.service.j2
+++ b/ansible/files/postgres_exporter.service.j2
@@ -9,7 +9,7 @@ StandardOutput=append:/var/log/postgres_exporter.stdout
 StandardError=append:/var/log/postgres_exporter.error
 Restart=always
 RestartSec=3
-Environment="DATA_SOURCE_NAME=host=localhost dbname=postgres sslmode=disable user=supabase_admin pg_stat_monitor.track=none application_name=postgres_exporter"
+Environment="DATA_SOURCE_NAME=host=localhost dbname=postgres sslmode=disable user=supabase_admin pg_stat_statements.track=none application_name=postgres_exporter"
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible/files/postgresql_config/postgresql.conf.j2
+++ b/ansible/files/postgresql_config/postgresql.conf.j2
@@ -720,7 +720,7 @@ default_text_search_config = 'pg_catalog.english'
 #local_preload_libraries = ''
 #session_preload_libraries = ''
 
-shared_preload_libraries = 'pg_stat_monitor, pgaudit, plpgsql, plpgsql_check, pg_cron, pg_net, pgsodium, timescaledb'	# (change requires restart)
+shared_preload_libraries = 'pg_stat_statements, pg_stat_monitor, pgaudit, plpgsql, plpgsql_check, pg_cron, pg_net, pgsodium, timescaledb'	# (change requires restart)
 jit_provider = 'llvmjit'		# JIT library to use
 
 # - Other Defaults -

--- a/ansible/files/stat_extension.sql
+++ b/ansible/files/stat_extension.sql
@@ -1,2 +1,2 @@
 CREATE SCHEMA IF NOT exists extensions;
-CREATE EXTENSION IF NOT EXISTS pg_stat_monitor with schema extensions;
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements with schema extensions;

--- a/ansible/tasks/internal/supautils.yml
+++ b/ansible/tasks/internal/supautils.yml
@@ -65,7 +65,7 @@
   lineinfile:
     path: /etc/postgresql/postgresql.conf
     state: present
-    # full list: supautils.privileged_extensions = 'address_standardizer, address_standardizer_data_us, adminpack, amcheck, autoinc, bloom, btree_gin, btree_gist, citext, cube, dblink, dict_int, dict_xsyn, earthdistance, file_fdw, fuzzystrmatch, hstore, http, insert_username, intagg, intarray, isn, lo, ltree, moddatetime, old_snapshot, pageinspect, pg_buffercache, pg_cron, pg_freespacemap, pg_graphql, pg_hashids, pg_net, pg_prewarm, pg_stat_monitor, pg_surgery, pg_trgm, pg_visibility, pgaudit, pgcrypto, pgjwt, pgrouting, pgrowlocks, pgsodium, pgstattuple, pgtap, plcoffee, pljava, plls, plpgsql, plpgsql_check, plv8, postgis, postgis_raster, postgis_sfcgal, postgis_tiger_geocoder, postgis_topology, postgres_fdw, refint, rum, seg, sslinfo, supautils, tablefunc, tcn, tsm_system_rows, tsm_system_time, unaccent, uuid-ossp'
+    # full list: supautils.privileged_extensions = 'address_standardizer, address_standardizer_data_us, adminpack, amcheck, autoinc, bloom, btree_gin, btree_gist, citext, cube, dblink, dict_int, dict_xsyn, earthdistance, file_fdw, fuzzystrmatch, hstore, http, insert_username, intagg, intarray, isn, lo, ltree, moddatetime, old_snapshot, pageinspect, pg_buffercache, pg_cron, pg_freespacemap, pg_graphql, pg_hashids, pg_net, pg_prewarm, pg_stat_statements, pg_stat_monitor, pg_surgery, pg_trgm, pg_visibility, pgaudit, pgcrypto, pgjwt, pgrouting, pgrowlocks, pgsodium, pgstattuple, pgtap, plcoffee, pljava, plls, plpgsql, plpgsql_check, plv8, postgis, postgis_raster, postgis_sfcgal, postgis_tiger_geocoder, postgis_topology, postgres_fdw, refint, rum, seg, sslinfo, supautils, tablefunc, tcn, tsm_system_rows, tsm_system_time, unaccent, uuid-ossp'
     #
     # omitted because may be unsafe: adminpack, amcheck, file_fdw, lo, old_snapshot, pageinspect, pg_buffercache, pg_freespacemap, pg_prewarm, pg_surgery, pg_visibility, pgstattuple
     #
@@ -73,7 +73,7 @@
     #
     # omitted because deprecated: intagg
     #
-    line: supautils.privileged_extensions = 'address_standardizer, address_standardizer_data_us, autoinc, bloom, btree_gin, btree_gist, citext, cube, dblink, dict_int, dict_xsyn, earthdistance, fuzzystrmatch, hstore, http, insert_username, intarray, isn, ltree, moddatetime, pg_cron, pg_graphql, pg_hashids, pg_net, pg_stat_monitor, pg_trgm, pgaudit, pgcrypto, pgrouting, pgrowlocks, pgsodium, plcoffee, pljava, plls, plpgsql, plpgsql_check, plv8, postgis, postgis_raster, postgis_sfcgal, postgis_topology, postgres_fdw, refint, rum, seg, sslinfo, supautils, tablefunc, tcn, tsm_system_rows, tsm_system_time, unaccent, uuid-ossp'
+    line: supautils.privileged_extensions = 'address_standardizer, address_standardizer_data_us, autoinc, bloom, btree_gin, btree_gist, citext, cube, dblink, dict_int, dict_xsyn, earthdistance, fuzzystrmatch, hstore, http, insert_username, intarray, isn, ltree, moddatetime, pg_cron, pg_graphql, pg_hashids, pg_net, pg_stat_statements, pg_stat_monitor, pg_trgm, pgaudit, pgcrypto, pgrouting, pgrowlocks, pgsodium, plcoffee, pljava, plls, plpgsql, plpgsql_check, plv8, postgis, postgis_raster, postgis_sfcgal, postgis_topology, postgres_fdw, refint, rum, seg, sslinfo, supautils, tablefunc, tcn, tsm_system_rows, tsm_system_time, unaccent, uuid-ossp'
 
 - name: supautils - set supautils.privileged_extensions_superuser
   become: yes

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "14.1.0.38"
+postgres-version = "14.1.0.39"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Reverts  changes which make pg_stat_monitor the primary stat tool and introduces pg_stat_statements as primary so that it can be run together with pg_stat_monitor

## What is the current behavior?

pg_stat_monitor as primary.


## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Related to #7552 on infrastructure
