### PR TITLE
fix: broken command in postgresql.csv logrotate config

### DIFF
--- a/ansible/files/logrotate_config/logrotate-postgres-csv.conf
+++ b/ansible/files/logrotate_config/logrotate-postgres-csv.conf
@@ -6,6 +6,6 @@
     notifempty
     missingok
     postrotate
-        sudo -u postgres pg_ctl -D /var/lib/postgresql/data logrotate
+        su postgres -c 'pg_ctl -D /var/lib/postgresql/data logrotate'
     endscript
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`sudo` binary doesn't exist in the container, presumably causing the log rotation to never happen.

Fixes #208.

## What is the new behavior?

Use `su` instead

This means the log file will rotate as per the logrotate config

![image](https://user-images.githubusercontent.com/1211903/179692363-2ac49bfe-3f5c-424e-b374-fcf0c4d3a3b7.png)
