### PR TITLE
upgrade wal2json to v2.5

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -73,7 +73,7 @@ pg_safeupdate_release_checksum: sha1:942dacd0ebce6123944212ffb3d6b5a0c09174f9
 
 timescaledb_release: "2.6.1"
 
-wal2json_commit_sha: 53b548a29ebd6119323b6eb2f6013d7c5fe807ec
+wal2json_commit_sha: 770872b890f9e122290f178e7c7bfa19ec7afa94
 
 supautils_release: "1.3.1"
 supautils_release_checksum: sha1:54d96cf1f96d2a16d1f9d8a8ac6fd632bd402154

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,2 +1,1 @@
-postgres-version = "14.1.0.81"
-
+postgres-version = "14.1.0.82"


### PR DESCRIPTION
## What kind of change does this PR introduce?
upgrades wal2json to version 2.5, which adds Postgres 15 support

Release details
https://github.com/eulerto/wal2json/releases/tag/wal2json_2_5