### PR TITLE
Upgrade pg_tle to 1.0.3 for pg_dump/pg_restore bugfix

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -133,4 +133,4 @@ pgvector_release: "0.4.0"
 pgvector_release_checksum: sha256:b76cf84ddad452cc880a6c8c661d137ddd8679c000a16332f4f03ecf6e10bcc8
 
 pg_tle_release: "1.0.3"
-pg_tle_release_checksum: sha256:c536b818ffcda478c2ea67d2cd30c70cab1fecdc3dd8146a5411377ba5f12950
+pg_tle_release_checksum: sha256:26e66503e45c67aa4a79f764c6775173239141cec78553ccf7c3b40524a558a3

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -132,5 +132,5 @@ pg_repack_release_checksum: sha256:18b4d871c1abf78cf0b1b1fe6081d435d183a8dc5eb97
 pgvector_release: "0.4.0"
 pgvector_release_checksum: sha256:b76cf84ddad452cc880a6c8c661d137ddd8679c000a16332f4f03ecf6e10bcc8
 
-pg_tle_release: "1.0.1"
+pg_tle_release: "1.0.3"
 pg_tle_release_checksum: sha256:c536b818ffcda478c2ea67d2cd30c70cab1fecdc3dd8146a5411377ba5f12950

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.67"
+postgres-version = "15.1.0.68"


### PR DESCRIPTION
## What kind of change does this PR introduce?
Upgrades pg_tle to fix pg_dump/pg_restore errors when pausing and restoring Supabase projects


