### PR TITLE
chore: add init scripts to docker build

### DIFF
--- a/.github/workflows/dockerhub-release.yml
+++ b/.github/workflows/dockerhub-release.yml
@@ -35,7 +35,7 @@ jobs:
             supabase/postgres
             public.ecr.aws/t3w2s2c9/postgres
           tags: |
-            type=raw,value=v${{ steps.settings.outputs.docker_version }}
+            type=raw,value=${{ steps.settings.outputs.docker_version }}
 
       - uses: docker/setup-qemu-action@v2
         with:

--- a/ansible/playbook-docker.yml
+++ b/ansible/playbook-docker.yml
@@ -5,12 +5,24 @@
   vars_files:
     - ./vars.yml
 
+  vars:
+    sql_files:
+      - { source: "pgbouncer_config/pgbouncer_auth_schema.sql", dest: "00-schema.sql" }
+      - { source: "stat_extension.sql", dest: "01-extension.sql" }
+      - { source: "sodium_extension.sql", dest: "02-sodium-extension.sql" }
+
   tasks:
     - name: Setup container
       import_tasks: tasks/docker/setup.yml
 
     - name: Install Postgres extensions
       import_tasks: tasks/setup-extensions.yml
+
+    - name: Transfer init SQL files
+      copy:
+        src: files/{{ item.source }}
+        dest: /docker-entrypoint-initdb.d/{{ item.dest }}
+      loop: "{{ sql_files }}"
 
     - name: Finalize docker
       import_tasks: tasks/docker/finalize.yml


### PR DESCRIPTION
## What kind of change does this PR introduce?

Include sql init scripts in docker image

## What is the current behavior?

initial schemas in ami build are missing from docker build

## What is the new behavior?

include all init scripts in docker image
