### PR TITLE
fix: set log_rotation_age to 1d and enable log_truncate_on_rotation.

### DIFF
--- a/ansible/files/postgresql_config/postgresql.conf.j2
+++ b/ansible/files/postgresql_config/postgresql.conf.j2
@@ -450,10 +450,10 @@ log_file_mode = 0640			# creation mode for log files,
 					# begin with 0 to use octal notation
 log_rotation_age = 1440			# Automatic rotation of logfiles will
 					# happen after that time.  0 disables.
-log_rotation_size = 10240		# Automatic rotation of logfiles will
+log_rotation_size = 0 # Automatic rotation of logfiles will
 					# happen after that much log output.
 					# 0 disables.
-#log_truncate_on_rotation = off		# If on, an existing log file with the
+log_truncate_on_rotation = on # If on, an existing log file with the
 					# same name as the new log file will be
 					# truncated rather than appended to.
 					# But such truncation only occurs on

--- a/ansible/files/postgresql_config/postgresql.conf.j2
+++ b/ansible/files/postgresql_config/postgresql.conf.j2
@@ -448,9 +448,9 @@ log_filename = 'postgresql.log'	# log file name pattern,
 					# can include strftime() escapes
 log_file_mode = 0640			# creation mode for log files,
 					# begin with 0 to use octal notation
-log_rotation_age = 0			# Automatic rotation of logfiles will
+log_rotation_age = 1440			# Automatic rotation of logfiles will
 					# happen after that time.  0 disables.
-log_rotation_size = 0		# Automatic rotation of logfiles will
+log_rotation_size = 10240		# Automatic rotation of logfiles will
 					# happen after that much log output.
 					# 0 disables.
 #log_truncate_on_rotation = off		# If on, an existing log file with the


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`log_rotation_size` and `log_rotation_time` are both set to 0, disabling the default functionality. This causes the disk to fill up endlessly with these log files.

Fixes #208.

## What is the new behavior?

- Set time limit for log rotation
- Enabled file truncate on log rotate

This means the log file will truncate daily.
