### PR TITLE
Enable auto_explain for all queries that run longer than 10 seconds.

### DIFF
--- a/ansible/files/postgresql_config/postgresql.conf.j2
+++ b/ansible/files/postgresql_config/postgresql.conf.j2
@@ -688,7 +688,7 @@ default_text_search_config = 'pg_catalog.english'
 #local_preload_libraries = ''
 #session_preload_libraries = ''
 
-shared_preload_libraries = 'pg_stat_statements, pg_stat_monitor, pgaudit, plpgsql, plpgsql_check, pg_cron, pg_net, pgsodium, timescaledb'	# (change requires restart)
+shared_preload_libraries = 'pg_stat_statements, pg_stat_monitor, pgaudit, plpgsql, plpgsql_check, pg_cron, pg_net, pgsodium, timescaledb, auto_explain'	# (change requires restart)
 jit_provider = 'llvmjit'		# JIT library to use
 
 # - Other Defaults -

--- a/ansible/tasks/postgres-extensions/21-auto_explain.yml
+++ b/ansible/tasks/postgres-extensions/21-auto_explain.yml
@@ -1,0 +1,7 @@
+
+- name: auto_explain - set auto_explain.log_min_duration
+  become: yes
+  lineinfile:
+    path: /etc/postgresql/postgresql.conf
+    state: present
+    line: auto_explain.log_min_duration = 10s

--- a/ansible/tasks/setup-extensions.yml
+++ b/ansible/tasks/setup-extensions.yml
@@ -60,5 +60,3 @@
 
 - name: Install auto_explain
   import_tasks: tasks/postgres-extensions/21-auto_explain.yml
-
-  

--- a/ansible/tasks/setup-extensions.yml
+++ b/ansible/tasks/setup-extensions.yml
@@ -57,3 +57,8 @@
 
 - name: Install pg_stat_monitor
   import_tasks: tasks/postgres-extensions/20-pg_stat_monitor.yml
+
+- name: Install auto_explain
+  import_tasks: tasks/postgres-extensions/21-auto_explain.yml
+
+  


### PR DESCRIPTION
## What kind of change does this PR introduce?

It preloads the auto_explain extension, and sets the minimum log duration to 10 seconds.

## What is the current behavior?

Auto explain is not enabled by default and must be loaded explicitly per session.

## What is the new behavior?

Auto explain is pre-loaded at database boot time, and the default minimum duration to log a query plan is 10 seconds.  The customer can set other auto explain parameters `SET` and `ALTER SYSTEM`.

