### PR TITLE
feat: upload software artifacts to internal bucket

### DIFF
--- a/.github/workflows/ami-release.yml
+++ b/.github/workflows/ami-release.yml
@@ -8,8 +8,12 @@ on:
 
 jobs:
   build:
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, X64]
     timeout-minutes: 150
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
 
     steps:
       - name: Checkout Repo
@@ -25,6 +29,20 @@ jobs:
         run: |
           VERSION=$(sed -e 's/postgres-version = "\(.*\)"/\1/g' common.vars.pkr.hcl)
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: configure aws credentials - staging
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.DEV_AWS_ROLE }}
+          aws-region: "us-east-1"
+
+      - name: Upload software manifest to s3
+        run: |
+          cd ansible
+          ansible-playbook -i localhost \
+            -e "ami_release_version=${{ steps.process_release_version.outputs.version }}" \
+            -e "internal_artifacts_bucket=${{ secrets.ARTIFACTS_BUCKET }}" \
+            manifest-playbook.yml
 
       - name: Create release
         uses: softprops/action-gh-release@v1

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 venv/
 *.swp
 docker/cache/
+
+ansible/image-manifest*.json

--- a/ansible/files/manifest.json
+++ b/ansible/files/manifest.json
@@ -1,0 +1,1 @@
+{{ vars | to_json }}

--- a/ansible/manifest-playbook.yml
+++ b/ansible/manifest-playbook.yml
@@ -1,0 +1,73 @@
+- hosts: localhost
+  gather_facts: no
+
+  vars_files:
+    - ./vars.yml
+
+  tasks:
+    - name: Write out image manifest
+      action: template src=files/manifest.json dest=./image-manifest-{{ ami_release_version }}.json
+
+    - name: Upload image manifest
+      shell: |
+        aws s3 cp ./image-manifest-{{ ami_release_version }}.json s3://{{ internal_artifacts_bucket }}/manifests/postgres-{{ ami_release_version }}/software-manifest.json
+
+    # upload software artifacts of interest
+    # Generally - download, extract, repack as xz archive, upload
+    # currently, we upload gotrue, adminapi, postgrest
+    - name: gotrue - download commit archive
+      get_url:
+        url: "https://github.com/supabase/gotrue/releases/download/{{ gotrue_release }}/gotrue-{{ gotrue_release }}-arm64.tar.gz"
+        dest: /tmp/gotrue.tar.gz
+        checksum: "{{ gotrue_release_checksum }}"
+        timeout: 60
+
+    - name: gotrue - create /tmp/gotrue
+      file:
+        path: /tmp/gotrue
+        state: directory
+        mode: 0775
+
+    - name: gotrue - unpack archive in /tmp/gotrue
+      unarchive:
+        remote_src: yes
+        src: /tmp/gotrue.tar.gz
+        dest: /tmp/gotrue
+
+    - name: gotrue - pack archive
+      shell: |
+        tar -cJf /tmp/gotrue-{{ gotrue_release }}-arm64.tar.xz /tmp/gotrue
+
+    - name: PostgREST - download ubuntu binary archive (arm)
+      get_url:
+        url: "https://github.com/PostgREST/postgrest/releases/download/v{{ postgrest_release }}/postgrest-v{{ postgrest_release }}-ubuntu-aarch64.tar.xz"
+        dest: /tmp/postgrest-{{ postgrest_release }}-arm64.tar.xz
+        checksum: "{{ postgrest_arm_release_checksum }}"
+        timeout: 60
+
+    - name: Download adminapi archive
+      get_url:
+        url: "https://supabase-public-artifacts-bucket.s3.amazonaws.com/supabase-admin-api/v{{ adminapi_release }}/supabase-admin-api_{{ adminapi_release }}_linux_arm64.tar.gz"
+        dest: "/tmp/adminapi.tar.gz"
+        timeout: 90
+
+    - name: adminapi - unpack archive in /tmp
+      unarchive:
+        remote_src: yes
+        src: /tmp/adminapi.tar.gz
+        dest: /tmp
+
+    - name: adminapi - pack archive
+      shell: |
+        tar -cJf /tmp/supabase-admin-api-{{ adminapi_release }}-arm64.tar.xz /tmp/supabase-admin-api
+
+    - name: upload archives
+      shell: |
+        aws s3 cp /tmp/{{ item.file }} s3://{{ internal_artifacts_bucket }}/upgrades/{{ item.service }}/{{ item.file }}
+      with_items:
+        - service: gotrue
+          file: gotrue-{{ gotrue_release }}-arm64.tar.xz
+        - service: postgrest
+          file: postgrest-{{ postgrest_release }}-arm64.tar.xz
+        - service: supabase-admin-api
+          file: supabase-admin-api-{{ adminapi_release }}-arm64.tar.xz

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.45"
+postgres-version = "15.1.0.46-rc0"


### PR DESCRIPTION
To support automated upgrades, we publish:

1. a manifest containing information on the software versions used to build an AMI
2. archives for software of interest (gotrue, postgrest, adminapi at this time)

(1) allows us to build knowledge of the versions included on new projects based on AMI used, which in turn allows us to determine available upgrades.
Once an upgrade is requested, archives from (2) can be used to facilitate it.

Overall this fits into the paradigm of software builds being available for upgrade once they're included in an AMI that's released on the platform.