### PR TITLE
chore: create tags and GH releases when we build an AMI

### DIFF
--- a/.github/workflows/ami-release.yml
+++ b/.github/workflows/ami-release.yml
@@ -20,6 +20,21 @@ jobs:
           GIT_SHA=$(git rev-parse HEAD)
           packer build -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${GITHUB_RUN_ID}" -var-file="development-arm.vars.pkr.hcl" -var-file="common.vars.pkr.hcl" amazon-arm64.pkr.hcl
 
+      - name: Grab release version
+        id: process_release_version
+        run: |
+          VERSION=$(sed -e 's/postgres-version = "\(.*\)"/\1/g' common.vars.pkr.hcl)
+          GIT_SHA=$(git rev-parse HEAD)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "git_sha=$GIT_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: ${{ steps.process_release_version.outputs.version }}
+          tag_name: ${{ steps.process_release_version.outputs.version }}
+          target_commitish: ${{ steps.process_release_vesion.outputs.git_sha }}
+
       - name: Slack Notification on Failure
         if: ${{ failure() }}
         uses: rtCamp/action-slack-notify@v2


### PR DESCRIPTION
Adding tags makes it easier to diff the changes that have been made
between releases. At the moment, this information only lives in the
contents of the repository (and we haven't really maintained a
changelog).