### PR TITLE
fix: capture db egress traffic on non-loopback interface only

### DIFF
--- a/ansible/files/admin_api_scripts/pg_egress_collect.pl
+++ b/ansible/files/admin_api_scripts/pg_egress_collect.pl
@@ -2,13 +2,13 @@
 
 # This script receive tcpdump output through STDIN and does:
 #
-# 1. extract outgoing TCP packet length on all devices port 5432 and 6543
+# 1. extract outgoing TCP packet length on the 1st non-loopback device port 5432 and 6543
 # 2. sum the length up to one minute
 # 3. save the total length to file (default is /tmp/pg_egress_collect.txt) per minute
 #
 # Usage:
 #
-# tcpdump -s 128 -Q out -i any -nn -tt -vv -p -l 'tcp and (port 5432 or port 6543)' | perl pg_egress_collect.pl -o /tmp/output.txt
+# tcpdump -s 128 -Q out -nn -tt -vv -p -l 'tcp and (port 5432 or port 6543)' | perl pg_egress_collect.pl -o /tmp/output.txt
 #
 
 use POSIX;

--- a/ansible/files/pg_egress_collect.service.j2
+++ b/ansible/files/pg_egress_collect.service.j2
@@ -3,7 +3,7 @@ Description=Postgres Egress Collector
 
 [Service]
 Type=simple
-ExecStart=/bin/bash -c "tcpdump -s 128 -Q out -i any -nn -tt -vv -p -l 'tcp and (port 5432 or port 6543)' | perl /root/pg_egress_collect.pl"
+ExecStart=/bin/bash -c "tcpdump -s 128 -Q out -nn -tt -vv -p -l 'tcp and (port 5432 or port 6543)' | perl /root/pg_egress_collect.pl"
 User=root
 Slice=services.slice
 Restart=always


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to change db egress collection config to let it capture on non-loopback interface only.

## What is the current behavior?

Currently the db egress collection capture traffic on all network devices, it will be double counted when combined bill with API egress. So the db egress collection should only capture traffic on interface like `ens5` not `lo`.

## What is the new behavior?

The tcpdump will automatically detect the 1st non-loopback interface and only capture packets on it.

## Additional context

N/A
