### PR TITLE
feat: add `/etc/gotrue.overrides.env` to gotrue systemd unit

### DIFF
--- a/ansible/files/gotrue.service.j2
+++ b/ansible/files/gotrue.service.j2
@@ -13,6 +13,7 @@ MemoryAccounting=true
 MemoryMax=50%
 
 EnvironmentFile=/etc/gotrue.env
+EnvironmentFile=-/etc/gotrue.overrides.env
 
 Slice=services.slice
 


### PR DESCRIPTION
Often Auth needs to modify GoTrue settings that need to persist across restarts / config changes. It's somewhat risky to be changing the systemd unit file on the fly. This makes it easy to add the config to an override file only.

(Note: I'm not sure what happens to systemd units if the [`EnvironmentFile=`](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#EnvironmentFile=) does not exist.)