### PR TITLE
Bugfix: remove grants to pg_graphql tables that DNE AO v0.5.0

### DIFF
--- a/migrations/db/migrations/20220317095840_pg_graphql.sql
+++ b/migrations/db/migrations/20220317095840_pg_graphql.sql
@@ -79,7 +79,6 @@ AS $func$
             SELECT graphql.resolve(query, coalesce(variables, '{}'));
         $$;
 
-        grant select on graphql.field, graphql.type, graphql.enum_value to postgres, anon, authenticated, service_role;
         grant execute on function graphql.resolve to postgres, anon, authenticated, service_role;
     END IF;
 

--- a/migrations/db/migrations/20220404205710_pg_graphql-on-by-default.sql
+++ b/migrations/db/migrations/20220404205710_pg_graphql-on-by-default.sql
@@ -44,7 +44,6 @@ BEGIN
             );
         $$;
 
-        grant select on graphql.field, graphql.type, graphql.enum_value to postgres, anon, authenticated, service_role;
         grant execute on function graphql.resolve to postgres, anon, authenticated, service_role;
     END IF;
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Update migrations to be compatible with updates pg_graphql v0.5.0

Ref:
Resolves failling CI build https://github.com/supabase/postgres/actions/runs/3342251842/jobs/5534288732#step:4:7757