### PR TITLE
chore: copy extension files for Docker builds

### DIFF
--- a/.github/workflows/dockerhub-release.yml
+++ b/.github/workflows/dockerhub-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - pcnc/fix-supabase-extensions
     paths:
       - '.github/workflows/dockerhub-release.yml'
       - 'common.vars*'

--- a/.github/workflows/dockerhub-release.yml
+++ b/.github/workflows/dockerhub-release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-      - pcnc/fix-supabase-extensions
     paths:
       - '.github/workflows/dockerhub-release.yml'
       - 'common.vars*'

--- a/ansible/tasks/docker/finalize.yml
+++ b/ansible/tasks/docker/finalize.yml
@@ -23,6 +23,7 @@
   with_items:
     - /etc/postgresql-custom
 
+# TODO(pcnc): remove these when install locations are fixed for Docker builds
 - name: copy Supabase extension libs
   become: yes
   copy:

--- a/ansible/tasks/docker/finalize.yml
+++ b/ansible/tasks/docker/finalize.yml
@@ -22,3 +22,15 @@
     mode: '0774'
   with_items:
     - /etc/postgresql-custom
+
+- name: copy Supabase extension libs
+  become: yes
+  copy:
+    src: /usr/lib/postgresql/lib/
+    dest: /usr/lib/postgresql/{{ postgresql_major }}/lib/
+
+- name: copy Supabase extension files
+  become: yes
+  copy:
+    src: /var/lib/postgresql/extension/
+    dest: /usr/share/postgresql/{{ postgresql_major }}/extension/

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.3-rc3"
+postgres-version = "15.1.0.3-rc4"

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.3-rc4"
+postgres-version = "15.1.0.10-rc1"


### PR DESCRIPTION
## What kind of change does this PR introduce?

* copies `pg_jsonschema`, `pg_graphql`, and `wrappers` extension files as a workaround to make Docker builds include them. Caused by [this](https://supabase.slack.com/archives/C01D6TWFFFW/p1670844450345809) behaviour.
* additionally bumps version to enable PITR for PG15. Context [here](https://supabase.slack.com/archives/C01D6TWFFFW/p1670612861544199?thread_ts=1670599699.983339&cid=C01D6TWFFFW).