### PR TITLE
chore: cleans up unix socket auth for PG conns

### DIFF
--- a/ansible/files/postgresql_config/pg_hba.conf.j2
+++ b/ansible/files/postgresql_config/pg_hba.conf.j2
@@ -78,22 +78,10 @@
 
 # TYPE  DATABASE        USER            ADDRESS                 METHOD
 
-# Default:
-# "local" is for Unix domain socket connections only
-local  all  all    peer
-# IPv4 local connections:
+# trust local connections
+local all  all                peer map=supabase_map
 host  all  all  127.0.0.1/32  trust
-# IPv6 local connections:
-host  all  all  ::1/128  scram-sha-256
-# Local root Unix user, passwordless access
-local  all  postgres    peer map=root_as_postgres
+host  all  all  ::1/128       trust
+
 # IPv4 external connections
-host  all  all  0.0.0.0/0  scram-sha-256
-
-# MD5 hashed password hosts
-
-# Password hosts
-
-# Trusted hosts
-
-# User custom
+host  all  all  0.0.0.0/0     scram-sha-256

--- a/ansible/files/postgresql_config/pg_ident.conf.j2
+++ b/ansible/files/postgresql_config/pg_ident.conf.j2
@@ -40,5 +40,11 @@
 # ----------------------------------
 
 # MAPNAME       SYSTEM-USERNAME         PG-USERNAME
-# root is allowed to login as postgres
-root_as_postgres  postgres  postgres
+supabase_map  postgres   postgres
+supabase_map  root       postgres
+supabase_map  ubuntu     postgres
+
+# supabase-specific users
+supabase_map  gotrue     supabase_auth_admin
+supabase_map  postgrest  authenticator
+supabase_map  adminapi   postgres

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "14.1.0.70"
+postgres-version = "14.1.0.71"


### PR DESCRIPTION
Allows additional users to auth into PG as the user for their service.

Additionally, trusts local ipv6 connections.