### PR TITLE
chore: revert pg_cron 1.4.2

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -54,8 +54,8 @@ pgrouting_release_checksum: sha256:a4e034efee8cf67582b67033d9c3ff714a09d8f542533
 pgtap_release: "1.2.0"
 pgtap_release_checksum: sha256:9c7c3de67ea41638e14f06da5da57bac6f5bd03fea05c165a0ec862205a5c052
 
-pg_cron_release: "1.5.2"
-pg_cron_release_checksum: sha256:6f7f0980c03f1e2a6a747060e67bf4a303ca2a50e941e2c19daeed2b44dec744
+pg_cron_release: "1.4.2"
+pg_cron_release_checksum: sha256:3652722ea98d94d8e27bf5e708dd7359f55a818a43550d046c5064c98876f1a8
 
 pgaudit_release: "1.7.0"
 pgaudit_release_checksum: sha256:8f4a73e451c88c567e516e6cba7dc1e23bc91686bb6f1f77f8f3126d428a8bd8

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.87"
+postgres-version = "15.1.0.88"


### PR DESCRIPTION
Restoring backups created when 1.4.2 to a database where pg_cron 1.5 exists breaks restores.

Issue filed here: https://github.com/citusdata/pg_cron/issues/274