### PR TITLE
chore: terminate packer instance on workflow cancellation

### DIFF
--- a/.github/workflows/ami-release.yml
+++ b/.github/workflows/ami-release.yml
@@ -18,9 +18,9 @@ jobs:
       - name: Build AMI
         run: |
           GIT_SHA=$(git rev-parse HEAD)
-          packer build -var "git-head-version=${GIT_SHA}" -var-file="development-arm.vars.pkr.hcl" -var-file="common.vars.pkr.hcl" amazon-arm64.pkr.hcl
+          packer build -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${GITHUB_RUN_ID}" -var-file="development-arm.vars.pkr.hcl" -var-file="common.vars.pkr.hcl" amazon-arm64.pkr.hcl
 
-      - name: Slack Notification
+      - name: Slack Notification on Failure
         if: ${{ failure() }}
         uses: rtCamp/action-slack-notify@v2
         env:
@@ -29,3 +29,8 @@ jobs:
           SLACK_COLOR: 'danger'
           SLACK_MESSAGE: 'Building Postgres AMI failed'
           SLACK_FOOTER: ''
+
+      - name: Cleanup resources on build cancellation
+        if: ${{ cancelled() }}
+        run: |
+          aws ec2 describe-instances --filters "Name=tag:packerExecutionId,Values=${GITHUB_RUN_ID}" --query "Reservations[].Instances[].InstanceId" --output text | xargs -I {} aws ec2 terminate-instances --instance-ids {}

--- a/amazon-arm64.pkr.hcl
+++ b/amazon-arm64.pkr.hcl
@@ -82,6 +82,11 @@ variable "git-head-version" {
   default = "unknown"
 }
 
+variable "packer-execution-id" {
+  type = string
+  default = "unknown"
+}
+
 # source block
 source "amazon-ebssurrogate" "source" {
   profile = "${var.profile}"
@@ -129,8 +134,9 @@ source "amazon-ebssurrogate" "source" {
   }
 
   run_tags = {
-    creator = "packer"
-    appType = "postgres"
+    creator           = "packer"
+    appType           = "postgres"
+    packerExecutionId = "${var.packer-execution-id}"
   }
   run_volume_tags = {
     creator = "packer"


### PR DESCRIPTION
## What kind of change does this PR introduce?

* terminates running builder instance on job cancellation
* tags builder instance using `GITHUB_RUN_ID`, which is a unique value per repository, representing the ID of the workflow which is ran at the time
* terminates instances having the same `GITHUB_RUN_ID` as the current execution