### PR TITLE
chore: fix plv8 version reference

### DIFF
--- a/ansible/tasks/postgres-extensions/13-plv8.yml
+++ b/ansible/tasks/postgres-extensions/13-plv8.yml
@@ -26,7 +26,7 @@
   git:
     repo: https://github.com/plv8/plv8.git
     dest: /tmp/plv8
-    version: "{{ plv8_release }}"
+    version: "v{{ plv8_release }}"
   become: yes
 
 - name: Create a symbolic link


### PR DESCRIPTION
## What kind of change does this PR introduce?

follow up #529 

## What is the current behavior?

ami build failure: https://github.com/supabase/postgres/actions/runs/4122613008/jobs/7119602752

## What is the new behavior?

correct git version ref

## Additional context

Add any other context or screenshots.
