### PR TITLE
fix: fail2ban regex for pgbouncer

### DIFF
--- a/ansible/files/fail2ban_config/filter-pgbouncer.conf.j2
+++ b/ansible/files/fail2ban_config/filter-pgbouncer.conf.j2
@@ -1,2 +1,2 @@
 [Definition]
-failregex = ^.+@<HOST>:.+error: password authentication failed$
+failregex = ^.+@<HOST>:.+password authentication failed$


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?
Log line for failed login looks like this:
```
C-0xyzxyzxyzxyz0: pgbouncer/pgbouncer@1.2.3.4:12345 password authentication failed
```