### PR TITLE
fix: postgres_fdw: alter fdw owner to `postgres`

### DIFF
--- a/ansible/files/postgresql_extension_custom_scripts/postgres_fdw/after-create.sql
+++ b/ansible/files/postgresql_extension_custom_scripts/postgres_fdw/after-create.sql
@@ -1,0 +1,21 @@
+do $$
+declare
+  is_super boolean;
+begin
+  is_super = (
+    select usesuper
+    from pg_user
+    where usename = 'postgres'
+  );
+
+  -- Need to be superuser to own FDWs, so we temporarily make postgres superuser.
+  if not is_super then
+    alter role postgres superuser;
+  end if;
+
+  alter foreign data wrapper postgres_fdw owner to postgres;
+
+  if not is_super then
+    alter role postgres nosuperuser;
+  end if;
+end $$;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

On `create extension postgres_fdw`, the `postgres_fdw` FDW is automatically created, but the owner is the `supautils.privileged_extensions_superuser`, i.e. `supabase_admin`. This means the regular `postgres` role can't do a `create server` using the FDW: https://github.com/supabase/supabase/discussions/9314#discussioncomment-4988727

## What is the new behavior?

Change the FDW owner to the `postgres` role on extension creation.

## Additional context

This is the same approach as https://github.com/supabase/supautils/blob/870932eabf517fbbd0caef7e88c7cb9cd59346ae/src/supautils.c#L589