### PR TITLE
fix: user permissions for extension schemas

### DIFF
--- a/ansible/files/postgresql_extension_custom_scripts/postgis_tiger_geocoder/after-create.sql
+++ b/ansible/files/postgresql_extension_custom_scripts/postgis_tiger_geocoder/after-create.sql
@@ -1,9 +1,10 @@
+-- These schemas are created by extension to house all tiger related functions, owned by supabase_admin
 grant usage on schema tiger, tiger_data to postgres with grant option;
-
+-- Give postgres permission to all existing entities, also allows postgres to grant other roles
 grant all on all tables in schema tiger, tiger_data to postgres with grant option;
 grant all on all routines in schema tiger, tiger_data to postgres with grant option;
 grant all on all sequences in schema tiger, tiger_data to postgres with grant option;
-
+-- Update default privileges so that new entities are also accessible by postgres
 alter default privileges in schema tiger, tiger_data grant all on tables to postgres with grant option;
 alter default privileges in schema tiger, tiger_data grant all on routines to postgres with grant option;
 alter default privileges in schema tiger, tiger_data grant all on sequences to postgres with grant option;

--- a/ansible/files/postgresql_extension_custom_scripts/postgis_tiger_geocoder/after-create.sql
+++ b/ansible/files/postgresql_extension_custom_scripts/postgis_tiger_geocoder/after-create.sql
@@ -1,0 +1,9 @@
+grant usage on schema tiger to postgres with grant option;
+
+grant all on all tables in schema tiger to postgres with grant option;
+grant all on all routines in schema tiger to postgres with grant option;
+grant all on all sequences in schema tiger to postgres with grant option;
+
+alter default privileges in schema tiger grant all on tables to postgres with grant option;
+alter default privileges in schema tiger grant all on routines to postgres with grant option;
+alter default privileges in schema tiger grant all on sequences to postgres with grant option;

--- a/ansible/files/postgresql_extension_custom_scripts/postgis_tiger_geocoder/after-create.sql
+++ b/ansible/files/postgresql_extension_custom_scripts/postgis_tiger_geocoder/after-create.sql
@@ -1,9 +1,9 @@
-grant usage on schema tiger to postgres with grant option;
+grant usage on schema tiger, tiger_data to postgres with grant option;
 
-grant all on all tables in schema tiger to postgres with grant option;
-grant all on all routines in schema tiger to postgres with grant option;
-grant all on all sequences in schema tiger to postgres with grant option;
+grant all on all tables in schema tiger, tiger_data to postgres with grant option;
+grant all on all routines in schema tiger, tiger_data to postgres with grant option;
+grant all on all sequences in schema tiger, tiger_data to postgres with grant option;
 
-alter default privileges in schema tiger grant all on tables to postgres with grant option;
-alter default privileges in schema tiger grant all on routines to postgres with grant option;
-alter default privileges in schema tiger grant all on sequences to postgres with grant option;
+alter default privileges in schema tiger, tiger_data grant all on tables to postgres with grant option;
+alter default privileges in schema tiger, tiger_data grant all on routines to postgres with grant option;
+alter default privileges in schema tiger, tiger_data grant all on sequences to postgres with grant option;

--- a/migrations/db/migrations/20230224042246_grant_extensions_perms_for_postgres.sql
+++ b/migrations/db/migrations/20230224042246_grant_extensions_perms_for_postgres.sql
@@ -1,0 +1,10 @@
+-- migrate:up
+grant all privileges on all tables in schema extensions to postgres with grant option;
+grant all privileges on all routines in schema extensions to postgres with grant option;
+grant all privileges on all sequences in schema extensions to postgres with grant option;
+alter default privileges in schema extensions grant all on tables to postgres with grant option;
+alter default privileges in schema extensions grant all on routines to postgres with grant option;
+alter default privileges in schema extensions grant all on sequences to postgres with grant option;
+
+-- migrate:down
+

