### PR TITLE
chore: remove killall command

### DIFF
--- a/ansible/tasks/setup-system.yml
+++ b/ansible/tasks/setup-system.yml
@@ -1,12 +1,3 @@
-# DigitalOcean's ubuntu droplet isn't up to date with installed packages, and on
-# a fresh install I see 71 security upgrades available.
-- name: Terminate any ongoing updates
-  shell: killall apt apt-get
-  ignore_errors: yes
-  tags:
-    - update
-    - update-only
-
 - name: System - apt update and apt upgrade
   apt: update_cache=yes upgrade=yes
   when: not ebssurrogate_mode


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore

## What is the current behavior?

```
Mon, 26 Dec 2022 14:34:39 GMT
    amazon-ebssurrogate.source: TASK [Terminate any ongoing updates] *******************************************
Mon, 26 Dec 2022 14:34:39 GMT
    amazon-ebssurrogate.source: Monday 26 December 2022  14:34:39 +0000 (0:00:01.012)       0:00:01.041 *******
Mon, 26 Dec 2022 14:34:39 GMT
    amazon-ebssurrogate.source: Monday 26 December 2022  14:34:39 +0000 (0:00:01.012)       0:00:01.040 *******
Mon, 26 Dec 2022 14:34:39 GMT
    amazon-ebssurrogate.source: fatal: [/mnt]: FAILED! => {"changed": true, "cmd": "killall apt apt-get", "delta": "0:00:00.002900", "end": "2022-12-26 14:34:39.823862", "msg": "non-zero return code", "rc": 127, "start": "2022-12-26 14:34:39.820962", "stderr": "/bin/sh: 1: killall: not found", "stderr_lines": ["/bin/sh: 1: killall: not found"], "stdout": "", "stdout_lines": []}
```
https://github.com/supabase/postgres/actions/runs/3781823667/jobs/6429034768

killall command is not available in default package and we are ignoring errors from it.

## What is the new behavior?

Remove killall step completely since it's already failing.

## Additional context

Add any other context or screenshots.
