### PR TITLE
chore: rollback extensions from pgtap tests

### DIFF
--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.42"
+postgres-version = "15.1.0.43"

--- a/migrations/docker-compose.yaml
+++ b/migrations/docker-compose.yaml
@@ -6,7 +6,7 @@ version: "3.8"
 
 services:
   db:
-    image: supabase/postgres:15.1.0.11
+    image: supabase/postgres:15.1.0.42
     restart: "no"
     ports:
       - 5478:5432
@@ -30,7 +30,8 @@ services:
         condition: service_healthy
     environment:
       PGHOST: db
-      PGUSER: postgres
+      PGUSER: supabase_admin
+      PGDATABASE: postgres
       PGPASSWORD: ${POSTGRES_PASSWORD}
     volumes:
       - ./tests:/tests

--- a/migrations/tests/extensions/01-postgis.sql
+++ b/migrations/tests/extensions/01-postgis.sql
@@ -1,1 +1,3 @@
+BEGIN;
 create extension if not exists postgis_sfcgal with schema "extensions" cascade;
+ROLLBACK;

--- a/migrations/tests/extensions/02-pgrouting.sql
+++ b/migrations/tests/extensions/02-pgrouting.sql
@@ -1,1 +1,3 @@
-create extension if not exists pgrouting with schema "extensions";
+BEGIN;
+create extension if not exists pgrouting with schema "extensions" cascade;
+ROLLBACK;

--- a/migrations/tests/extensions/03-pgtap.sql
+++ b/migrations/tests/extensions/03-pgtap.sql
@@ -1,1 +1,3 @@
+BEGIN;
 create extension if not exists pgtap with schema "extensions";
+ROLLBACK;

--- a/migrations/tests/extensions/04-pg_cron.sql
+++ b/migrations/tests/extensions/04-pg_cron.sql
@@ -1,1 +1,3 @@
+BEGIN;
 create extension if not exists pg_cron with schema "extensions";
+ROLLBACK;

--- a/migrations/tests/extensions/05-pgaudit.sql
+++ b/migrations/tests/extensions/05-pgaudit.sql
@@ -1,1 +1,3 @@
+BEGIN;
 create extension if not exists pgaudit with schema "extensions";
+ROLLBACK;

--- a/migrations/tests/extensions/06-pgjwt.sql
+++ b/migrations/tests/extensions/06-pgjwt.sql
@@ -1,1 +1,3 @@
+BEGIN;
 create extension if not exists pgjwt with schema "extensions" cascade;
+ROLLBACK;

--- a/migrations/tests/extensions/07-pgsql-http.sql
+++ b/migrations/tests/extensions/07-pgsql-http.sql
@@ -1,1 +1,3 @@
+BEGIN;
 create extension if not exists http with schema "extensions";
+ROLLBACK;

--- a/migrations/tests/extensions/08-plpgsql_check.sql
+++ b/migrations/tests/extensions/08-plpgsql_check.sql
@@ -1,1 +1,3 @@
+BEGIN;
 create extension if not exists plpgsql_check with schema "extensions";
+ROLLBACK;

--- a/migrations/tests/extensions/09-pg-safeupdate.sql
+++ b/migrations/tests/extensions/09-pg-safeupdate.sql
@@ -1,1 +1,3 @@
+BEGIN;
 alter role postgres set session_preload_libraries = 'safeupdate';
+ROLLBACK;

--- a/migrations/tests/extensions/10-timescaledb.sql
+++ b/migrations/tests/extensions/10-timescaledb.sql
@@ -1,1 +1,3 @@
+BEGIN;
 create extension if not exists timescaledb with schema "extensions";
+ROLLBACK;

--- a/migrations/tests/extensions/11-wal2json.sql
+++ b/migrations/tests/extensions/11-wal2json.sql
@@ -1,2 +1,4 @@
+BEGIN;
 select pg_drop_replication_slot(slot_name) from pg_replication_slots where slot_name = 'test_slot';
 select * from pg_create_logical_replication_slot('test_slot', 'wal2json');
+ROLLBACK;

--- a/migrations/tests/extensions/12-pljava.sql
+++ b/migrations/tests/extensions/12-pljava.sql
@@ -1,1 +1,3 @@
+BEGIN;
 create extension if not exists pljava with schema "sqlj";
+ROLLBACK;

--- a/migrations/tests/extensions/13-plv8.sql
+++ b/migrations/tests/extensions/13-plv8.sql
@@ -1,1 +1,3 @@
+BEGIN;
 create extension if not exists plv8 with schema "pg_catalog";
+ROLLBACK;

