### PR TITLE
chore: revoke supabase_admin from authenticator

### DIFF
--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "14.1.0.87"
+postgres-version = "14.1.0.89"

--- a/migrations/db/migrations/20221028101028_set_authenticator_timeout.sql
+++ b/migrations/db/migrations/20221028101028_set_authenticator_timeout.sql
@@ -1,2 +1,5 @@
 -- migrate:up
 alter role authenticator set statement_timeout = '8s';
+
+-- migrate:down
+

--- a/migrations/db/migrations/20221103090837_revoke_admin.sql
+++ b/migrations/db/migrations/20221103090837_revoke_admin.sql
@@ -1,0 +1,5 @@
+-- migrate:up
+revoke supabase_admin from authenticator;
+
+-- migrate:down
+


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

authenticator doesn't need superuser

## What is the new behavior?

1. revoke supabase_admin on new and restored projects 
2. Roll out to existing projects via ansible 

## Additional context

Add any other context or screenshots.
