### PR TITLE
Optimize code for target cpu/arch

### DIFF
--- a/ansible/tasks/setup-postgres.yml
+++ b/ansible/tasks/setup-postgres.yml
@@ -64,7 +64,7 @@
 
 - name: Setting CFLAGS (x86)
   set_fact:
-    cflags: "-fsigned-char -mtune=native -march=native"
+    cflags: "-fsigned-char"
   when: platform == "amd64"
 
 - name: Postgres - configure

--- a/ansible/tasks/setup-postgres.yml
+++ b/ansible/tasks/setup-postgres.yml
@@ -59,12 +59,12 @@
 
 - name: Setting CFLAGS (arm)
   set_fact:
-    cflags: "-moutline-atomics -mtune=neoverse-n1 -fsigned-char"
+    cflags: "-moutline-atomics -mtune=native -march=native -mcpu=native -fsigned-char"
   when: platform == "arm64"
 
 - name: Setting CFLAGS (x86)
   set_fact:
-    cflags: "-fsigned-char"
+    cflags: "-fsigned-char -mtune=native -march=native"
   when: platform == "amd64"
 
 - name: Postgres - configure


### PR DESCRIPTION
GCC default behavior is to generate binaries compatible with older CPU's of the specified architecture. E.g. arm64 will generate armv8-a - compatible code. It sill not use LSE optimizations that make atomics much faster on more recent CPUs. And all other optimizations of modern CPU. I'd suggest we use "native" value i.e. code will be compiled to use all optimizations the build machine CPU supports. (If we want to run binaries on older CPU's than we build them the current commit will not suit, and then I'd suggest we chose the oldest CPU that we use for running Supabase and chose CFLAGS accordingly).

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
