### PR TITLE
fix: update build and runtime dependencies for groonga

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -648,6 +648,19 @@ ADD --checksum=${groonga_release_checksum} \
     /tmp/groonga.tar.gz
 RUN tar -xvf /tmp/groonga.tar.gz -C /tmp && \
     rm -rf /tmp/groonga.tar.gz
+# Install build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    zlib1g-dev \
+    liblz4-dev \
+    libz-dev \
+    libzstd-dev \
+    libmsgpack-dev \
+    libzmq3-dev \
+    libevent-dev \
+    libmecab-dev \
+    mecab-naist-jdic \
+    pkg-config \
+    && rm -rf /var/lib/apt/lists/*
 # Build from source
 WORKDIR /tmp/groonga-${groonga_release}
 RUN ./configure
@@ -665,16 +678,12 @@ ADD --checksum=${pgroonga_release_checksum} \
     /tmp/pgroonga.tar.gz
 RUN tar -xvf /tmp/pgroonga.tar.gz -C /tmp && \
     rm -rf /tmp/pgroonga.tar.gz
-# Install build dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    pkg-config \
-    && rm -rf /var/lib/apt/lists/*
 # Build from source
 WORKDIR /tmp/pgroonga-${pgroonga_release}
 RUN --mount=type=cache,target=/ccache,from=public.ecr.aws/supabase/postgres:ccache \
     make -j$(nproc)
 # Create debian package
-RUN checkinstall -D --install=no --fstrans=no --backup=no --pakdir=/tmp --nodoc
+RUN checkinstall -D --install=no --fstrans=no --backup=no --pakdir=/tmp --requires=libmsgpackc2 --nodoc
 
 FROM scratch as pgroonga-deb
 COPY --from=pgroonga-source /tmp/*.deb /tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -652,13 +652,12 @@ RUN tar -xvf /tmp/groonga.tar.gz -C /tmp && \
 RUN apt-get update && apt-get install -y --no-install-recommends \
     zlib1g-dev \
     liblz4-dev \
-    libz-dev \
     libzstd-dev \
     libmsgpack-dev \
     libzmq3-dev \
     libevent-dev \
     libmecab-dev \
-    mecab-naist-jdic \
+    rapidjson-dev \
     pkg-config \
     && rm -rf /var/lib/apt/lists/*
 # Build from source
@@ -667,7 +666,7 @@ RUN ./configure
 RUN --mount=type=cache,target=/ccache,from=public.ecr.aws/supabase/postgres:ccache \
     make -j$(nproc)
 # Create debian package
-RUN checkinstall -D --install=yes --fstrans=no --backup=no --pakdir=/tmp --nodoc
+RUN checkinstall -D --install=yes --fstrans=no --backup=no --pakdir=/tmp --requires=zlib1g,liblz4-1,libzstd1,libmsgpackc2,libzmq5,libevent-2.1-7,libmecab2 --nodoc
 
 FROM groonga as pgroonga-source
 # Download and extract
@@ -683,7 +682,7 @@ WORKDIR /tmp/pgroonga-${pgroonga_release}
 RUN --mount=type=cache,target=/ccache,from=public.ecr.aws/supabase/postgres:ccache \
     make -j$(nproc)
 # Create debian package
-RUN checkinstall -D --install=no --fstrans=no --backup=no --pakdir=/tmp --requires=libmsgpackc2 --nodoc
+RUN checkinstall -D --install=no --fstrans=no --backup=no --pakdir=/tmp --nodoc
 
 FROM scratch as pgroonga-deb
 COPY --from=pgroonga-source /tmp/*.deb /tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -682,7 +682,7 @@ WORKDIR /tmp/pgroonga-${pgroonga_release}
 RUN --mount=type=cache,target=/ccache,from=public.ecr.aws/supabase/postgres:ccache \
     make -j$(nproc)
 # Create debian package
-RUN checkinstall -D --install=no --fstrans=no --backup=no --pakdir=/tmp --nodoc
+RUN checkinstall -D --install=no --fstrans=no --backup=no --pakdir=/tmp --requires=mecab-naist-jdic --nodoc
 
 FROM scratch as pgroonga-deb
 COPY --from=pgroonga-source /tmp/*.deb /tmp/

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.89"
+postgres-version = "15.1.0.90"


### PR DESCRIPTION
## What kind of change does this PR introduce?

relates to https://github.com/supabase/postgres/pull/462

## What is the new behavior?

- rebuilds groonga with same libraries as AMI

```bash
root@b410f42e11ab:/# groonga --version
Groonga 12.0.8 [linux-gnu,x86_64,utf8,match-escalation-threshold=0,nfkc,mecab,message-pack,onigmo,zlib,lz4,zstandard,epoll]

configure options: <>
```

## Additional context

 build information from [official PPA](https://groonga.org/docs/install/ubuntu.html)
```bash
root@bddd111bde15:/# groonga --version
Groonga 13.0.1 [linux-gnu,x86_64,utf8,match-escalation-threshold=0,nfkc,mecab,message-pack,mruby,onigmo,zlib,lz4,zstandard,epoll,rapidjson]

configure options: < '--build=x86_64-linux-gnu' '--prefix=/usr' '--includedir=${prefix}/include' '--mandir=${prefix}/share/man' '--infodir=${prefix}/share/info' '--sysconfdir=/etc' '--localstatedir=/var' '--disable-silent-rules' '--libdir=${prefix}/lib/x86_64-linux-gnu' '--libexecdir=${prefix}/lib/x86_64-linux-gnu' '--disable-maintainer-mode' '--disable-dependency-tracking' '--with-munin-plugins' '--enable-mruby' 'build_alias=x86_64-linux-gnu' 'CFLAGS=-g -O2 -fdebug-prefix-map=/build/groonga-w1u2kP/groonga-13.0.1=. -fstack-protector-strong -Wformat -Werror=format-security' 'LDFLAGS=-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now' 'CPPFLAGS=-Wdate-time -D_FORTIFY_SOURCE=2' 'CXXFLAGS=-g -O2 -fdebug-prefix-map=/build/groonga-w1u2kP/groonga-13.0.1=. -fstack-protector-strong -Wformat -Werror=format-security'>
```
