### PR TITLE
feat: add `auth` schema protections

### DIFF
--- a/migrations/db/migrations/20230607094822_add_auth_schema_protections.sql
+++ b/migrations/db/migrations/20230607094822_add_auth_schema_protections.sql
@@ -1,0 +1,115 @@
+-- migrate:up
+
+drop sequence if exists auth.changes_seq;
+
+create sequence
+  auth.changes_seq increment by 1;
+
+comment on sequence auth.changes_seq is 'Tracks the number of changes of the auth schema.';
+
+grant all on sequence
+  auth.changes_seq
+  to supabase_auth_admin
+  with grant option;
+
+drop sequence if exists auth.lock_seq;
+
+create sequence
+  auth.lock_seq increment by -1 no minvalue no maxvalue start with -1;
+  -- starting off with protection disabled
+
+comment on sequence auth.lock_seq is 'Used to protect against accidental schema changes in the auth schema.';
+
+grant all on sequence
+  auth.lock_seq
+  to supabase_auth_admin
+  with grant option;
+
+create or replace function
+  auth.enable_schema_ddl_protection()
+  returns void
+  language sql
+  as $$
+    alter sequence if exists auth.lock_seq increment by 1 no minvalue no maxvalue restart with 1;
+  $$;
+
+grant all on function
+  auth.enable_schema_ddl_protection()
+  to supabase_auth_admin
+  with grant option;
+
+create or replace function
+  auth.disable_schema_ddl_protection()
+  returns void
+  language sql
+  as $$
+    alter sequence if exists auth.lock_seq increment by -1 no minvalue no maxvalue restart with -1;
+  $$;
+
+grant all on function
+  auth.disable_schema_ddl_protection()
+  to supabase_auth_admin
+  with grant option;
+
+create or replace function
+  auth.schema_ddl_protection_command_end()
+  returns event_trigger
+  security definer
+  language plpgsql
+  as $$
+    declare
+      cmd record;
+    begin
+      for cmd in select * from pg_event_trigger_ddl_commands()
+      loop
+        if cmd.schema_name = 'auth' then
+          if nextval('auth.lock_seq') > 0 then
+            raise exception 'auth schema is protected from unintended changes. To unlock run SELECT auth.disable_schema_ddl_protection(); ';
+          end if;
+
+          perform nextval('auth.changes_seq');
+        end if;
+      end loop;
+    end;
+  $$;
+
+drop event trigger if exists protect_auth_schema_ddl_command_end;
+drop function if exists auth.schema_ddl_protection();
+
+create or replace function
+  auth.schema_ddl_protection_drop()
+  returns event_trigger
+  security definer
+  language plpgsql
+  as $$
+    declare
+      cmd record;
+    begin
+      for cmd in select * from pg_event_trigger_dropped_objects()
+      loop
+        if cmd.schema_name = 'auth' and cmd.object_identity not in ('auth.changes_seq', 'auth.lock_seq') then
+          if nextval('auth.lock_seq') > 0 then
+            raise exception 'auth schema is protected from unintended changes. To unlock run SELECT auth.disable_schema_ddl_protection(); ';
+          end if;
+
+          perform nextval('auth.changes_seq');
+        end if;
+      end loop;
+    end;
+  $$;
+
+drop event trigger if exists protect_auth_schema_ddl_command_end cascade;
+
+create event trigger
+  protect_auth_schema_ddl_command_end
+  on ddl_command_end
+  execute function auth.schema_ddl_protection_command_end();
+
+drop event trigger if exists protect_auth_schema_ddl_sql_drop cascade;
+
+create event trigger
+  protect_auth_schema_ddl_sql_drop
+  on sql_drop
+  execute function auth.schema_ddl_protection_drop();
+
+-- migrate:down

--- a/migrations/db/migrations/20230607094822_add_auth_schema_protections.sql
+++ b/migrations/db/migrations/20230607094822_add_auth_schema_protections.sql
@@ -103,7 +103,7 @@ create or replace function
         if cmd.schema_name = 'auth' then
           if cmd.object_identity in ('auth.lock_seq', 'auth.changes_seq') then
             raise notice 'Dropping % is likely to cause issues with other DDL commands in auth.schema! Please make sure all protect_auth_schema_ddl_... event triggers are removed first.', cmd.object_identity;
-          else if nextval('auth.lock_seq') > 0 then
+          elsif nextval('auth.lock_seq') > 0 then
             raise exception 'auth schema is protected from unintended changes. To unlock run SELECT auth.disable_schema_ddl_protection(); ';
           end if;
 


### PR DESCRIPTION
Adds an event trigger for DDL commands on the `auth` schema that:

- Prevents commands from running if `auth.enable_schema_ddl_protection()` has been called.
- Increments the sequence `auth.changes_seq` on each applied change.

These can be used by Supabase Auth to:

- Prevent users from accidentally changing the `auth` schema in a way that would break their project. Users can call `auth.disable_schema_ddl_protection()` at any time to make any changes they wish.
- Giving Supabase Auth the ability to detect that the schema has been changed so that when service interruption does occur, the root cause can be identified more easily.

Schema protection is disabled by default with this change, and will be enabled upon further testing with a new PR.