### PR TITLE
pin pg_graphql to graphql schema. it is not relocatable

### DIFF
--- a/migrations/db/migrations/20220613123923_pg_graphql-pg-dump-perms.sql
+++ b/migrations/db/migrations/20220613123923_pg_graphql-pg-dump-perms.sql
@@ -67,7 +67,7 @@ BEGIN
 
   IF graphql_exists 
   THEN
-  create extension if not exists pg_graphql schema extensions;
+  create extension if not exists pg_graphql schema graphql;
   END IF;
 END $$;
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
pg_graphql is now explicitly not relocatable. It has always installed in the graphql schema but now attempting to install it in `extensions` results in an error.

this PR explicitly installs pg_graphql in the graphql schema