### PR TITLE
fix: provide unit name when disabling fail2ban

### DIFF
--- a/ansible/tasks/setup-fail2ban.yml
+++ b/ansible/tasks/setup-fail2ban.yml
@@ -60,5 +60,6 @@
 
 - name: fail2ban - disable service
   systemd:
+    name: fail2ban
     enabled: no
     daemon_reload: yes


### PR DESCRIPTION
see title, replaces #325 