### PR TITLE
chore: add workflow to auto rebuild ccache

### DIFF
--- a/.github/workflows/build-ccache.yml
+++ b/.github/workflows/build-ccache.yml
@@ -1,0 +1,87 @@
+name: Update ccache
+
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - ".github/workflows/build-ccache.yml"
+      - "ansible/Dockerfile"
+      - "ansible/vars.yml"
+  workflow_dispatch:
+
+env:
+  image_tag: public.ecr.aws/t3w2s2c9/postgres:ccache
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+jobs:
+  settings:
+    runs-on: ubuntu-latest
+    outputs:
+      build_args: ${{ steps.args.outputs.result }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: args
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq 'to_entries | map(select(.value|type == "!!str")) |  map(.key + "=" + .value) | join("\n")' 'ansible/vars.yml'
+
+  build_image:
+    needs: settings
+    strategy:
+      matrix:
+        include:
+          - runner: [self-hosted, X64]
+            arch: amd64
+          - runner: arm-runner
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 180
+    outputs:
+      image_digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - run: docker context create builders
+      - uses: docker/setup-buildx-action@v2
+        with:
+          endpoint: builders
+      - name: Configure AWS credentials - prod
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.PROD_AWS_ROLE }}
+          aws-region: "us-east-1"
+      - uses: docker/login-action@v2
+        with:
+          registry: public.ecr.aws
+      - id: build
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          context: ansible
+          target: postgres-buildcache
+          build-args: |
+            ${{ needs.settings.outputs.build_args }}
+          tags: ${{ env.image_tag }}_${{ matrix.arch }}
+          platforms: linux/${{ matrix.arch }}
+          no-cache: true
+
+  merge_manifest:
+    needs: build_image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/setup-buildx-action@v2
+      - name: Configure AWS credentials - prod
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.PROD_AWS_ROLE }}
+          aws-region: "us-east-1"
+      - uses: docker/login-action@v2
+        with:
+          registry: public.ecr.aws
+      - name: Merge multi-arch manifests
+        run: |
+          docker buildx imagetools create -t ${{ env.image_tag }} \
+          ${{ env.image_tag }}_amd64 \
+          ${{ env.image_tag }}_arm64


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore

## What is the current behavior?

ccache is maintained from a private repo

## What is the new behavior?

- make the workflow public
- update ccache automatically on merge

## Additional context

Add any other context or screenshots.
