### PR TITLE
Separate --skip-tags parameters from Ansible arguments

### DIFF
--- a/amazon-arm64.pkr.hcl
+++ b/amazon-arm64.pkr.hcl
@@ -20,7 +20,12 @@ variable "ami_regions" {
 
 variable "ansible_arguments" {
   type    = string
-  default = "--skip-tags,install-postgrest,--skip-tags,install-pgbouncer,--skip-tags,install-supabase-internal,ebssurrogate_mode='true'"
+  default = "ebssurrogate_mode='true'"
+}
+
+variable "skip_tags" {
+  type    = string
+  default = "install-postgrest,install-pgbouncer,install-supabase-internal"
 }
 
 variable "aws_access_key" {
@@ -211,6 +216,7 @@ build {
   provisioner "shell" {
     environment_vars = [
       "ARGS=${var.ansible_arguments}",
+      "SKIP_TAGS=${var.skip_tags}",
       "DOCKER_USER=${var.docker_user}",
       "DOCKER_PASSWD=${var.docker_passwd}",
       "DOCKER_IMAGE=${var.docker_image}",

--- a/development-arm.vars.pkr.hcl
+++ b/development-arm.vars.pkr.hcl
@@ -4,4 +4,4 @@ environment = "dev"
 instance-type = "c6g.4xlarge"
 region= "us-east-1"
 ubuntu-2004 = "ami-0b49a4a6e8e22fa16"
-
+skip_tags = ""

--- a/ebssurrogate/scripts/surrogate-bootstrap.sh
+++ b/ebssurrogate/scripts/surrogate-bootstrap.sh
@@ -21,6 +21,7 @@ function waitfor_boot_finished {
 	export DEBIAN_FRONTEND=noninteractive
 
 	echo "args: ${ARGS}"
+	echo "skip tags: ${SKIP_TAGS}"
 	# Wait for cloudinit on the surrogate to complete before making progress
 	while [[ ! -f /var/lib/cloud/instance/boot-finished ]]; do
 	    echo 'Waiting for cloud-init...'
@@ -194,7 +195,7 @@ function execute_playbook {
 	# Run Ansible playbook
 	#export ANSIBLE_LOG_PATH=/tmp/ansible.log && export ANSIBLE_DEBUG=True && export ANSIBLE_REMOTE_TEMP=/mnt/tmp 
 	export ANSIBLE_LOG_PATH=/tmp/ansible.log && export ANSIBLE_REMOTE_TEMP=/mnt/tmp 
-	ansible-playbook -c chroot -i '/mnt,' /tmp/ansible-playbook/ansible/playbook.yml --extra-vars " $ARGS"
+	ansible-playbook -c chroot -i '/mnt,' /tmp/ansible-playbook/ansible/playbook.yml --skip-tags "$SKIP_TAGS" --extra-vars "$ARGS"
 }
 
 function update_systemd_services {


### PR DESCRIPTION
* Noticed that `--skip-tags` parameters [are not observed ](https://github.com/supabase/postgres/runs/7894989613?check_suite_focus=true#step:4:6036) when building an image.
    * By right, with this configuration, certain steps would be omitted in the build process. Instead, all steps are still included. 
* For internal builds, this value is set to `""` as we will want to include all steps. 