### PR TITLE
Install from .deb for supabase pgx projects

### DIFF
--- a/ansible/tasks/postgres-extensions/19-pg_graphql.yml
+++ b/ansible/tasks/postgres-extensions/19-pg_graphql.yml
@@ -1,69 +1,14 @@
 # pg_graphql
-- name: pg_graphql - download & install dependencies
-  apt:
-    pkg:
-      - make
-      - gcc
-      - pkg-config
-      - clang
-      - libssl-dev
-    update_cache: yes
-    install_recommends: no
+- name: Setting arch (x86)
+  set_fact:
+    arch: "amd64"
+  when: platform == "amd64"
 
-- name: download rust/cargo installer
-  become: yes
-  get_url:
-    url: https://sh.rustup.rs
-    dest: /tmp/sh.rustup.rs
-    mode: '0755'
-    owner: postgres
-    group: postgres
+- name: Setting arch (arm)
+  set_fact:
+    arch: "arm64"
+  when: platform == "arm64"
 
-- name: install rust/cargo
-  become: yes
-  become_user: postgres
-  shell: /tmp/sh.rustup.rs -y
-
-- name: install cargo-pgx
-  become: yes
-  become_user: postgres
-  shell:
-    cmd: "~/.cargo/bin/cargo install --version '={{ pg_graphql_pgx_version }}' cargo-pgx && ~/.cargo/bin/cargo pgx init --pg{{ postgresql_major }} pg_config"
-
-- name: pg_graphql - download latest release
-  become: yes
-  git:
-    repo: https://github.com/supabase/pg_graphql.git
-    dest: /tmp/pg_graphql
-    version: "{{ pg_graphql_release }}"
-
-- name: pg_graphql - temporarily transfer ownership to postgres
-  become: yes
-  file:
-    path: '{{ item }}'
-    recurse: yes
-    owner: postgres
-    group: postgres
-  with_items:
-    - /tmp/pg_graphql
-    - /usr/lib/postgresql/lib # AMI
-    - /usr/lib/postgresql/14/lib # Docker Image
-    - /usr/share/postgresql/14
-
-- name: pg_graphql - install
-  become: yes
-  become_user: postgres
-  shell:
-    cmd: "~/.cargo/bin/cargo pgx install --release"
-    chdir: /tmp/pg_graphql
-
-- name: pg_graphql - return ownership to root
-  file:
-    path: '{{ item }}'
-    recurse: yes
-    owner: root
-    group: root
-  with_items:
-    - /usr/lib/postgresql/lib
-    - /usr/lib/postgresql/14/lib
-    - /usr/share/postgresql/14
+- name: install pg_graphql
+  ansible.builtin.apt:
+    deb: "https://github.com/supabase/pg_graphql/releases/download/{{ pg_graphql_release }}/pg_graphql-{{ pg_graphql_release }}-pg{{ postgres_major }}-{{ arch }}-linux-gnu.deb"

--- a/ansible/tasks/postgres-extensions/19-pg_graphql.yml
+++ b/ansible/tasks/postgres-extensions/19-pg_graphql.yml
@@ -1,14 +1,3 @@
-# pg_graphql
-- name: Setting arch (x86)
-  set_fact:
-    arch: "amd64"
-  when: platform == "amd64"
-
-- name: Setting arch (arm)
-  set_fact:
-    arch: "arm64"
-  when: platform == "arm64"
-
 - name: install pg_graphql
   ansible.builtin.apt:
-    deb: "https://github.com/supabase/pg_graphql/releases/download/{{ pg_graphql_release }}/pg_graphql-{{ pg_graphql_release }}-pg{{ postgres_major }}-{{ arch }}-linux-gnu.deb"
+    deb: "https://github.com/supabase/pg_graphql/releases/download/{{ pg_graphql_release }}/pg_graphql-{{ pg_graphql_release }}-pg{{ postgres_major }}-{{ platform }}-linux-gnu.deb"

--- a/ansible/tasks/postgres-extensions/22-pg_jsonschema.yml
+++ b/ansible/tasks/postgres-extensions/22-pg_jsonschema.yml
@@ -1,14 +1,3 @@
-# pg_jsonschema
-- name: Setting arch (x86)
-  set_fact:
-    arch: "amd64"
-  when: platform == "amd64"
-
-- name: Setting arch (arm)
-  set_fact:
-    arch: "arm64"
-  when: platform == "arm64"
-
 - name: install pg_jsonschema
   ansible.builtin.apt:
