### PR TITLE
fix: update vector version to 0.22.3

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -85,8 +85,8 @@ pg_net_release_checksum: sha1:0695ad2e4e9b2a35a77dfa89bd4c5a90c622eb24
 rum_release: "1.3.9"
 rum_release_checksum: sha1:71901640ccf9e2e1886aad37703a9fd07ced9e53
 
-vector_x86_deb: 'https://packages.timber.io/vector/0.17.0/vector-0.17.0-amd64.deb'
-vector_arm_deb: 'https://packages.timber.io/vector/0.17.0/vector-0.17.0-arm64.deb'
+vector_x86_deb: 'https://packages.timber.io/vector/0.22.3/vector_0.22.3-1_amd64.deb' 
+vector_arm_deb: 'https://packages.timber.io/vector/0.22.3/vector_0.22.3-1_arm64.deb'
 
 libsodium_release: "1.0.18"
 libsodium_release_checksum: sha1:795b73e3f92a362fabee238a71735579bf46bb97

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "14.1.0.41"
+postgres-version = "14.1.0.42"


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Bumps Vector version to 0.22.3
- Requires config to be updated to work with 0.22.3
  - Unfortunately existing config is not backwards compatible with 0.17.0 due to the VRL `replace` function becoming fallible since 0.20.0, requiring its error to be handled or raised:
```Component errors
----------------
x Transform "csv_parse":
error[E103]: unhandled fallible assignment
   ┌─ :29:10
   │
29 │   z_ts = replace(.parsed.timestamp, " UTC", "Z")
   │   ------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   │   │      │
   │   │      this expression is fallible
   │   │      update the expression to be infallible
   │   or change this to an infallible assignment:
   │   z_ts, err = replace(.parsed.timestamp, " UTC", "Z")
   │
```

Requires [infrastructure#7974](https://github.com/supabase/infrastructure/pull/7974) to be deployed at the same time the released image goes online