### PR TITLE
fix: path to shared postgres binaries

### DIFF
--- a/.github/workflows/ami-release.yml
+++ b/.github/workflows/ami-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - cleanup
     paths:
       - '.github/workflows/ami-release.yml'
       - 'common.vars.pkr.hcl'
@@ -137,7 +138,7 @@ jobs:
           target_commitish: ${{github.sha}}
 
       - name: Slack Notification on Failure
-        if: ${{ failure() }}
+        if: ${{ false }}
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_NOTIFICATIONS_WEBHOOK }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 # syntax=docker/dockerfile:1.5-labs
+ARG ubuntu_release=focal
 ARG postgresql_major=15
 ARG postgresql_release=${postgresql_major}.1
 
@@ -41,8 +42,9 @@ ARG wal_g_release=2.0.1
 ####################
 # Setup Postgres PPA
 ####################
-FROM ubuntu:focal as ppa
+FROM ubuntu:${ubuntu_release} as ppa
 # Redeclare args for use in subsequent stages
+ARG ubuntu_release
 ARG postgresql_major
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gnupg \
@@ -51,7 +53,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Add Postgres PPA
 ARG postgresql_gpg_key=B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "${postgresql_gpg_key}" && \
-    echo "deb https://apt-archive.postgresql.org/pub/repos/apt focal-pgdg-archive main" > /etc/apt/sources.list.d/pgdg.list
+    echo "deb https://apt-archive.postgresql.org/pub/repos/apt ${ubuntu_release}-pgdg-archive main" > /etc/apt/sources.list.d/pgdg.list
 
 ####################
 # Download pre-built postgres
@@ -75,9 +77,10 @@ RUN mv /var/cache/apt/archives/*.deb /tmp/
 ####################
 # Install postgres
 ####################
-FROM ubuntu:focal as base
+FROM ubuntu:${ubuntu_release} as base
 # Redeclare args for use in subsequent stages
 ARG TARGETARCH
+ARG ubuntu_release
 ARG postgresql_major
 
 # Install postgres
@@ -691,7 +694,7 @@ FROM base as pgroonga
 # Latest available is 3.0.3
 ARG pgroonga_release
 # Download pre-built packages
-ADD "https://packages.groonga.org/ubuntu/groonga-apt-source-latest-focal.deb" /tmp/source.deb
+ADD "https://packages.groonga.org/ubuntu/groonga-apt-source-latest-${ubuntu_release}.deb" /tmp/source.deb
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     /tmp/source.deb \
@@ -854,7 +857,7 @@ COPY --from=supautils /tmp/*.deb /tmp/
 ####################
 # Download gosu for easy step-down from root
 ####################
-FROM ubuntu:focal as gosu
+FROM ubuntu:${ubuntu_release} as gosu
 ARG TARGETARCH
 # Install dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/ansible/tasks/internal/collect-pg-binaries.yml
+++ b/ansible/tasks/internal/collect-pg-binaries.yml
@@ -6,7 +6,7 @@
 - name: Collect Postgres binaries - collect binaries and libraries
   copy:
     remote_src: yes
-    src: /usr/lib/postgresql/{{ item }}/
+    src: /usr/lib/postgresql/{{ postgresql_major }}/{{ item }}/
     dest: /tmp/pg_binaries/{{ postgresql_major }}/{{ item }}/
   with_items:
     - bin
@@ -15,7 +15,7 @@
 - name: Collect Postgres binaries - collect shared files
   copy:
     remote_src: yes
-    src: /var/lib/postgresql/
+    src: /usr/share/postgresql/{{ postgresql_major }}/
     dest: /tmp/pg_binaries/{{ postgresql_major }}/share/
 
 - name: Collect Postgres binaries - create tarfile

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.91"
+postgres-version = "15.1.0.92-rc1"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,7 +31,7 @@ ENV PYTHONDONTWRITEBYTECODE=1
 ENV DEB_BUILD_OPTIONS="nocheck parallel=$(nproc)"
 
 # Configure processor optimised build
-ARG CPPFLAGS="-mcpu=neoverse-n1"
+ARG CPPFLAGS
 ENV DEB_CPPFLAGS_APPEND="${CPPFLAGS} -fsigned-char"
 
 RUN apt-get build-dep -y postgresql-common pgdg-keyring && \


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix #539 

## What is the new behavior?

Moved shared path from `/var/lib/postgresql` to `/usr/share/postgresql/15` (PPA default)

TOOD:
- [ ] check if `/var/lib/postgresql/data` is correctly restored

## Additional context

Add any other context or screenshots.
