### PR TITLE
chore: disable pgbouncer logfile output

### DIFF
--- a/ansible/files/fail2ban_config/filter-pgbouncer.conf.j2
+++ b/ansible/files/fail2ban_config/filter-pgbouncer.conf.j2
@@ -1,2 +1,3 @@
 [Definition]
 failregex = ^.+@<HOST>:.+password authentication failed$
+journalmatch = _SYSTEMD_UNIT=pgbouncer.service

--- a/ansible/files/fail2ban_config/jail-pgbouncer.conf.j2
+++ b/ansible/files/fail2ban_config/jail-pgbouncer.conf.j2
@@ -3,5 +3,5 @@ enabled = true
 port    = 6543
 protocol = tcp
 filter = pgbouncer
-logpath = /var/log/pgbouncer.log
+backend = systemd[journalflags=1]
 maxretry = 3

--- a/ansible/files/pgbouncer_config/pgbouncer.ini.j2
+++ b/ansible/files/pgbouncer_config/pgbouncer.ini.j2
@@ -43,7 +43,7 @@
 ;;; Administrative settings
 ;;;
 
-logfile = /var/log/pgbouncer.log
+;logfile = /var/log/pgbouncer.log
 pidfile = /var/run/pgbouncer/pgbouncer.pid
 
 ;;;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Disable pgbouncer logging to logfile. Logging to systemd/journal is retained.
