### PR TITLE
fix: retain key packages for PostgREST and Kong

### DIFF
--- a/ansible/tasks/setup-kong.yml
+++ b/ansible/tasks/setup-kong.yml
@@ -23,7 +23,6 @@
   shell: |
     set -e
     apt-mark manual kong zlib1g*
-    apt-mark auto zlib1g*-dev
 
 - name: Kong - configuration
   template:

--- a/ansible/tasks/setup-kong.yml
+++ b/ansible/tasks/setup-kong.yml
@@ -19,8 +19,11 @@
 - name: Kong - deb installation
   apt: deb=file:///tmp/kong.deb
 
-- name: Kong - ensure it is NOT autoremovd
-  shell: apt-mark manual kong
+- name: Kong - ensure it is NOT autoremoved
+  shell: |
+    set -e
+    apt-mark manual kong zlib1g*
+    apt-mark auto zlib1g*-dev
 
 - name: Kong - configuration
   template:

--- a/ansible/tasks/setup-postgrest.yml
+++ b/ansible/tasks/setup-postgrest.yml
@@ -9,6 +9,12 @@
       - libpq5
       - libnuma-dev
 
+- name: postgis - ensure dependencies do not get autoremoved
+  shell: |
+    set -e
+    apt-mark manual libnuma*
+    apt-mark auto libnuma*-dev
+
 - name: PostgREST - download ubuntu binary archive (arm)
   get_url:
     url: "https://github.com/PostgREST/postgrest/releases/download/v{{ postgrest_release }}/postgrest-v{{ postgrest_release }}-ubuntu-aarch64.tar.xz"

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "14.1.0.62"
+postgres-version = "14.1.0.63"


### PR DESCRIPTION
FLUP of #278. Changes in previous PR were insufficient in ensuring that PostgREST and Kong are properly installed.