### PR TITLE
feat: add pg_egress_collect service

### DIFF
--- a/ansible/files/admin_api_scripts/pg_egress_collect.pl
+++ b/ansible/files/admin_api_scripts/pg_egress_collect.pl
@@ -1,0 +1,110 @@
+#!/usr/bin/env perl
+
+# This script receive tcpdump output through STDIN and does:
+#
+# 1. extract outgoing TCP packet length on all devices port 5432 and 6543
+# 2. sum the length up to one minute
+# 3. save the total length to prom file (default is /tmp/pg_egress_collect.prom)
+#
+# Usage:
+#
+# tcpdump -s 128 -Q out -i any -nn -tt -vv -p -l 'tcp and (port 5432 or port 6543)' | perl pg_egress_collect.pl /tmp/output.prom
+#
+
+use POSIX;
+use List::Util qw(sum);
+use IO::Async::Loop;
+use IO::Async::Stream;
+use IO::Async::Timer::Periodic;
+
+use strict;
+use warnings;
+
+# total captured packets lenth in a time frame
+my $captured_len = 0;
+
+# extract tcp packet length captured by tcpdump
+#
+# Sample input lines:
+#
+# 1674013833.940253 IP (tos 0x0, ttl 64, id 0, offset 0, flags [DF], proto TCP (6), length 60)
+#     10.112.101.122.5432 > 220.235.16.223.62599: Flags [S.], cksum 0x5de3 (incorrect -> 0x63da), seq 2314200657, ack 2071735457, win 62643, options [mss 8961,sackOK,TS val 3358598837 ecr 1277499190,nop,wscale 7], length 0
+# 1674013833.989257 IP (tos 0x0, ttl 64, id 24975, offset 0, flags [DF], proto TCP (6), length 52)
+#     10.112.101.122.5432 > 220.235.16.223.62599: Flags [.], cksum 0x5ddb (incorrect -> 0xa25b), seq 1, ack 9, win 490, options [nop,nop,TS val 3358598885 ecr 1277499232], length 0
+sub extract_packet_length {
+    my ($line) = @_;
+
+    #print("debug: >> " . $line);
+
+    if ($line =~ /^(\d+)\.\d+/) {
+        # extract packet timestamp, do nothing for now
+        my $ts = $1;
+    } elsif ($line =~ /^\s+\d+\.\d+\.\d+\.\d+\..*, length (\d+)$/) {
+        # extract tcp packet length and add it up
+        my $len = $1;
+        $captured_len += $len;
+    }
+}
+
+# write total length to prom file
+#
+# ref: https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format
+sub write_prom_file {
+    my ($output) = @_;
+
+    my $now = strftime "%F %T", localtime time;
+    print "[$now] write captured len $captured_len to $output\n";
+
+    open(my $fh, "+>", $output) or die "Could not open file '$output' $!";
+    print $fh "# HELP postgres db network egress bytes\n";
+    print $fh "# TYPE db_egress_bytes counter\n";
+    print $fh "db_egress_bytes $captured_len\n";
+    close($fh);
+}
+
+# main
+sub main {
+    my ($output) = @ARGV;
+
+    if (not defined $output) {
+        # default prom file path
+        $output = "/tmp/pg_egress_collect.prom";
+    }
+
+    my $loop = IO::Async::Loop->new;
+
+    # tcpdump extractor
+    my $extractor = IO::Async::Stream->new_for_stdin(
+        on_read => sub {
+            my ($self, $buffref, $eof) = @_;
+
+            while($$buffref =~ s/^(.*\n)//) {
+                my $line = $1;
+                extract_packet_length($line);
+            }
+
+            return 0;
+        },
+    );
+
+    # schedule prom file writer per minute
+    my $writer = IO::Async::Timer::Periodic->new(
+        interval => 60,
+        on_tick => sub {
+            write_prom_file($output);
+
+            # reset total captured length
+            $captured_len = 0;
+        },
+    );
+    $writer->start;
+
+    print "pg_egress_collect started, egress data will be saved to $output\n";
+
+    $loop->add($extractor);
+    $loop->add($writer);
+    $loop->run;
+}
+
+main();
+

