### PR TITLE
fix: enable pg_egress_collect service

### DIFF
--- a/ansible/tasks/internal/pg_egress_collect.yml
+++ b/ansible/tasks/internal/pg_egress_collect.yml
@@ -11,5 +11,7 @@
 
 - name: pg_egress_collect - reload systemd
   systemd:
+    enabled: yes
+    name: pg_egress_collect
     daemon_reload: yes
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to enable `pg_egress_collect` service, which was introduced in #486 but not enabled yet.

## What is the current behavior?

Currently the service is not enabled, so it is not started when boot.

## What is the new behavior?

This service should start when server is booted.

## Additional context

N/A
