### PR TITLE
Enable a systemd timeout for PG.

### DIFF
--- a/ansible/files/postgresql_config/postgresql.service.j2
+++ b/ansible/files/postgresql_config/postgresql.service.j2
@@ -13,7 +13,7 @@ ExecStart=/usr/lib/postgresql/bin/postgres -D /etc/postgresql
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=mixed
 KillSignal=SIGINT
-TimeoutSec=0
+TimeoutSec=90
 Restart=always
 RestartSec=5
 


### PR DESCRIPTION
Under error conditions, ensure that PG does not block a system restart.