--- a/ansible/files/admin_api_scripts/pg_egress_collect.pl
+++ b/ansible/files/admin_api_scripts/pg_egress_collect.pl
@@ -53,7 +53,7 @@ sub write_file {
 
     open(my $fh, "+>", $output) or die "Could not open file '$output' $!";
     print $fh "$captured_len";
-    close($fh);
+    close($fh) or die "Could not write file '$output' $!";
 }
 
 # main

--- a/ansible/files/adminapi.sudoers.conf
+++ b/ansible/files/adminapi.sudoers.conf
@@ -2,7 +2,6 @@ Cmnd_Alias KONG = /bin/systemctl start kong.service, /bin/systemctl stop kong.se
 Cmnd_Alias POSTGREST = /bin/systemctl start postgrest.service, /bin/systemctl stop postgrest.service, /bin/systemctl restart postgrest.service, /bin/systemctl disable postgrest.service, /bin/systemctl enable postgrest.service
 Cmnd_Alias GOTRUE = /bin/systemctl start gotrue.service, /bin/systemctl stop gotrue.service, /bin/systemctl restart gotrue.service, /bin/systemctl disable gotrue.service, /bin/systemctl enable gotrue.service
 Cmnd_Alias PGBOUNCER = /bin/systemctl start pgbouncer.service, /bin/systemctl stop pgbouncer.service, /bin/systemctl restart pgbouncer.service, /bin/systemctl disable pgbouncer.service, /bin/systemctl enable pgbouncer.service, /bin/systemctl reload pgbouncer.service
-Cmnd_Alias PG_EGRESS_COLLECT = /bin/systemctl start pg_egress_collect.service, /bin/systemctl stop pg_egress_collect.service, /bin/systemctl restart pg_egress_collect.service, /bin/systemctl disable pg_egress_collect.service, /bin/systemctl enable pg_egress_collect.service, /bin/systemctl reload pg_egress_collect.service
 
 %adminapi ALL= NOPASSWD: /root/grow_fs.sh
 %adminapi ALL= NOPASSWD: /root/commence_walg_backup.sh
@@ -26,4 +25,3 @@ Cmnd_Alias PG_EGRESS_COLLECT = /bin/systemctl start pg_egress_collect.service, /
 %adminapi ALL= NOPASSWD: POSTGREST
 %adminapi ALL= NOPASSWD: GOTRUE
 %adminapi ALL= NOPASSWD: PGBOUNCER
-%adminapi ALL= NOPASSWD: PG_EGRESS_COLLECT

--- a/ansible/files/adminapi.sudoers.conf
+++ b/ansible/files/adminapi.sudoers.conf
@@ -2,6 +2,7 @@ Cmnd_Alias KONG = /bin/systemctl start kong.service, /bin/systemctl stop kong.se
 Cmnd_Alias POSTGREST = /bin/systemctl start postgrest.service, /bin/systemctl stop postgrest.service, /bin/systemctl restart postgrest.service, /bin/systemctl disable postgrest.service, /bin/systemctl enable postgrest.service
 Cmnd_Alias GOTRUE = /bin/systemctl start gotrue.service, /bin/systemctl stop gotrue.service, /bin/systemctl restart gotrue.service, /bin/systemctl disable gotrue.service, /bin/systemctl enable gotrue.service
 Cmnd_Alias PGBOUNCER = /bin/systemctl start pgbouncer.service, /bin/systemctl stop pgbouncer.service, /bin/systemctl restart pgbouncer.service, /bin/systemctl disable pgbouncer.service, /bin/systemctl enable pgbouncer.service, /bin/systemctl reload pgbouncer.service
