### PR TITLE
chore: grant auth roles to supabase_storage_admin user

### DIFF
--- a/migrations/db/migrations/20230327032006_grant_auth_roles_to_supabase_storage_admin.sql
+++ b/migrations/db/migrations/20230327032006_grant_auth_roles_to_supabase_storage_admin.sql
@@ -1,0 +1,4 @@
+-- migrate:up
+grant anon, authenticated, service_role to supabase_storage_admin;
+
+-- migrate:down

--- a/migrations/tests/storage/privs.sql
+++ b/migrations/tests/storage/privs.sql
@@ -1,0 +1,3 @@
+select is_member_of('anon', 'supabase_storage_admin');
+select is_member_of('authenticated', 'supabase_storage_admin');
+select is_member_of('service_role', 'supabase_storage_admin');

--- a/migrations/tests/storage/test.sql
+++ b/migrations/tests/storage/test.sql
@@ -1,2 +1,3 @@
 
 \ir exists.sql
+\ir privs.sql

--- a/migrations/tests/test.sql
+++ b/migrations/tests/test.sql
@@ -5,7 +5,7 @@ BEGIN;
 
 CREATE EXTENSION IF NOT EXISTS pgtap;
 
-SELECT plan(33);
+SELECT plan(36);
 
 \ir fixtures.sql
 \ir database/test.sql


### PR DESCRIPTION
## What kind of change does this PR introduce?

supabase_storage_admin needs to be able to switch to these roles without relying postgrest

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

[Slack context](https://supabase.slack.com/archives/C01D6TWFFFW/p1679489985890339) 
