### PR TITLE
pg14 - Adds docker support for pgx extensions

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -97,9 +97,9 @@ libsodium_release_checksum: sha1:795b73e3f92a362fabee238a71735579bf46bb97
 pgsodium_release: "3.0.4"
 pgsodium_release_checksum: sha1:f08e9ac109ab5e6fc8b15ea21b26f88f451a2070
 
-pg_graphql_release: "v1.0.0"
+pg_graphql_release: "v1.0.1"
 
-pg_jsonschema_release: "v0.1.3"
+pg_jsonschema_release: "v0.1.4"
 
 pg_stat_monitor_release: "1.0.1"
 
@@ -112,4 +112,4 @@ groonga_release_checksum: sha1:32aee787efffc2a22760fde946fb6462286074e2
 pgroonga_release: "2.4.0"
 pgroonga_release_checksum: sha1:235d67e8487b318e656d4d3016a49c14fae0512d
 
-wrappers_release: "v0.1.5"
+wrappers_release: "v0.1.6

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -112,4 +112,4 @@ groonga_release_checksum: sha1:32aee787efffc2a22760fde946fb6462286074e2
 pgroonga_release: "2.4.0"
 pgroonga_release_checksum: sha1:235d67e8487b318e656d4d3016a49c14fae0512d
 
-wrappers_release: "v0.1.6
+wrappers_release: "v0.1.6"

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "14.1.0.104"
+postgres-version = "14.1.0.105"


### PR DESCRIPTION
Bumps pgx extensions to versions that include support for the `supabase/postgres:14*` image