+Cmnd_Alias PG_EGRESS_COLLECT = /bin/systemctl start pg_egress_collect.service, /bin/systemctl stop pg_egress_collect.service, /bin/systemctl restart pg_egress_collect.service, /bin/systemctl disable pg_egress_collect.service, /bin/systemctl enable pg_egress_collect.service, /bin/systemctl reload pg_egress_collect.service
 
 %adminapi ALL= NOPASSWD: /root/grow_fs.sh
 %adminapi ALL= NOPASSWD: /root/commence_walg_backup.sh
@@ -25,3 +26,4 @@ Cmnd_Alias PGBOUNCER = /bin/systemctl start pgbouncer.service, /bin/systemctl st
 %adminapi ALL= NOPASSWD: POSTGREST
 %adminapi ALL= NOPASSWD: GOTRUE
 %adminapi ALL= NOPASSWD: PGBOUNCER
+%adminapi ALL= NOPASSWD: PG_EGRESS_COLLECT

--- a/ansible/files/pg_egress_collect.service.j2
+++ b/ansible/files/pg_egress_collect.service.j2
@@ -1,0 +1,13 @@
+[Unit]
+Description=Postgres Egress Collector
+
+[Service]
+Type=simple
+ExecStart=/bin/bash -c "tcpdump -s 128 -Q out -i any -nn -tt -vv -p -l 'tcp and (port 5432 or port 6543)' | perl /root/pg_egress_collect.pl"
+User=root
+Slice=services.slice
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/tasks/internal/admin-api.yml
+++ b/ansible/tasks/internal/admin-api.yml
@@ -23,6 +23,7 @@
     - { file: "pg_upgrade_initiate.sh" }
     - { file: "pg_upgrade_prepare.sh" }
     - { file: "pg_upgrade_pgsodium_getkey.sh" }
+    - { file: "pg_egress_collect.pl" }
 
 - name: give adminapi user permissions
   copy:

--- a/ansible/tasks/internal/pg_egress_collect.yml
+++ b/ansible/tasks/internal/pg_egress_collect.yml
@@ -1,0 +1,15 @@
+- name: pg_egress_collect - install tcpdump and perl async lib
+  apt:
+    pkg:
+      - tcpdump
+      - libio-async-perl
+
+- name: pg_egress_collect - create service file
+  template:
+    src: files/pg_egress_collect.service.j2
+    dest: /etc/systemd/system/pg_egress_collect.service
+
+- name: pg_egress_collect - reload systemd
+  systemd:
+    daemon_reload: yes
+

--- a/ansible/tasks/setup-supabase-internal.yml
+++ b/ansible/tasks/setup-supabase-internal.yml
@@ -88,3 +88,6 @@
 
 - name: Init nftabless
   import_tasks: internal/setup-nftables.yml
+
+- name: Install pg_egress_collect
+  import_tasks: internal/pg_egress_collect.yml

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.31"
+postgres-version = "15.1.0.30"

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.26"
+postgres-version = "15.1.0.27"

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.27"
+postgres-version = "15.1.0.31"


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add service for postgres egress metric collection. See more context: https://www.notion.so/supabase/Fix-DB-egress-metric-190164a5c4e5444cbbe20c726cea241d

## What is the current behavior?

Currently there is no reliable way to gather accurate database-only egress, so the whole server egress is used instead.

## What is the new behavior?

The solution is using `tcpdump` to capture outgoing TCP packets on port 5432 and 6543, and a perl script extract packet length and sum up to one minute interval. The result is saved to text file at `/tmp/pg_egress_collect.txt` by default. Admin API then can read metric from that file and expose it to Victoria Metrics.

By using this approach, we can collect accurate network egress for postgres and expose it in admin api so Victoria Metrics can gather for downstream pipeline.

## Additional context

This metric will also be as data source for admin api, see more details: https://github.com/supabase/supabase-admin-api/pull/130
