### PR TITLE
chore: add additional permissions to adminapi

### DIFF
--- a/ansible/files/adminapi.sudoers.conf
+++ b/ansible/files/adminapi.sudoers.conf
@@ -1,4 +1,6 @@
-Cmnd_Alias KONG = /bin/systemctl restart kong.service, /bin/systemctl reload kong.service
+Cmnd_Alias KONG = /bin/systemctl start kong.service, /bin/systemctl stop kong.service, /bin/systemctl restart kong.service, /bin/systemctl disable kong.service, /bin/systemctl enable kong.service, /bin/systemctl reload kong.service
+Cmnd_Alias POSTGREST = /bin/systemctl start postgrest.service, /bin/systemctl stop postgrest.service, /bin/systemctl restart postgrest.service, /bin/systemctl disable postgrest.service, /bin/systemctl enable postgrest.service
+Cmnd_Alias GOTRUE = /bin/systemctl start gotrue.service, /bin/systemctl stop gotrue.service, /bin/systemctl restart gotrue.service, /bin/systemctl disable gotrue.service, /bin/systemctl enable gotrue.service
 
 %adminapi ALL= NOPASSWD: /root/grow_fs.sh
 %adminapi ALL= NOPASSWD: /root/commence_walg_backup.sh
@@ -12,6 +14,6 @@ Cmnd_Alias KONG = /bin/systemctl restart kong.service, /bin/systemctl reload kon
 %adminapi ALL= NOPASSWD: /usr/bin/systemctl restart pgbouncer.service
 %adminapi ALL= NOPASSWD: /bin/systemctl daemon-reload
 %adminapi ALL= NOPASSWD: /bin/systemctl restart services.slice
-%adminapi ALL= NOPASSWD: /bin/systemctl restart gotrue.service
-%adminapi ALL= NOPASSWD: /bin/systemctl restart postgrest.service
 %adminapi ALL= NOPASSWD: KONG
+%adminapi ALL= NOPASSWD: POSTGREST
+%adminapi ALL= NOPASSWD: GOTRUE

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "14.1.0.67"
+postgres-version = "14.1.0.68"


### PR DESCRIPTION
* This PR adds additional permissions to allow adminapi to stop, start, enable, and disable the following services:
    * Kong
    * PostgREST
    * Gotrue