### PR TITLE
chore: enable ccache for plv8 ami build

### DIFF
--- a/ansible/tasks/postgres-extensions/13-plv8.yml
+++ b/ansible/tasks/postgres-extensions/13-plv8.yml
@@ -37,6 +37,13 @@
   when: platform == "arm64"
   ignore_errors: yes # not needed for docker build
 
+- name: plv8 - enable ccache
+  become: yes
+  replace:
+    path: /tmp/plv8/Makefiles/Makefile.docker
+    regexp: "^GN_ARGS ="
+    replace: GN_ARGS = cc_wrapper=\"env CCACHE_SLOPPINESS=time_macros ccache\"
+
 - name: plv8 - build
   make:
     chdir: /tmp/plv8

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.39-rc1"
+postgres-version = "15.1.0.39-rc2"


### PR DESCRIPTION
## What kind of change does this PR introduce?

build

## What is the current behavior?

cpp artefacts from ninja-build not cached (see [plv8 build](https://github.com/supabase/container-images/actions/runs/4135554251/jobs/7158192506#step:8:925) which took 10 mins)

## What is the new behavior?

Using instructions from macos which also works for Linux https://chromium.googlesource.com/chromium/src/+/HEAD/docs/ccache_mac.md

## Additional context
Built successfully: https://github.com/supabase/container-images/actions/runs/4141347573