### PR TITLE
feat: remove `disable.vault` suffix from 15.1.0.66

### DIFF
--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.66-disable.vault"
+postgres-version = "15.1.0.66"


### PR DESCRIPTION
So that we can push an image to prod.