### PR TITLE
Prevent the libc6-dev package from getting uninstalled

### DIFF
--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "14.1.0.63"
+postgres-version = "14.1.0.64"

--- a/scripts/90-cleanup.sh
+++ b/scripts/90-cleanup.sh
@@ -37,7 +37,6 @@ elif [ -n "$(command -v apt-get)" ]; then
 	libasound2 \
 	libicu-dev \
 	libcgal-dev \
-	libc6-dev  \
 	libgcc-9-dev \
 	libgcc-8-dev \
 	linux-headers-5.11.0-1021-aws


### PR DESCRIPTION
Determined that by uninstalling the `libc6-dev` package, `zlib1g-dev` is uninstalled along as well as it is dependent on it. `kong` is uninstalled as a result as it is dependent on `zlib1g-dev` package.

Have attempted to build locally and have confirmed that Kong is no longer uninstalled with this branch.