### PR TITLE
fix: bump gotrue to v2.23.2

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -14,8 +14,8 @@ postgrest_release: "9.0.1.20220717"
 postgrest_arm_release_checksum: sha1:4d62e6adbd1f15eee735deae778650a1ec2cbbf6
 postgrest_x86_release_checksum: sha1:41b2c3ab6288dc0e3ab9bcd1c76cedf7b66f1d5e
 
-gotrue_release: v2.19.4
-gotrue_release_checksum: sha1:394192321ffaec376da03456d4ebeb5f5c28b821
+gotrue_release: v2.23.2
+gotrue_release_checksum: sha1:4d973415933ef37b622a16faaf05dcedf9bbdfb3
 
 aws_cli_release: "2.2.7"
 

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "14.1.0.83-rc1"
+postgres-version = "14.1.0.84"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump Gotrue to v2.23
