### PR TITLE
chore: upgrade to postgrest v11.0.1

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgresql_release_checksum: sha256:ea2cf059a85882654b989acd07edc121833164a30340
 pgbouncer_release: "1.17.0"
 pgbouncer_release_checksum: sha256:657309b7bc5c7a85cbf70a9a441b535f7824123081eabb7ba86d00349a256e23
 
-postgrest_release: "10.2.0"
-postgrest_arm_release_checksum: sha1:93404f97cc5079d8412ffa23c415a394503d2f24
-postgrest_x86_release_checksum: sha1:78cb66b297eee56d84a0a46869a4be9f388cddc7
+postgrest_release: "11.0.1"
+postgrest_arm_release_checksum: sha1:3dd463fa514f9acfce40f186436e989e668ebb36
+postgrest_x86_release_checksum: sha1:836221d191eb3e6c5fdd468e1812501cbf607268
 
 gotrue_release: v2.60.7
 gotrue_release_checksum: sha1:bfccf8e0e011fa57377f02d8fab69d131bb64271

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.75"
+postgres-version = "15.1.0.76"


### PR DESCRIPTION
v11.0.1 brings stability to v11.0.0. This should now be safe to deploy to the Supabase platform.

Release notes:

- https://github.com/PostgREST/postgrest/releases/tag/v11.0.1
- https://github.com/PostgREST/postgrest/releases/tag/v11.0.0