### PR TITLE
chore: build pg15 with docker

### DIFF
--- a/.github/workflows/ami-release.yml
+++ b/.github/workflows/ami-release.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
       - ansi-dock
+      - build-pg
     paths:
       - '.github/workflows/ami-release.yml'
       - 'common.vars.pkr.hcl'
@@ -110,7 +111,7 @@ jobs:
           target_commitish: ${{github.sha}}
 
       - name: Slack Notification on Failure
-        if: ${{ failure() }}
+        if: ${{ false }}
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_NOTIFICATIONS_WEBHOOK }}

--- a/.github/workflows/ami-release.yml
+++ b/.github/workflows/ami-release.yml
@@ -56,6 +56,25 @@ jobs:
             tar xvf "$layer" -C ansible/files/extensions --strip-components 1
           done
 
+      - name: Build Postgres deb
+        uses: docker/build-push-action@v3
+        with:
+          push: false
+          load: true
+          file: docker/Dockerfile
+          target: pg-deb
+          tags: supabase/postgres:deb
+          platforms: linux/${{ matrix.arch }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Extract Postgres deb
+        run: |
+          mkdir -p /tmp/build ansible/files/postgres
+          docker save supabase/postgres:deb | tar xv -C /tmp/build
+          for layer in /tmp/build/*/layer.tar; do
+            tar xvf "$layer" -C ansible/files/postgres --strip-components 1
+          done
+
       - name: Build AMI
         run: |
           GIT_SHA=${{github.sha}}

--- a/ansible/tasks/setup-docker.yml
+++ b/ansible/tasks/setup-docker.yml
@@ -5,7 +5,10 @@
 
 # Builtin apt module does not support wildcard for deb paths
 - name: Install extensions
-  shell: apt-get install -y --no-install-recommends /tmp/extensions/*.deb
+  shell: |
+    set -e
+    apt-get update
+    apt-get install -y --no-install-recommends /tmp/extensions/*.deb
 
 - name: pg_cron - set cron.database_name
   become: yes

--- a/ansible/tasks/setup-postgres.yml
+++ b/ansible/tasks/setup-postgres.yml
@@ -13,11 +13,62 @@
     repo: "deb https://apt-archive.postgresql.org/pub/repos/apt {{ ansible_distribution_release }}-pgdg-archive main"
     state: present
 
+# let's build binaries from their published source packages
+- name: Add Postgres PPA - source
+  apt_repository:
+    repo: "deb-src https://apt-archive.postgresql.org/pub/repos/apt {{ ansible_distribution_release }}-pgdg-archive main"
+    state: present
+
+- name: Create temporary build directory
+  tempfile:
+    state: directory
+  register: pg_build_dir
+
+- name: Setting mcpu (arm)
+  set_fact:
+    mcpu: "neoverse-n1"
+  when: platform == "arm64"
+
+- name: Postgres - build
+  shell: |
+    set -e
+    export PYTHONDONTWRITEBYTECODE=1
+    savedAptMark="$(apt-mark showmanual)"
+    cd "{{ pg_build_dir.path }}"
+
+    # create a temporary local APT repo to install from (so that dependency resolution can be handled by APT, as it should be)
+    apt-get update
+    apt-get install -y --no-install-recommends dpkg-dev
+    echo "deb [ trusted=yes ] file://{{ pg_build_dir.path }} ./" > /etc/apt/sources.list.d/temp.list
+    _update_repo() {
+      dpkg-scanpackages . > Packages
+      apt-get -o Acquire::GzipIndexes=false update
+    }
+    _update_repo
+
+    # build .deb files from upstream's source packages (which are verified by apt-get)
+    export DEB_BUILD_OPTIONS="nocheck parallel=$(nproc)"
+    export DEB_CPPFLAGS_APPEND="-mcpu={{ mcpu }} -fsigned-char"
+
+    # we have to build postgresql-common first because postgresql-15 shares "debian/rules" logic with it: https://salsa.debian.org/postgresql/postgresql/-/commit/99f44476e258cae6bf9e919219fa2c5414fa2876
+    # (and it "Depends: pgdg-keyring")
+    apt-get build-dep -y postgresql-common pgdg-keyring
+    apt-get source --compile postgresql-common pgdg-keyring
+    _update_repo
+    apt-get build-dep -y "postgresql-{{ postgresql_major }}={{ postgresql_release }}-1.pgdg20.04+1"
+    apt-get source --compile "postgresql-{{ postgresql_major }}={{ postgresql_release }}-1.pgdg20.04+1"
+
+    # we don't remove APT lists here because they get re-downloaded and removed later
+    # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+    # (which is done after we install the built packages so we don't have to redownload any overlapping dependencies)
+    apt-mark showmanual | xargs apt-mark auto > /dev/null
+    apt-mark manual $savedAptMark
+    _update_repo
+
 - name: Postgres - install commons
   apt:
     name: postgresql-common
-    state: latest
-    update_cache: yes
+    install_recommends: no
 
 - name: Do not create main cluster
   shell:
@@ -26,6 +77,16 @@
 - name: Postgres - install server
   apt:
     name: postgresql-{{ postgresql_major }}={{ postgresql_release }}-1.pgdg20.04+1
+    install_recommends: no
+
+# if we have leftovers from building, let's purge them (including extra, unnecessary build deps)
+- name: Remove build dependencies
+  shell: |
+    set -e
+    rm -rf /var/lib/apt/lists/*
+    apt-get purge -y --auto-remove
+    rm -rf "{{ pg_build_dir.path }}" /etc/apt/sources.list.d/temp.list
+    find /usr -name '*.pyc' -type f -exec bash -c 'for pyc; do dpkg -S "$pyc" &> /dev/null || rm -vf "$pyc"; done' -- '{}' +
 
 - name: Hold postgres {{ postgresql_release }} from apt upgrade
   shell: apt-mark hold postgresql-{{ postgresql_major }}

--- a/ansible/tasks/setup-postgres.yml
+++ b/ansible/tasks/setup-postgres.yml
@@ -1,69 +1,12 @@
-# Downloading dependencies
-- name: GPG dependencies
-  apt:
-    name: gnupg
+- name: Postgres - copy package
+  copy:
+    src: files/postgres/
+    dest: /tmp/build/
 
-- name: Add Postgres GPG key
-  apt_key:
-    keyserver: keyserver.ubuntu.com
-    id: B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
-
-- name: Add Postgres PPA
+- name: Postgres - add PPA
   apt_repository:
-    repo: "deb https://apt-archive.postgresql.org/pub/repos/apt {{ ansible_distribution_release }}-pgdg-archive main"
+    repo: "deb [ trusted=yes ] file:///tmp/build ./"
     state: present
-
-# let's build binaries from their published source packages
-- name: Add Postgres PPA - source
-  apt_repository:
-    repo: "deb-src https://apt-archive.postgresql.org/pub/repos/apt {{ ansible_distribution_release }}-pgdg-archive main"
-    state: present
-
-- name: Create temporary build directory
-  tempfile:
-    state: directory
-  register: pg_build_dir
-
-- name: Setting mcpu (arm)
-  set_fact:
-    mcpu: "neoverse-n1"
-  when: platform == "arm64"
-
-- name: Postgres - build
-  shell: |
-    set -e
-    export PYTHONDONTWRITEBYTECODE=1
-    savedAptMark="$(apt-mark showmanual)"
-    cd "{{ pg_build_dir.path }}"
-
-    # create a temporary local APT repo to install from (so that dependency resolution can be handled by APT, as it should be)
-    apt-get update
-    apt-get install -y --no-install-recommends dpkg-dev
-    echo "deb [ trusted=yes ] file://{{ pg_build_dir.path }} ./" > /etc/apt/sources.list.d/temp.list
-    _update_repo() {
-      dpkg-scanpackages . > Packages
-      apt-get -o Acquire::GzipIndexes=false update
-    }
-    _update_repo
-
-    # build .deb files from upstream's source packages (which are verified by apt-get)
-    export DEB_BUILD_OPTIONS="nocheck parallel=$(nproc)"
-    export DEB_CPPFLAGS_APPEND="-mcpu={{ mcpu }} -fsigned-char"
-
-    # we have to build postgresql-common first because postgresql-15 shares "debian/rules" logic with it: https://salsa.debian.org/postgresql/postgresql/-/commit/99f44476e258cae6bf9e919219fa2c5414fa2876
-    # (and it "Depends: pgdg-keyring")
-    apt-get build-dep -y postgresql-common pgdg-keyring
-    apt-get source --compile postgresql-common pgdg-keyring
-    _update_repo
-    apt-get build-dep -y "postgresql-{{ postgresql_major }}={{ postgresql_release }}-1.pgdg20.04+1"
-    apt-get source --compile "postgresql-{{ postgresql_major }}={{ postgresql_release }}-1.pgdg20.04+1"
-
-    # we don't remove APT lists here because they get re-downloaded and removed later
-    # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
-    # (which is done after we install the built packages so we don't have to redownload any overlapping dependencies)
-    apt-mark showmanual | xargs apt-mark auto > /dev/null
-    apt-mark manual $savedAptMark
-    _update_repo
 
 - name: Postgres - install commons
   apt:
@@ -79,17 +22,15 @@
     name: postgresql-{{ postgresql_major }}={{ postgresql_release }}-1.pgdg20.04+1
     install_recommends: no
 
-# if we have leftovers from building, let's purge them (including extra, unnecessary build deps)
-- name: Remove build dependencies
-  shell: |
-    set -e
-    rm -rf /var/lib/apt/lists/*
-    apt-get purge -y --auto-remove
-    rm -rf "{{ pg_build_dir.path }}" /etc/apt/sources.list.d/temp.list
-    find /usr -name '*.pyc' -type f -exec bash -c 'for pyc; do dpkg -S "$pyc" &> /dev/null || rm -vf "$pyc"; done' -- '{}' +
+- name: Postgres - remove PPA
+  apt_repository:
+    repo: "deb [ trusted=yes ] file:///tmp/build ./"
+    state: absent
 
-- name: Hold postgres {{ postgresql_release }} from apt upgrade
-  shell: apt-mark hold postgresql-{{ postgresql_major }}
+- name: Postgres - cleanup package
+  file:
+    path: /tmp/build
+    state: absent
 
 - name: Create symlink to /usr/lib/postgresql/bin
   shell:

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.86-rc1"
+postgres-version = "15.1.0.89-rc0"

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.89-rc0"
+postgres-version = "15.1.0.89-rc1"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,71 @@
+ARG ubuntu_release=focal
+FROM ubuntu:${ubuntu_release} as base
+
+ARG ubuntu_release
+ARG postgresql_major=15
+ARG postgresql_release=${postgresql_major}.1
+
+FROM base as pg-source
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gnupg \
+    dpkg-dev \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Add Postgres PPA
+ARG postgresql_gpg_key=B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "${postgresql_gpg_key}" && \
+    echo "deb https://apt-archive.postgresql.org/pub/repos/apt ${ubuntu_release}-pgdg-archive main" > /etc/apt/sources.list.d/pgdg.list && \
+    echo "deb-src https://apt-archive.postgresql.org/pub/repos/apt ${ubuntu_release}-pgdg-archive main" > /etc/apt/sources.list.d/pgdg.list
+
+# Create local PPA
+WORKDIR /tmp/build
+RUN echo "deb [ trusted=yes ] file:///tmp/build ./" > /etc/apt/sources.list.d/temp.list && \
+    dpkg-scanpackages . > Packages && \
+    apt-get -o Acquire::GzipIndexes=false update
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV DEB_BUILD_OPTIONS="nocheck parallel=$(nproc)"
+
+# Configure processor optimised build
+ARG CPPFLAGS="-mcpu=neoverse-n1"
+ENV DEB_CPPFLAGS_APPEND="${CPPFLAGS} -fsigned-char"
+
+RUN apt-get build-dep -y postgresql-common pgdg-keyring && \
+    apt-get source --compile postgresql-common pgdg-keyring && \
+    dpkg-scanpackages . > Packages && \
+    apt-get -o Acquire::GzipIndexes=false update
+
+RUN apt-get build-dep -y "postgresql-${postgresql_major}=${postgresql_release}-1.pgdg20.04+1" && \
+    apt-get source --compile "postgresql-${postgresql_major}=${postgresql_release}-1.pgdg20.04+1" && \
+    dpkg-scanpackages . > Packages && \
+    apt-get -o Acquire::GzipIndexes=false update
+
+# Remove source directories
+RUN rm -rf /tmp/build/*/
+
+FROM base as pg
+
+# Inherit args from base stage
+ARG postgresql_major
+ARG postgresql_release
+
+COPY --from=pg-source /tmp/build /tmp/build
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN echo "deb [ trusted=yes ] file:///tmp/build ./" > /etc/apt/sources.list.d/temp.list && \
+    apt-get -o Acquire::GzipIndexes=false update && \
+    apt-get install -y --no-install-recommends postgresql-common && \
+    sed -ri 's/#(create_main_cluster) .*$/\1 = false/' /etc/postgresql-common/createcluster.conf && \
+    apt-get install -y --no-install-recommends "postgresql-${postgresql_major}=${postgresql_release}-1.pgdg20.04+1" && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /tmp/build /etc/apt/sources.list.d/temp.list
+
+ENV PATH $PATH:/usr/lib/postgresql/${postgresql_major}/bin
+
+FROM scratch as pg-deb
+
+COPY --from=pg-source /tmp/build /tmp


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

- Build Postgres from source with official PPA flags and graviton optimisations
- Improved performance in all 3 benchmarks over [generic build](https://github.com/supabase/postgres/pull/539#discussion_r1205295186).

| AMI Build       | TPCB-like  | select-only | simple-update | Flags        |
|-----------------|------------|-------------|---------------|--------------|
| `15.1.0.75`     | 150.575 ms | 6.591 ms    | 17.112 ms     | -mcpu=native |
| `15.1.0.86-rc1` | 112.694 ms | 6.608 ms    | 17.834 ms     | Official PPA |
| `15.1.0.89-rc1` | 109.967 ms | 6.126 ms    | 16.505 ms     | PPA + mcpu   |

All benchmarks are run on `m6g.xlarge` instances on staging, using pgbench with postgres 15.1.

## Additional context

tpcb-like: `109.967 ms`
```bash
postgres@db-agbqdybysfheblwajkpx:/home/ubuntu$ pgbench -c 100 -T 60 -b tpcb-like
pgbench (15.1 (Ubuntu 15.1-1.pgdg20.04+1))
starting vacuum...end.
transaction type: <builtin: TPC-B (sort of)>
scaling factor: 1
query mode: simple
number of clients: 100
number of threads: 1
maximum number of tries: 1
duration: 60 s
number of transactions actually processed: 54191
number of failed transactions: 0 (0.000%)
latency average = 109.967 ms
initial connection time = 610.771 ms
tps = 909.365320 (without initial connection time)
```

simple select: `6.126 ms`
```bash
postgres@db-agbqdybysfheblwajkpx:/home/ubuntu$ pgbench -c 100 -T 60 -b select-only
pgbench (15.1 (Ubuntu 15.1-1.pgdg20.04+1))
starting vacuum...end.
transaction type: <builtin: select only>
scaling factor: 1
query mode: simple
number of clients: 100
number of threads: 1
maximum number of tries: 1
duration: 60 s
number of transactions actually processed: 971096
number of failed transactions: 0 (0.000%)
latency average = 6.126 ms
initial connection time = 604.199 ms
tps = 16323.771087 (without initial connection time)
```

simple update: `16.505 ms`
```bash
postgres@db-agbqdybysfheblwajkpx:/home/ubuntu$ pgbench -c 100 -T 60 -b simple-update
pgbench (15.1 (Ubuntu 15.1-1.pgdg20.04+1))
starting vacuum...end.
transaction type: <builtin: simple update>
scaling factor: 1
query mode: simple
number of clients: 100
number of threads: 1
maximum number of tries: 1
duration: 60 s
number of transactions actually processed: 360550
number of failed transactions: 0 (0.000%)
latency average = 16.505 ms
initial connection time = 606.376 ms
tps = 6058.872750 (without initial connection time)
```