### PR TITLE
fix: Allow vector write access to postgresql log

### DIFF
--- a/ebssurrogate/files/apparmor_profiles/usr.bin.vector
+++ b/ebssurrogate/files/apparmor_profiles/usr.bin.vector
@@ -20,8 +20,8 @@
   /usr/bin/vector mrix,
   /var/lib/vector/** rw,
   /var/log/journal/ r,
+  /var/log/postgresql/** rw,
   /var/log/postgresql/ r,
-  /var/log/postgresql/** r,
   /var/run/systemd/notify rw,
   owner /proc/*/cgroup r,
 }


### PR DESCRIPTION
Signed-off-by: Lakshmipathi <lakshmi@supabase.io>
