### PR TITLE
chore: disable logging all statements by default

### DIFF
--- a/ansible/files/postgresql_config/postgresql.conf.j2
+++ b/ansible/files/postgresql_config/postgresql.conf.j2
@@ -540,7 +540,7 @@ log_line_prefix = '%h %m [%p] %q%u@%d '		# special values:
 #log_parameter_max_length_on_error = 0	# when logging an error, limit logged
 					# bind-parameter values to N bytes;
 					# -1 means print in full, 0 disables
-log_statement = 'all'			# none, ddl, mod, all
+log_statement = 'none'			# none, ddl, mod, all
 #log_replication_commands = off
 #log_temp_files = -1			# log temporary files equal or larger
 					# than the specified size in kilobytes;

--- a/ansible/files/postgresql_config/supautils.conf.j2
+++ b/ansible/files/postgresql_config/supautils.conf.j2
@@ -1,6 +1,6 @@
 supautils.reserved_roles = 'supabase_admin, supabase_auth_admin, supabase_storage_admin, dashboard_user, pgbouncer, service_role, authenticator, authenticated, anon'
 supautils.reserved_memberships = 'pg_read_server_files, pg_write_server_files, pg_execute_server_program, authenticator'
-supautils.placeholders = 'response.headers'
+supautils.placeholders = 'response.headers, pgaudit.log_parameter'
 supautils.placeholders_disallowed_values = '"content-type"'
 # full list:                                 address_standardizer, address_standardizer_data_us, adminpack, amcheck, autoinc, bloom, btree_gin, btree_gist, citext, cube, dblink, dict_int, dict_xsyn, earthdistance, file_fdw, fuzzystrmatch, hstore, http, insert_username, intagg, intarray, isn, lo, ltree, moddatetime, old_snapshot, pageinspect, pg_buffercache, pg_cron, pg_freespacemap, pg_graphql, pg_hashids, pg_net, pg_prewarm, pg_stat_statements, pg_stat_monitor, pg_surgery, pg_trgm, pg_visibility, pgaudit, pgcrypto, pgjwt, pgrouting, pgrowlocks, pgsodium, pgstattuple, pgtap, plcoffee, pljava, plls, plpgsql, plpgsql_check, plv8, postgis, postgis_raster, postgis_sfcgal, postgis_tiger_geocoder, postgis_topology, postgres_fdw, refint, rum, seg, sslinfo, supautils, tablefunc, tcn, tsm_system_rows, tsm_system_time, unaccent, uuid-ossp, pg_jsonschema
 # omitted because may be unsafe:             adminpack, amcheck, file_fdw, lo, old_snapshot, pageinspect, pg_buffercache, pg_freespacemap, pg_prewarm, pg_surgery, pg_visibility, pgstattuple


### PR DESCRIPTION
We'll be adding docs and dashboard functionality to make it easier to
hook into the more sophisticated logging options offered by pgAudit
instead.