### PR TITLE
Update pg_graphql to v0.5.0

### DIFF
--- a/ansible/tasks/postgres-extensions/19-pg_graphql.yml
+++ b/ansible/tasks/postgres-extensions/19-pg_graphql.yml
@@ -2,49 +2,68 @@
 - name: pg_graphql - download & install dependencies
   apt:
     pkg:
-      - bison
-      - build-essential
-      - clang-11
-      - cmake
-      - flex
-      - python2
+      - make
+      - gcc
+      - pkg-config
+      - clang
+      - libssl-dev
     update_cache: yes
     install_recommends: no
 
-- name: pg_graphql - download libgraphqlparser
-  git:
-    repo: https://github.com/graphql/libgraphqlparser.git
-    dest: /tmp/libgraphqlparser
-    version: "{{ libgraphqlparser_commit_sha }}"
+- name: download rust/cargo installer
   become: yes
+  get_url:
+    url: https://sh.rustup.rs
+    dest: /tmp/sh.rustup.rs
+    mode: '0755'
+    owner: postgres
+    group: postgres
 
-- name: pg_graphql - compile libgraphqlparser
+- name: install rust/cargo
+  become: yes
+  become_user: postgres
+  shell: /tmp/sh.rustup.rs -y
+
+- name: install cargo-pgx
+  become: yes
+  become_user: postgres
   shell:
-    cmd: "cmake ."
-    chdir: /tmp/libgraphqlparser
-  become: yes
-
-- name: pg_graphql - build libgraphqlparser
-  make:
-    chdir: /tmp/libgraphqlparser
-    target: install
-  become: yes
+    cmd: "~/.cargo/bin/cargo install --version '={{ pg_graphql_pgx_version }}' cargo-pgx && ~/.cargo/bin/cargo pgx init --pg{{ postgresql_major }} pg_config"
 
 - name: pg_graphql - download latest release
+  become: yes
   git:
     repo: https://github.com/supabase/pg_graphql.git
     dest: /tmp/pg_graphql
     version: "{{ pg_graphql_release }}"
-  become: yes
 
-- name: pg_graphql - build
-  make:
-    chdir: /tmp/pg_graphql
-    target: install
+- name: pg_graphql - temporarily transfer ownership to postgres
   become: yes
+  file:
+    path: '{{ item }}'
+    recurse: yes
+    owner: postgres
+    group: postgres
+  with_items:
+    - /tmp/pg_graphql
+    - /usr/lib/postgresql/lib # AMI
+    - /usr/lib/postgresql/14/lib # Docker Image
+    - /usr/share/postgresql/14
 
-- name: pg_graphql - update links and cache for shared libraries
+- name: pg_graphql - install
+  become: yes
+  become_user: postgres
   shell:
-    cmd: "/sbin/ldconfig -v"
+    cmd: "~/.cargo/bin/cargo pgx install --release"
     chdir: /tmp/pg_graphql
-  become: yes
+
+- name: pg_graphql - return ownership to root
+  file:
+    path: '{{ item }}'
+    recurse: yes
+    owner: root
+    group: root
+  with_items:
+    - /usr/lib/postgresql/lib
+    - /usr/lib/postgresql/14/lib
+    - /usr/share/postgresql/14

--- a/ansible/tasks/postgres-extensions/22-pg_jsonschema.yml
+++ b/ansible/tasks/postgres-extensions/22-pg_jsonschema.yml
@@ -28,7 +28,7 @@
   become: yes
   become_user: postgres
   shell:
-    cmd: "~/.cargo/bin/cargo install --version '={{ pgx_version }}' cargo-pgx && ~/.cargo/bin/cargo pgx init --pg{{ postgresql_major }} pg_config"
+    cmd: "~/.cargo/bin/cargo install --version '={{ pg_jsonschema_pgx_version }}' cargo-pgx && ~/.cargo/bin/cargo pgx init --pg{{ postgresql_major }} pg_config"
 
 - name: pg_jsonschema - download release
   become: yes

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -100,11 +100,10 @@ libsodium_release_checksum: sha1:795b73e3f92a362fabee238a71735579bf46bb97
 pgsodium_release: "3.0.6"
 pgsodium_release_checksum: sha1:829f5d87a5fdb479a22f3d2f05ba1799067dd898
 
-libgraphqlparser_commit_sha: 3b64cd52d13621921990a5801ba019e8a9402599
+pg_graphql_pgx_version: "0.5.2"
+pg_graphql_release: "v0.5.0"
 
-pg_graphql_release: "v0.4.1"
-
-pgx_version: "0.4.5"
+pg_jsonschema_pgx_version: "0.4.5"
 pg_jsonschema_release: "v0.1.0"
 
 pg_stat_monitor_release: "1.0.1"

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "14.1.0.82"
+postgres-version = "14.1.0.83-rc0"


### PR DESCRIPTION
## What kind of change does this PR introduce?
Updates `pg_graphql` from `v0.4.1` to `v0.5.0`

Note, this is a more significantly change than usual version bumps because the tooling to install `pg_graphql` has changed