### PR TITLE
feat: bump wrappers to 0.1.8

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -121,7 +121,7 @@ groonga_release_checksum: sha256:7770c0ff6804ef4b47b015b15736cd973cffced977c2099
 pgroonga_release: "2.4.0"
 pgroonga_release_checksum: sha256:5baaae0e7d81f8167e278e9a34c6ed56aece8b34f5ab98f228c64408093417b3
 
-wrappers_release: "0.1.7"
+wrappers_release: "0.1.8"
 
 hypopg_release: "1.3.1"
 hypopg_release_checksum: sha256:e7f01ee0259dc1713f318a108f987663d60f3041948c2ada57a94b469565ca8e

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.52"
+postgres-version = "15.1.0.53"


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to upgrade Wrappers to v0.1.8. See more details about this version: https://github.com/supabase/wrappers/releases/tag/v0.1.8

## What is the current behavior?

Currently it is v0.1.7.

## What is the new behavior?

Wrappers version upgraded to v0.1.8.

## Additional context

N/A
