### PR TITLE
chore: use a readonly script for pgsodium keys on AMI

### DIFF
--- a/ansible/files/pgsodium_getkey_readonly.sh.j2
+++ b/ansible/files/pgsodium_getkey_readonly.sh.j2
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -euo pipefail
+
+KEY_FILE=/var/lib/postgresql/pgsodium_root.key
+
+# On the hosted platform, the root key is generated and managed for each project
+# If for some reason the key is missing, we want to fail loudly,
+# rather than generating a new one.
+if [[ ! -f "${KEY_FILE}" ]]; then
+    echo "Key file ${KEY_FILE} does not exist." >&2
+    exit 1
+fi
+cat $KEY_FILE

--- a/ansible/files/pgsodium_getkey_urandom.sh.j2
+++ b/ansible/files/pgsodium_getkey_urandom.sh.j2
@@ -1,7 +1,10 @@
 #!/bin/bash
+
+set -euo pipefail
+
 KEY_FILE=/var/lib/postgresql/pgsodium_root.key
 
-if [ ! -f "$KEY_FILE" ]; then
-    head -c 32 /dev/urandom | od -A n -t x1 | tr -d ' \n' > $KEY_FILE
+if [[ ! -f "${KEY_FILE}" ]]; then
+    head -c 32 /dev/urandom | od -A n -t x1 | tr -d ' \n' > "${KEY_FILE}"
 fi
 cat $KEY_FILE

--- a/ansible/tasks/docker/finalize.yml
+++ b/ansible/tasks/docker/finalize.yml
@@ -3,3 +3,11 @@
     src: files/postgresql_config/postgresql-stdout-log.conf
     dest: /etc/postgresql/logging.conf
     group: postgres
+
+- name: import pgsodium_getkey_urandom.sh
+  template:
+    src: files/pgsodium_getkey_urandom.sh.j2
+    dest: "{{ pg_bindir }}/pgsodium_getkey.sh"
+    owner: postgres
+    group: postgres
+    mode: 0700

--- a/ansible/tasks/finalize-ami.yml
+++ b/ansible/tasks/finalize-ami.yml
@@ -51,3 +51,11 @@
         sed -i -e 's;daily;*:0/10;' /etc/systemd/system/logrotate.timer
         systemctl reenable logrotate.timer
   become: yes
+
+- name: import pgsodium_getkey script
+  template:
+    src: files/pgsodium_getkey_readonly.sh.j2
+    dest: "{{ pg_bindir }}/pgsodium_getkey.sh"
+    owner: postgres
+    group: postgres
+    mode: 0700

--- a/ansible/tasks/postgres-extensions/18-pgsodium.yml
+++ b/ansible/tasks/postgres-extensions/18-pgsodium.yml
@@ -61,18 +61,10 @@
     target: install
   become: yes
   
-# Add pgsodium_getkey_urandom.sh
-- name: import pgsodium_getkey_urandom.sh
-  template:
-    src: files/pgsodium_getkey_urandom.sh.j2
-    dest: "{{ pg_bindir }}/pgsodium_getkey_urandom.sh"
-    owner: postgres
-    group: postgres
-    mode: 0700
-
 - name: pgsodium - set pgsodium.getkey_script
   become: yes
   lineinfile:
     path: /etc/postgresql/postgresql.conf
     state: present
-    line: pgsodium.getkey_script= '{{ pg_bindir }}/pgsodium_getkey_urandom.sh'
+    # script is expected to be placed by finalization tasks for different target platforms
+    line: pgsodium.getkey_script= '{{ pg_bindir }}/pgsodium_getkey.sh'

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "14.1.0.53"
+postgres-version = "14.1.0.54"


### PR DESCRIPTION
Docker build is unchanged and generates a key if needed.