### PR TITLE
chore: bump gotrue version to 2.16.7

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -13,8 +13,8 @@ postgrest_release: "9.0.1.20220717"
 postgrest_arm_release_checksum: sha1:4d62e6adbd1f15eee735deae778650a1ec2cbbf6
 postgrest_x86_release_checksum: sha1:41b2c3ab6288dc0e3ab9bcd1c76cedf7b66f1d5e
 
-gotrue_release: v2.15.3
-gotrue_release_checksum: sha1:24d0f09f918bb950430cd326c333692cbd3c45db
+gotrue_release: v2.16.7
+gotrue_release_checksum: sha1:4fb24945c3d7ccda4f71dd63d2d97f750f2aeee7
 
 aws_cli_release: "2.2.7"
 
@@ -90,8 +90,8 @@ pg_net_release_checksum: sha1:8457081e28021043f77cec8c14a866bf9e9fdb8b
 rum_release: "1.3.9"
 rum_release_checksum: sha1:71901640ccf9e2e1886aad37703a9fd07ced9e53
 
-vector_x86_deb: 'https://packages.timber.io/vector/0.22.3/vector_0.22.3-1_amd64.deb'
-vector_arm_deb: 'https://packages.timber.io/vector/0.22.3/vector_0.22.3-1_arm64.deb'
+vector_x86_deb: "https://packages.timber.io/vector/0.22.3/vector_0.22.3-1_amd64.deb"
+vector_arm_deb: "https://packages.timber.io/vector/0.22.3/vector_0.22.3-1_arm64.deb"
 
 libsodium_release: "1.0.18"
 libsodium_release_checksum: sha1:795b73e3f92a362fabee238a71735579bf46bb97
@@ -110,4 +110,3 @@ pg_stat_monitor_release: "1.0.1"
 
 vault_release: "0.0.1"
 vault_release_checksum: sha1:a5ea3356c6f41985b2bef67b6a0491d4ffa99816
-

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "14.1.0.68"
+postgres-version = "14.1.0.69"


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Bump gotrue version to 2.16.7