### PR TITLE
Fixes to ensure PostgREST and Kong are properly installed

### DIFF
--- a/ansible/tasks/clean-build-dependencies.yml
+++ b/ansible/tasks/clean-build-dependencies.yml
@@ -13,6 +13,5 @@
       - gcc-10
       - ninja-build
       - python2
-      - zlib1g-dev
     state: absent
     autoremove: yes

--- a/ansible/tasks/setup-extensions.yml
+++ b/ansible/tasks/setup-extensions.yml
@@ -64,5 +64,5 @@
 - name: Install pg_jsonschema
   import_tasks: tasks/postgres-extensions/22-pg_jsonschema.yml
 
-- name: Install vault
-  import_tasks: tasks/postgres-extensions/23-vault.yml
+# - name: Install vault
+#   import_tasks: tasks/postgres-extensions/23-vault.yml

--- a/ansible/tasks/setup-kong.yml
+++ b/ansible/tasks/setup-kong.yml
@@ -19,6 +19,9 @@
 - name: Kong - deb installation
   apt: deb=file:///tmp/kong.deb
 
+- name: Kong - ensure it is NOT autoremovd
+  shell: apt-mark manual kong
+
 - name: Kong - configuration
   template:
     src: files/kong_config/kong.conf.j2

--- a/ansible/tasks/setup-postgrest.yml
+++ b/ansible/tasks/setup-postgrest.yml
@@ -7,6 +7,7 @@
   apt:
     pkg:
       - libpq5
+      - libnuma-dev
 
 - name: PostgREST - download ubuntu binary archive (arm)
   get_url:

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -23,9 +23,9 @@ golang_version_checksum:
   arm64: sha256:beacbe1441bee4d7978b900136d1d6a71d150f0a9bb77e9d50c822065623a35a
   amd64: sha256:956f8507b302ab0bb747613695cdae10af99bbd39a90cae522b7c0302cc27245
 
-kong_release_target: xenial # if it works, it works
+kong_release_target: focal # if it works, it works
 kong_deb: kong_2.8.1_arm64.deb
-kong_deb_checksum: sha1:e61882d652d1f41bc3b7d179163b8a7abfe41d94
+kong_deb_checksum: sha1:2086f6ccf8454fe64435252fea4d29d736d7ec61
 
 nginx_release: 1.22.0
 nginx_release_checksum: sha1:419efb77b80f165666e2ee406ad8ae9b845aba93

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "14.1.0.60"
+postgres-version = "14.1.0.62"


### PR DESCRIPTION
* PostgREST lacks the `libnuma-dev`.
* Kong is uninstalled when `zlib1g-dev` is uninstalled.