### PR TITLE
chore: use internal ansible module to fetch adminapi artifact

### DIFF
--- a/ansible/tasks/internal/admin-api.yml
+++ b/ansible/tasks/internal/admin-api.yml
@@ -39,9 +39,10 @@
   when: platform == "arm64"
 
 - name: Download adminapi archive
-  shell:
-    cmd: "curl -sf -L https://supabase-public-artifacts-bucket.s3.amazonaws.com/supabase-admin-api/v{{ adminapi_release }}/supabase-admin-api_{{ adminapi_release }}_linux_{{ arch }}.tar.gz -o /tmp/adminapi.tar.gz"
-  timeout: 90
+  get_url:
+    url: "https://supabase-public-artifacts-bucket.s3.amazonaws.com/supabase-admin-api/v{{ adminapi_release }}/supabase-admin-api_{{ adminapi_release }}_linux_{{ arch }}.tar.gz"
+    dest: "/tmp/adminapi.tar.gz"
+    timeout: 60
 
 - name: Copy adminapi archive to remote
   copy:

--- a/ansible/tasks/internal/admin-api.yml
+++ b/ansible/tasks/internal/admin-api.yml
@@ -42,7 +42,7 @@
   get_url:
     url: "https://supabase-public-artifacts-bucket.s3.amazonaws.com/supabase-admin-api/v{{ adminapi_release }}/supabase-admin-api_{{ adminapi_release }}_linux_{{ arch }}.tar.gz"
     dest: "/tmp/adminapi.tar.gz"
-    timeout: 60
+    timeout: 90
 
 - name: Copy adminapi archive to remote
   copy:

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "14.1.0.96"
+postgres-version = "14.1.0.97"


### PR DESCRIPTION
## Description

- Previous download failed since `curl` was missing; this uses ansible's internal `get_url` module to fetch artifacts