### PR TITLE
Remove schema from create extension call for pg_graphql

### DIFF
--- a/migrations/db/migrations/20220613123923_pg_graphql-pg-dump-perms.sql
+++ b/migrations/db/migrations/20220613123923_pg_graphql-pg-dump-perms.sql
@@ -67,7 +67,7 @@ BEGIN
 
   IF graphql_exists 
   THEN
-  create extension if not exists pg_graphql schema graphql;
+  create extension if not exists pg_graphql;
   END IF;
 END $$;
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
resolves 
```
Failed to toggle PG_GRAPHQL: failed to create pg.extensions: schema "graphql" does not exist
```

when toggling pg_graphql on and off via create/drop extension