--- a/migrations/tests/extensions/14-pg_plan_filter.sql
+++ b/migrations/tests/extensions/14-pg_plan_filter.sql
@@ -1,1 +1,3 @@
+BEGIN;
 alter role postgres set session_preload_libraries = 'plan_filter';
+ROLLBACK;

--- a/migrations/tests/extensions/15-pg_net.sql
+++ b/migrations/tests/extensions/15-pg_net.sql
@@ -1,1 +1,3 @@
+BEGIN;
 create extension if not exists pg_net with schema "extensions";
+ROLLBACK;

--- a/migrations/tests/extensions/16-rum.sql
+++ b/migrations/tests/extensions/16-rum.sql
@@ -1,1 +1,3 @@
+BEGIN;
 create extension if not exists rum with schema "extensions";
+ROLLBACK;

--- a/migrations/tests/extensions/17-pg_hashids.sql
+++ b/migrations/tests/extensions/17-pg_hashids.sql
@@ -1,1 +1,3 @@
+BEGIN;
 create extension if not exists pg_hashids with schema "extensions";
+ROLLBACK;

--- a/migrations/tests/extensions/18-pgsodium.sql
+++ b/migrations/tests/extensions/18-pgsodium.sql
@@ -1,2 +1,4 @@
+BEGIN;
 create schema if not exists "pgsodium";
 create extension if not exists pgsodium with schema "pgsodium";
+ROLLBACK;

--- a/migrations/tests/extensions/19-pg_graphql.sql
+++ b/migrations/tests/extensions/19-pg_graphql.sql
@@ -1,2 +1,4 @@
+BEGIN;
 create schema if not exists "graphql";
 create extension if not exists pg_graphql with schema "graphql";
+ROLLBACK;

--- a/migrations/tests/extensions/20-pg_stat_monitor.sql
+++ b/migrations/tests/extensions/20-pg_stat_monitor.sql
@@ -1,1 +1,3 @@
+BEGIN;
 create extension if not exists pg_stat_monitor with schema "extensions";
+ROLLBACK;

--- a/migrations/tests/extensions/22-pg_jsonschema.sql
+++ b/migrations/tests/extensions/22-pg_jsonschema.sql
@@ -1,1 +1,3 @@
+BEGIN;
 create extension if not exists pg_jsonschema with schema "extensions";
+ROLLBACK;

--- a/migrations/tests/extensions/23-vault.sql
+++ b/migrations/tests/extensions/23-vault.sql
@@ -1,2 +1,4 @@
+BEGIN;
 create schema if not exists "vault";
 create extension if not exists supabase_vault with schema "vault" cascade;
+ROLLBACK;

--- a/migrations/tests/extensions/24-pgroonga.sql
+++ b/migrations/tests/extensions/24-pgroonga.sql
@@ -1,1 +1,3 @@
+BEGIN;
 create extension if not exists pgroonga with schema "extensions";
+ROLLBACK;

--- a/migrations/tests/extensions/25-wrappers.sql
+++ b/migrations/tests/extensions/25-wrappers.sql
@@ -1,1 +1,3 @@
+BEGIN;
 create extension if not exists wrappers with schema "extensions";
+ROLLBACK;

--- a/migrations/tests/extensions/26-hypopg.sql
+++ b/migrations/tests/extensions/26-hypopg.sql
@@ -1,1 +1,3 @@
+BEGIN;
 create extension if not exists hypopg with schema "extensions";
+ROLLBACK;

--- a/migrations/tests/extensions/27-pg_repack.sql
+++ b/migrations/tests/extensions/27-pg_repack.sql
@@ -1,1 +1,3 @@
+BEGIN;
 create extension if not exists pg_repack with schema "extensions";
+ROLLBACK;

--- a/migrations/tests/extensions/28-pgvector.sql
+++ b/migrations/tests/extensions/28-pgvector.sql
@@ -1,1 +1,3 @@
+BEGIN;
 create extension if not exists vector with schema "extensions";
+ROLLBACK;

--- a/migrations/tests/test.sql
+++ b/migrations/tests/test.sql
@@ -1,6 +1,8 @@
 -- Create all extensions
 \ir extensions/test.sql
 
+CREATE EXTENSION IF NOT EXISTS pgtap;
+
 BEGIN;
 
 SELECT plan(19);


### PR DESCRIPTION
## What kind of change does this PR introduce?

tests

## What is the new behavior?

wrap individual extension tests in transactions

## Additional context

considered wrapping extensions.sql but that leads to error 
```
migrations-pg_prove-1  | psql:/tests/extensions/11-wal2json.sql:2: ERROR:  cannot create logical replication slot in transaction that has performed writes
```
