### PR TITLE
chore: bump postgres version

### DIFF
--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.74"
+postgres-version = "15.1.0.75"


### PR DESCRIPTION
* Previous AMI version was built, but workflow failed overall: https://github.com/supabase/postgres/actions/runs/4869380040
* Retriggering the workflow will immediately fail as there is an AMI name conflict
* Bumping version to avoid this