### PR TITLE
fix: source download for pg_repack

### DIFF
--- a/ansible/tasks/postgres-extensions/27-pg_repack.yml
+++ b/ansible/tasks/postgres-extensions/27-pg_repack.yml
@@ -1,7 +1,7 @@
 # pg-repack
 - name: pg_repack - download latest release
   get_url:
-    url: "https://github.com/reorg/pg_repack/releases/tag/ver_{{pg_repack_release}}.tar.gz"
+    url: "https://github.com/reorg/pg_repack/archive/refs/tags/ver_{{pg_repack_release}}.tar.gz"
     dest: /tmp/pg-repack-{{ pg_repack_release }}.tar.gz
     checksum: "{{ pg_repack_release_checksum }}"
     timeout: 60

--- a/ansible/tasks/setup-extensions.yml
+++ b/ansible/tasks/setup-extensions.yml
@@ -79,8 +79,8 @@
 - name: Install pg_repack
   import_tasks: tasks/postgres-extensions/27-pg_repack.yml
 
-- name: Install pgvector
-  import_tasks: tasks/postgres-extensions/28-pgvector.yml
+# - name: Install pgvector
+#   import_tasks: tasks/postgres-extensions/28-pgvector.yml
 
 - name: Verify async task status
   import_tasks: tasks/postgres-extensions/99-finish_async_tasks.yml


### PR DESCRIPTION
* Confirmed by checking https://github.com/reorg/pg_repack/releases/tag/ver_1.4.8
* Source file should be: https://github.com/reorg/pg_repack/archive/refs/tags/ver_1.4.8.tar.gz