--- a/migrations/tests/database/privs.sql
+++ b/migrations/tests/database/privs.sql
@@ -8,6 +8,11 @@ SELECT function_privs_are('pgsodium', 'crypto_aead_det_encrypt', array['bytea', 
 SELECT function_privs_are('pgsodium', 'crypto_aead_det_keygen', array[]::text[], 'service_role', array['EXECUTE']);
 
 -- Verify public schema privileges
+SELECT schema_privs_are('public', 'postgres', array['CREATE', 'USAGE']);
+SELECT schema_privs_are('public', 'anon', array['USAGE']);
+SELECT schema_privs_are('public', 'authenticated', array['USAGE']);
+SELECT schema_privs_are('public', 'service_role', array['USAGE']);
+
 set role postgres;
 create table test_priv();
 SELECT table_owner_is('test_priv', 'postgres');

--- a/migrations/tests/database/privs.sql
+++ b/migrations/tests/database/privs.sql
@@ -7,12 +7,19 @@ SELECT function_privs_are('pgsodium', 'crypto_aead_det_decrypt', array['bytea', 
 SELECT function_privs_are('pgsodium', 'crypto_aead_det_encrypt', array['bytea', 'bytea', 'uuid', 'bytea'], 'service_role', array['EXECUTE']);
 SELECT function_privs_are('pgsodium', 'crypto_aead_det_keygen', array[]::text[], 'service_role', array['EXECUTE']);
 
+-- Verify public schema privileges
 set role postgres;
 create table test_priv();
 SELECT table_owner_is('test_priv', 'postgres');
 SELECT table_privs_are('test_priv', 'supabase_admin', array['DELETE', 'INSERT', 'REFERENCES', 'SELECT', 'TRIGGER', 'TRUNCATE', 'UPDATE']);
+SELECT table_privs_are('test_priv', 'postgres', array['DELETE', 'INSERT', 'REFERENCES', 'SELECT', 'TRIGGER', 'TRUNCATE', 'UPDATE']);
 SELECT table_privs_are('test_priv', 'anon', array['DELETE', 'INSERT', 'REFERENCES', 'SELECT', 'TRIGGER', 'TRUNCATE', 'UPDATE']);
 SELECT table_privs_are('test_priv', 'authenticated', array['DELETE', 'INSERT', 'REFERENCES', 'SELECT', 'TRIGGER', 'TRUNCATE', 'UPDATE']);
 SELECT table_privs_are('test_priv', 'service_role', array['DELETE', 'INSERT', 'REFERENCES', 'SELECT', 'TRIGGER', 'TRUNCATE', 'UPDATE']);
-SELECT table_privs_are('test_priv', 'postgres', array['DELETE', 'INSERT', 'REFERENCES', 'SELECT', 'TRIGGER', 'TRUNCATE', 'UPDATE']);
 reset role;
+
+-- Verify extensions schema privileges
+SELECT schema_privs_are('extensions', 'postgres', array['CREATE', 'USAGE']);
+SELECT schema_privs_are('extensions', 'anon', array['USAGE']);
+SELECT schema_privs_are('extensions', 'authenticated', array['USAGE']);
+SELECT schema_privs_are('extensions', 'service_role', array['USAGE']);

--- a/migrations/tests/extensions/01-postgis.sql
+++ b/migrations/tests/extensions/01-postgis.sql
@@ -7,20 +7,20 @@ BEGIN;
 create extension if not exists address_standardizer with schema extensions;
 create extension if not exists postgis_tiger_geocoder cascade;
 -- \ir ansible/files/postgresql_extension_custom_scripts/postgis_tiger_geocoder/after-create.sql
-grant usage on schema tiger to postgres with grant option;
-grant all privileges on all tables in schema tiger to postgres with grant option;
-grant all privileges on all routines in schema tiger to postgres with grant option;
-grant all privileges on all sequences in schema tiger to postgres with grant option;
-alter default privileges in schema tiger grant all on tables to postgres with grant option;
-alter default privileges in schema tiger grant all on routines to postgres with grant option;
-alter default privileges in schema tiger grant all on sequences to postgres with grant option;
+grant usage on schema tiger, tiger_data to postgres with grant option;
+grant all privileges on all tables in schema tiger, tiger_data to postgres with grant option;
+grant all privileges on all routines in schema tiger, tiger_data to postgres with grant option;
+grant all privileges on all sequences in schema tiger, tiger_data to postgres with grant option;
+alter default privileges in schema tiger, tiger_data grant all on tables to postgres with grant option;
+alter default privileges in schema tiger, tiger_data grant all on routines to postgres with grant option;
+alter default privileges in schema tiger, tiger_data grant all on sequences to postgres with grant option;
 -- postgres role should have access
 set local role postgres;
 select tiger.pprint_addy(tiger.pagc_normalize_address('710 E Ben White Blvd, Austin, TX 78704'));
 -- other roles can be granted access
-grant usage on schema tiger to authenticated;
-grant select on all tables in schema tiger to authenticated;
-grant execute on all routines in schema tiger to authenticated;
+grant usage on schema tiger, tiger_data to authenticated;
+grant select on all tables in schema tiger, tiger_data to authenticated;
+grant execute on all routines in schema tiger, tiger_data to authenticated;
 -- authenticated role should have access now
 set local role authenticated;
 select tiger.pprint_addy(tiger.pagc_normalize_address('710 E Ben White Blvd, Austin, TX 78704'));

--- a/migrations/tests/extensions/01-postgis.sql
+++ b/migrations/tests/extensions/01-postgis.sql
@@ -1,3 +1,26 @@
 BEGIN;
 create extension if not exists postgis_sfcgal with schema "extensions" cascade;
 ROLLBACK;
+
+BEGIN;
+create extension if not exists address_standardizer with schema extensions;
+create extension if not exists postgis_tiger_geocoder cascade;
+-- \ir ansible/files/postgresql_extension_custom_scripts/postgis_tiger_geocoder/after-create.sql
+grant usage on schema tiger to postgres with grant option;
+grant all on all tables in schema tiger to postgres with grant option;
+grant all on all routines in schema tiger to postgres with grant option;
+grant all on all sequences in schema tiger to postgres with grant option;
+alter default privileges in schema tiger grant all on tables to postgres with grant option;
+alter default privileges in schema tiger grant all on routines to postgres with grant option;
+alter default privileges in schema tiger grant all on sequences to postgres with grant option;
+-- postgres role should have access
+set local role postgres;
+select tiger.pprint_addy(tiger.pagc_normalize_address('710 E Ben White Blvd, Austin, TX 78704'));
+-- other roles can be granted access
+grant usage on schema tiger to authenticated;
+grant select on all tables in schema tiger to authenticated;
+grant execute on all routines in schema tiger to authenticated;
+-- authenticated role should have access now
+set local role authenticated;
+select tiger.pprint_addy(tiger.pagc_normalize_address('710 E Ben White Blvd, Austin, TX 78704'));
+ROLLBACK;

--- a/migrations/tests/extensions/01-postgis.sql
+++ b/migrations/tests/extensions/01-postgis.sql
@@ -8,9 +8,9 @@ create extension if not exists address_standardizer with schema extensions;
 create extension if not exists postgis_tiger_geocoder cascade;
 -- \ir ansible/files/postgresql_extension_custom_scripts/postgis_tiger_geocoder/after-create.sql
 grant usage on schema tiger to postgres with grant option;
-grant all on all tables in schema tiger to postgres with grant option;
-grant all on all routines in schema tiger to postgres with grant option;
-grant all on all sequences in schema tiger to postgres with grant option;
+grant all privileges on all tables in schema tiger to postgres with grant option;
+grant all privileges on all routines in schema tiger to postgres with grant option;
+grant all privileges on all sequences in schema tiger to postgres with grant option;
 alter default privileges in schema tiger grant all on tables to postgres with grant option;
 alter default privileges in schema tiger grant all on routines to postgres with grant option;
 alter default privileges in schema tiger grant all on sequences to postgres with grant option;
@@ -24,4 +24,10 @@ grant execute on all routines in schema tiger to authenticated;
 -- authenticated role should have access now
 set local role authenticated;
 select tiger.pprint_addy(tiger.pagc_normalize_address('710 E Ben White Blvd, Austin, TX 78704'));
+ROLLBACK;
+
+BEGIN;
+create extension if not exists address_standardizer_data_us with schema extensions;
+set local role postgres;
+select * from extensions.us_lex;
 ROLLBACK;

--- a/migrations/tests/extensions/01-postgis.sql
+++ b/migrations/tests/extensions/01-postgis.sql
@@ -3,6 +3,7 @@ create extension if not exists postgis_sfcgal with schema "extensions" cascade;
 ROLLBACK;
 
 BEGIN;
+-- create postgis tiger as supabase_admin
 create extension if not exists address_standardizer with schema extensions;
 create extension if not exists postgis_tiger_geocoder cascade;
 -- \ir ansible/files/postgresql_extension_custom_scripts/postgis_tiger_geocoder/after-create.sql

--- a/migrations/tests/extensions/01-postgis.sql
+++ b/migrations/tests/extensions/01-postgis.sql
@@ -6,6 +6,7 @@ BEGIN;
 -- create postgis tiger as supabase_admin
 create extension if not exists address_standardizer with schema extensions;
 create extension if not exists postgis_tiger_geocoder cascade;
+
 -- \ir ansible/files/postgresql_extension_custom_scripts/postgis_tiger_geocoder/after-create.sql
 grant usage on schema tiger, tiger_data to postgres with grant option;
 grant all privileges on all tables in schema tiger, tiger_data to postgres with grant option;
@@ -14,20 +15,25 @@ grant all privileges on all sequences in schema tiger, tiger_data to postgres wi
 alter default privileges in schema tiger, tiger_data grant all on tables to postgres with grant option;
 alter default privileges in schema tiger, tiger_data grant all on routines to postgres with grant option;
 alter default privileges in schema tiger, tiger_data grant all on sequences to postgres with grant option;
+
 -- postgres role should have access
 set local role postgres;
 select tiger.pprint_addy(tiger.pagc_normalize_address('710 E Ben White Blvd, Austin, TX 78704'));
+
 -- other roles can be granted access
 grant usage on schema tiger, tiger_data to authenticated;
 grant select on all tables in schema tiger, tiger_data to authenticated;
 grant execute on all routines in schema tiger, tiger_data to authenticated;
+
 -- authenticated role should have access now
 set local role authenticated;
 select tiger.pprint_addy(tiger.pagc_normalize_address('710 E Ben White Blvd, Austin, TX 78704'));
 ROLLBACK;
 
 BEGIN;
+-- address standardizer creates a table in extensions schema, owned by supabase_admin
 create extension if not exists address_standardizer_data_us with schema extensions;
+-- postgres role should have access
 set local role postgres;
 select * from extensions.us_lex;
 ROLLBACK;

--- a/migrations/tests/test.sql
+++ b/migrations/tests/test.sql
@@ -5,7 +5,7 @@ CREATE EXTENSION IF NOT EXISTS pgtap;
 
 BEGIN;
 
-SELECT plan(29);
+SELECT plan(33);
 
 \ir fixtures.sql
 \ir database/test.sql

--- a/migrations/tests/test.sql
+++ b/migrations/tests/test.sql
@@ -5,7 +5,7 @@ CREATE EXTENSION IF NOT EXISTS pgtap;
 
 BEGIN;
 
-SELECT plan(25);
+SELECT plan(29);
 
 \ir fixtures.sql
 \ir database/test.sql


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/supabase/issues/12588

## What is the new behavior?

- Schemas created by postgis tiger extension are owned by supabase_admin. We now give full grant option to postgres so that platform users can further grant permissions to other roles. 
- Tables, functions, and sequences in extensions schema are now accessible to postgres by default.

## Additional context

Add any other context or screenshots.
