### PR TITLE
fix: installs and removes pg_prove as needed for AMI assertions

### DIFF
--- a/ansible/tasks/test-image.yml
+++ b/ansible/tasks/test-image.yml
@@ -1,3 +1,8 @@
+- name: install pg_prove
+  apt:
+    pkg:
+      - libtap-parser-sourcehandler-pgtap-perl
+
 - name: Enable pgTAP extension
   shell: /usr/lib/postgresql/bin/psql -U postgres -h localhost -d postgres -c "CREATE extension pgtap";
   when: ebssurrogate_mode
@@ -12,3 +17,9 @@
   shell: /usr/lib/postgresql/bin/psql -U postgres -h localhost -d postgres -c "DROP extension if exists pgtap";
   when: ebssurrogate_mode
 
+- name: remove pg_prove
+  apt:
+    pkg:
+      - libtap-parser-sourcehandler-pgtap-perl
+    state: absent
+    autoremove: yes

--- a/ebssurrogate/scripts/chroot-bootstrap.sh
+++ b/ebssurrogate/scripts/chroot-bootstrap.sh
@@ -67,8 +67,7 @@ function update_install_packages {
 		locales \
 		at \
 		less \
-		python3-systemd \
-		pgtap
+		python3-systemd
 
 	if [ "${ARCH}" = "arm64" ]; then
 		apt-get $APT_OPTIONS --yes install linux-aws initramfs-tools dosfstools


### PR DESCRIPTION
Removes system-wide pgtap install as it undesirably pulls in pg12
server and misc other dependencies from apt, and is furthermore
unnecessary as pgtap is already built from source.