### PR TITLE
upgrade to pg_net 0.6.1

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -84,13 +84,13 @@ plv8_commit_version: 3656177d384e3e02b74faa8e2931600f3690ab59
 
 pg_plan_filter_commit_version: 5081a7b5cb890876e67d8e7486b6a64c38c9a492
 
-pg_net_release: "0.3"
-pg_net_release_checksum: sha1:0695ad2e4e9b2a35a77dfa89bd4c5a90c622eb24
+pg_net_release: "0.6.1"
+pg_net_release_checksum: sha1:8457081e28021043f77cec8c14a866bf9e9fdb8b
 
 rum_release: "1.3.9"
 rum_release_checksum: sha1:71901640ccf9e2e1886aad37703a9fd07ced9e53
 
-vector_x86_deb: 'https://packages.timber.io/vector/0.22.3/vector_0.22.3-1_amd64.deb' 
+vector_x86_deb: 'https://packages.timber.io/vector/0.22.3/vector_0.22.3-1_amd64.deb'
 vector_arm_deb: 'https://packages.timber.io/vector/0.22.3/vector_0.22.3-1_arm64.deb'
 
 libsodium_release: "1.0.18"


### PR DESCRIPTION
No longer depends on `libuv`, only `curl`. A `make && make install` should do.
  
For migrating existing instances(to be included in an ansible script):

```sql
-- for webhooks, see comment below, should be safe to run even if they don't use them
ALTER TABLE IF EXISTS supabase_functions.hooks DROP CONSTRAINT IF EXISTS hooks_request_id_fkey;

-- terminate the existing worker to avoid further errors when modifying the extension tables/functions
select pg_terminate_backend(pid) from pg_stat_activity where backend_type like '%pg_net%';
-- the customer will need to restart the postgres instance for the pg_net worker to be up again

-- Drop and recreate the extension, this could be left to the customer
drop extension if exists pg_net;
create extension pg_net;

-- alternatively(might fail if the customer modified the net tables/functiosn)
-- alter extension pg_net update to '0.6';
```