### PR TITLE
chore: fix PG AMI build

### DIFF
--- a/ansible/tasks/test-image.yml
+++ b/ansible/tasks/test-image.yml
@@ -52,11 +52,11 @@
   when: ebssurrogate_mode
 
 - name: Drop pgTap extension
-  shell: /usr/lib/postgresql/bin/psql -U postgres -h localhost -d postgres -c "DROP extension if exists pgtap";
+  shell: /usr/lib/postgresql/bin/psql -U supabase_admin -h localhost -d postgres -c "DROP extension if exists pgtap";
   when: ebssurrogate_mode
 
 - name: Drop extension test function
-  shell: /usr/lib/postgresql/bin/psql -U postgres -h localhost -d postgres -c "DROP FUNCTION IF EXISTS install_available_extensions_and_test";
+  shell: /usr/lib/postgresql/bin/psql -U supabase_admin -h localhost -d postgres -c "DROP FUNCTION IF EXISTS install_available_extensions_and_test";
   when: ebssurrogate_mode
 
 - name: Reset db stats

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.43"
+postgres-version = "15.1.0.44"


### PR DESCRIPTION
## What kind of change does this PR introduce?

* `pg_prove` is now run as supabase_admin, which might create objects that cannot be dropped by the postgres role: https://github.com/supabase/postgres/commit/6ecf278dd3cbf24370fd19694d5ae0e790d0f257
* already built off this branch

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
