### PR TITLE
chore: bump GoTrue to v2.19.4(bug fix)

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -13,8 +13,8 @@ postgrest_release: "9.0.1.20220717"
 postgrest_arm_release_checksum: sha1:4d62e6adbd1f15eee735deae778650a1ec2cbbf6
 postgrest_x86_release_checksum: sha1:41b2c3ab6288dc0e3ab9bcd1c76cedf7b66f1d5e
 
-gotrue_release: v2.19.2
-gotrue_release_checksum: sha1:f7b99d8c5850b16a623839e2d73584e8675976fd
+gotrue_release: v2.19.4
+gotrue_release_checksum: sha1:394192321ffaec376da03456d4ebeb5f5c28b821
 
 aws_cli_release: "2.2.7"
 

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -13,8 +13,8 @@ postgrest_release: "9.0.1.20220717"
 postgrest_arm_release_checksum: sha1:4d62e6adbd1f15eee735deae778650a1ec2cbbf6
 postgrest_x86_release_checksum: sha1:41b2c3ab6288dc0e3ab9bcd1c76cedf7b66f1d5e
 
-gotrue_release: v2.19.0
-gotrue_release_checksum: sha1:15afef09d09973d29f5a8b664f8ea449a6a05f20
+gotrue_release: v2.19.2
+gotrue_release_checksum: sha1:f7b99d8c5850b16a623839e2d73584e8675976fd
 
 aws_cli_release: "2.2.7"
 

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "14.1.0.79"
+postgres-version = "14.1.0.80"


### PR DESCRIPTION
We realised there's a bug in the mfa implementation and this version contains the fix