### PR TITLE
chore: update pg_graphql to v1.2.0

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -105,7 +105,7 @@ libsodium_release_checksum: sha256:6f504490b342a4f8a4c4a02fc9b866cbef8622d5df4e5
 pgsodium_release: "3.1.5"
 pgsodium_release_checksum: sha256:bec847388a5db2a60ea9d991962ce27954d91b4c41cbcc7bd8e34472c69114d1
 
-pg_graphql_release: "1.1.0"
+pg_graphql_release: "1.2.0"
 
 pg_jsonschema_release: "0.1.4"
 

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.62"
+postgres-version = "15.1.0.63"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Updates pg_graphql to v1.2.0: https://github.com/supabase/pg_graphql/releases/tag/v1.2.0

> - feature: String type filters support ilike, like, startsWith
> - feature: Support for @skip and @include directives
> - feature: Custom descriptions via comment directive @graphql({"description": ...})
> - bugfix: Unknown types are represented in GraphQL schema as Opaque rather than String
> - bugfix: PostgreSQL type modifiers, e.g. char(n), no longer truncate excess text
> - bugfix: Creating a new enum variant between existing variants no longer errors

I copied how this was done in #509

Closes #596
