### PR TITLE
chore: tag the correct commit when creating a release

### DIFF
--- a/.github/workflows/ami-release.yml
+++ b/.github/workflows/ami-release.yml
@@ -17,23 +17,21 @@ jobs:
 
       - name: Build AMI
         run: |
-          GIT_SHA=$(git rev-parse HEAD)
+          GIT_SHA=${{github.sha}}
           packer build -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${GITHUB_RUN_ID}" -var-file="development-arm.vars.pkr.hcl" -var-file="common.vars.pkr.hcl" amazon-arm64.pkr.hcl
 
       - name: Grab release version
         id: process_release_version
         run: |
           VERSION=$(sed -e 's/postgres-version = "\(.*\)"/\1/g' common.vars.pkr.hcl)
-          GIT_SHA=$(git rev-parse HEAD)
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "git_sha=$GIT_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Create release
         uses: softprops/action-gh-release@v1
         with:
           name: ${{ steps.process_release_version.outputs.version }}
           tag_name: ${{ steps.process_release_version.outputs.version }}
-          target_commitish: ${{ steps.process_release_vesion.outputs.git_sha }}
+          target_commitish: ${{github.sha}}
 
       - name: Slack Notification on Failure
         if: ${{ failure() }}


### PR DESCRIPTION
Initial PR works, but always creates the tag on develop. This change fixes it to create the tag on the commit triggering the action.