### PR TITLE
Fix WAL-G build

### DIFF
--- a/ansible/tasks/setup-wal-g.yml
+++ b/ansible/tasks/setup-wal-g.yml
@@ -30,21 +30,24 @@
     version: "{{ wal_g_release }}"
   become: yes
 
-- name: wal-g - additional go dependencies
+- name: wal-g - pg_clean
+  make:
+    chdir: /tmp/wal-g
+    target: pg_clean
+  become: yes
+  ignore_errors: yes
+
+- name: wal-g - deps
   make:
     chdir: /tmp/wal-g
     target: deps
-    params:
-      GOBIN: "/usr/local/bin"
-      PATH: "{{ ansible_env.PATH }}:/usr/local/go/bin"
-      USE_LIBSODIUM: true
   become: yes
   ignore_errors: yes
 
 - name: wal-g - build and install
   make:
     chdir: /tmp/wal-g
-    target: pg_build
+    target: pg_install
     jobs: "{{ parallel_jobs | default(omit) }}"
     params:
       GOBIN: "/usr/local/bin"

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "14.1.0.43"
+postgres-version = "14.1.0.44"


### PR DESCRIPTION
Fixes [previous PR](https://github.com/supabase/postgres/pull/231) wherein WAL-G was not built properly. Changes here follow the second set of instructions [found here for installing WAL-G in Ubuntu](https://github.com/wal-g/wal-g/blob/master/docs/PostgreSQL.md#ubuntu). Previous PR was following the first set of instructions but failed to copy the binary to `/usr/local/bin`.