### PR TITLE
chore: disable RemoveIPC to avoid shared memory issues

### DIFF
--- a/ansible/files/logind.conf
+++ b/ansible/files/logind.conf
@@ -1,0 +1,2 @@
+[Login]
+RemoveIPC=no

--- a/ansible/tasks/setup-system.yml
+++ b/ansible/tasks/setup-system.yml
@@ -75,6 +75,16 @@
    name: systemd-journald
    state: restarted
 
+- name: Configure logind
+  copy:
+    src: files/logind.conf
+    dest: /etc/systemd/logind.conf
+
+- name: reload systemd-logind
+  systemd:
+   name: systemd-logind
+   state: restarted
+
 - name: enable timestamps for shell history
   copy:
     content: |


### PR DESCRIPTION
## What kind of change does this PR introduce?

* `systemd-logind` removes shared memory segments when it detects a user isn't logged in
* this can happen during repeated postgresql restarts, also encountered during upgrades: https://www.postgresql.org/docs/current/kernel-resources.html#SYSTEMD-REMOVEIPC
* an alternative is to make `postgres` a system user, although that would modify the user's UID potentially introducing other issues