### PR TITLE
Upgrade pg_graphql to v1.1.0

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -97,7 +97,7 @@ libsodium_release_checksum: sha1:795b73e3f92a362fabee238a71735579bf46bb97
 pgsodium_release: "3.1.5"
 pgsodium_release_checksum: sha256:bec847388a5db2a60ea9d991962ce27954d91b4c41cbcc7bd8e34472c69114d1
 
-pg_graphql_release: "v1.0.2"
+pg_graphql_release: "v1.1.0"
 
 pg_jsonschema_release: "v0.1.4"
 

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.31"
+postgres-version = "15.1.0.32"


### PR DESCRIPTION
Upgrade pg_graphql from v1.0.2 to v1.1.0

Which includes:
- feature: Add support for Views, Materialized Views, and Foreign Tables
- feature: Add support for filtering on is null and is not null
- feature: User configurable page size
- bugfix: Remove requirement for insert permission on every column for inserts to succeed
- bugfix: hasNextPage and hasPreviousPage during reverse pagination were backwards

---
Note:
Once this releases please push an update to the dockerhub images. Some folks have been requesting the features in the supabase CLI