### PR TITLE
fix(docker): missing ca-certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -762,18 +762,15 @@ COPY --from=supautils /tmp/*.deb /tmp/
 # Build final image
 ####################
 FROM base as production
-# Install essential packages
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    # Needed for anything using libcurl
-    # https://github.com/supabase/postgres/issues/573
-    ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
 
 # Setup extensions
 COPY --from=extensions /tmp /tmp
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
     /tmp/*.deb \
+    # Needed for anything using libcurl
+    # https://github.com/supabase/postgres/issues/573
+    ca-certificates \
     && rm -rf /var/lib/apt/lists/* /tmp/*
 
 # Initialise configs

--- a/Dockerfile
+++ b/Dockerfile
@@ -244,7 +244,7 @@ WORKDIR /tmp/pgsql-http-${pgsql_http_release}
 RUN --mount=type=cache,target=/ccache,from=public.ecr.aws/supabase/postgres:ccache \
     make -j$(nproc)
 # Create debian package
-RUN checkinstall -D --install=no --fstrans=no --backup=no --pakdir=/tmp --nodoc
+RUN checkinstall -D --install=no --fstrans=no --backup=no --pakdir=/tmp --requires=libcurl3-gnutls --nodoc
 
 ####################
 # 08-plpgsql_check.yml
@@ -762,6 +762,12 @@ COPY --from=supautils /tmp/*.deb /tmp/
 # Build final image
 ####################
 FROM base as production
+# Install essential packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    # Needed for anything using libcurl
+    # https://github.com/supabase/postgres/issues/573
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
 # Setup extensions
 COPY --from=extensions /tmp /tmp

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.53"
+postgres-version = "15.1.0.54-rc0"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`ca-certificates` is missing on the Docker image, which breaks extensions that use SSL.

## What is the new behavior?

Add `ca-certificates`

## Additional context

Fixes https://github.com/supabase/postgres/issues/573
