### PR TITLE
chore: update-timescaledb

### DIFF
--- a/ansible/tasks/postgres-extensions/10-timescaledb.yml
+++ b/ansible/tasks/postgres-extensions/10-timescaledb.yml
@@ -15,7 +15,7 @@
 
 - name: timescaledb - bootstrap
   shell:
-    cmd: "./bootstrap -DAPACHE_ONLY=1 -DEXPERIMENTAL=ON" #TODO: remove this after official support is rolled out: https://github.com/timescale/timescaledb/pulls?q=is%3Apr+label%3Apg15+is%3Aclosed
+    cmd: "./bootstrap -DAPACHE_ONLY=1"
     chdir: /tmp/timescaledb
   become: yes
 

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -68,8 +68,7 @@ plpgsql_check_release_checksum: sha256:6c3a3c5faf3f9689425c6db8a6b20bf4cd5e7144a
 pg_safeupdate_release: "1.4"
 pg_safeupdate_release_checksum: sha1:942dacd0ebce6123944212ffb3d6b5a0c09174f9
 
-timescaledb_release: bfed42c2d371322b7f5bcddfbf43d09042296379
-# timescaledb_release: "2.8.1" //TODO: update version after pg15 support is rolled out: https://github.com/timescale/timescaledb/pulls?q=is%3Apr+label%3Apg15+is%3Aclosed
+timescaledb_release: "2.9.1"
 
 wal2json_commit_sha: 770872b890f9e122290f178e7c7bfa19ec7afa94
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

* upgrades TimescaleDB to [2.9.1](https://github.com/timescale/timescaledb/releases/tag/2.9.1), which includes official and stable PG15 support