### PR TITLE
chore: grant pg monitor role to postgres

### DIFF
--- a/migrations/db/migrations/20230306081037_grant_pg_monitor_to_postgres.sql
+++ b/migrations/db/migrations/20230306081037_grant_pg_monitor_to_postgres.sql
@@ -1,0 +1,5 @@
+-- migrate:up
+grant pg_monitor to postgres;
+
+-- migrate:down
+


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Query performance report doesn't have sufficient privilege to view statements executed by non-postgres role.

## What is the new behavior?

Allow postgres to get stats of queries executed by other roles.

One security consideration is that it gives `postgres` role the privilege to monitor all queries run in a database, including those run by supabase_admin and other superusers. This is a low risk change as long as sensitive data is not directly embedded in query strings.

## Additional context

Add any other context or screenshots.
