### PR TITLE
fix: don't hold default-jre-headless version during docker build

### DIFF
--- a/ansible/tasks/postgres-extensions/12-pljava.yml
+++ b/ansible/tasks/postgres-extensions/12-pljava.yml
@@ -54,6 +54,7 @@
   dpkg_selections:
     name: default-jre-headless
     selection: hold
+  when: async_mode
 
 - name: pljava - set pljava.libjvm_location
   become: yes


### PR DESCRIPTION
## What kind of change does this PR introduce?

* fixes error generated [here](https://github.com/supabase/postgres/actions/runs/3600141334/jobs/6064477690)
* given it's a Docker image, and thus immutable, we shouldn't worry about default-jre-headless being updated further down the line - this skips that step