-    deb: "https://github.com/supabase/pg_jsonschema/releases/download/{{ pg_jsonschema_release }}/pg_jsonschema-{{ pg_jsonschema_release }}-pg{{ postgres_major }}-{{ arch }}-linux-gnu.deb"
+    deb: "https://github.com/supabase/pg_jsonschema/releases/download/{{ pg_jsonschema_release }}/pg_jsonschema-{{ pg_jsonschema_release }}-pg{{ postgres_major }}-{{ platform }}-linux-gnu.deb"

--- a/ansible/tasks/postgres-extensions/22-pg_jsonschema.yml
+++ b/ansible/tasks/postgres-extensions/22-pg_jsonschema.yml
@@ -1,83 +1,14 @@
 # pg_jsonschema
-- name: pg_jsonschema - download & install dependencies
-  apt:
-    pkg:
-      - make
-      - gcc
-      - pkg-config
-      - clang
-      - libssl-dev
-    update_cache: yes
-    install_recommends: no
+- name: Setting arch (x86)
+  set_fact:
+    arch: "amd64"
+  when: platform == "amd64"
 
-- name: download rust/cargo installer
-  become: yes
-  get_url:
-    url: https://sh.rustup.rs
-    dest: /tmp/sh.rustup.rs
-    mode: '0755'
-    owner: postgres
-    group: postgres
+- name: Setting arch (arm)
+  set_fact:
+    arch: "arm64"
+  when: platform == "arm64"
 
-- name: install rust/cargo
-  become: yes
-  become_user: postgres
-  shell: /tmp/sh.rustup.rs -y
-
-- name: install cargo-pgx
-  become: yes
-  become_user: postgres
-  shell:
-    cmd: "~/.cargo/bin/cargo install --version '={{ pg_jsonschema_pgx_version }}' cargo-pgx && ~/.cargo/bin/cargo pgx init --pg{{ postgresql_major }} pg_config"
-
-- name: pg_jsonschema - download release
-  become: yes
-  git:
-    repo: https://github.com/supabase/pg_jsonschema.git
-    dest: /tmp/pg_jsonschema
-    version: "{{ pg_jsonschema_release }}"
-
-- name: pg_jsonschema - temporarily transfer ownership to postgres
-  become: yes
-  file:
-    path: '{{ item }}'
-    recurse: yes
-    owner: postgres
-    group: postgres
-  with_items:
-    - /tmp/pg_jsonschema
-    - /usr/lib/postgresql/lib # AMI
-    - /usr/lib/postgresql/14/lib # Docker Image
-    - /usr/share/postgresql/14
-
-- name: pg_jsonschema - install
-  become: yes
-  become_user: postgres
-  shell:
-    cmd: "~/.cargo/bin/cargo pgx install --release"
-    chdir: /tmp/pg_jsonschema
-  when: not async_mode
-
-- name: pg_jsonschema - return ownership to root
-  file:
-    path: '{{ item }}'
-    recurse: yes
-    owner: root
-    group: root
-  with_items:
-    - /usr/lib/postgresql/lib
-    - /usr/lib/postgresql/14/lib
-    - /usr/share/postgresql/14
-  when: not async_mode
-
-- name: pg_jsonschema - install
-  become: yes
-  become_user: postgres
-  shell:
-    cmd: "~/.cargo/bin/cargo pgx install --release"
-    chdir: /tmp/pg_jsonschema
-  async: 1000
-  poll: 0
-  register: jsonschema_build
-  when: async_mode
-
+- name: install pg_jsonschema
+  ansible.builtin.apt:
+    deb: "https://github.com/supabase/pg_jsonschema/releases/download/{{ pg_jsonschema_release }}/pg_jsonschema-{{ pg_jsonschema_release }}-pg{{ postgres_major }}-{{ arch }}-linux-gnu.deb"

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -97,11 +97,9 @@ libsodium_release_checksum: sha1:795b73e3f92a362fabee238a71735579bf46bb97
 pgsodium_release: "3.0.4"
 pgsodium_release_checksum: sha1:f08e9ac109ab5e6fc8b15ea21b26f88f451a2070
 
-pg_graphql_pgx_version: "0.5.2"
-pg_graphql_release: "v0.5.0"
+pg_graphql_release: "v0.5.2"
 
-pg_jsonschema_pgx_version: "0.5.6"
-pg_jsonschema_release: "v0.1.1"
+pg_jsonschema_release: "v0.1.3"
 
 pg_stat_monitor_release: "1.0.1"
 

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "14.1.0.99"
+postgres-version = "14.1.0.100"


### PR DESCRIPTION
## What kind of change does this PR introduce?
Updates the install process for supabase pgx projects to install from .deb packages attached to the GitHub release instead of installing using dev toolchain