### PR TITLE
chore: grant auth roles to postgres user

### DIFF
--- a/migrations/db/migrations/20230201083204_grant_auth_roles_to_postgres.sql
+++ b/migrations/db/migrations/20230201083204_grant_auth_roles_to_postgres.sql
@@ -1,0 +1,5 @@
+-- migrate:up
+grant anon, authenticated, service_role to postgres;
+
+-- migrate:down
+


### PR DESCRIPTION
## What kind of change does this PR introduce?

https://www.notion.so/supabase/team-cli-2ccbfbcbfb5048ed940d227ee5a93b49?p=f540a4bcb6354bc892a5bff4774e2a8a&pm=s

## What is the current behavior?

Impossible to test RLS as postgres user

## What is the new behavior?

Grant the default auth roles to postgres so that RLS can be tested from cli client.

## Additional context

Discussed many times in the linked slack convo. Will roll out a migration helper script after merging.
