### PR TITLE
feat: bump wrappers to 0.1.7

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -113,4 +113,4 @@ groonga_release_checksum: sha1:32aee787efffc2a22760fde946fb6462286074e2
 pgroonga_release: "2.4.0"
 pgroonga_release_checksum: sha1:235d67e8487b318e656d4d3016a49c14fae0512d
 
-wrappers_release: "v0.1.6"
+wrappers_release: "v0.1.7"

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.20"
+postgres-version = "15.1.0.21"


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to upgrade Wrappers to v0.1.7. See more details about this version: https://github.com/supabase/wrappers/releases/tag/v0.1.7

## What is the current behavior?

Currently it is v0.1.6.

## What is the new behavior?

Wrappers version upgraded to v0.1.7.

## Additional context

N/A
