### PR TITLE
chore: enable swap on fly

### DIFF
--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.92"
+postgres-version = "15.1.0.94"

--- a/docker/all-in-one/entrypoint.sh
+++ b/docker/all-in-one/entrypoint.sh
@@ -37,6 +37,13 @@ function configure_services {
   done
 }
 
+function enable_swap {
+  fallocate -l 1G /mnt/swapfile
+  chmod 600 /mnt/swapfile
+  mkswap /mnt/swapfile
+  swapon /mnt/swapfile
+}
+
 PG_CONF=/etc/postgresql/postgresql.conf
 SUPERVISOR_CONF=/etc/supervisor/supervisord.conf
 
@@ -222,6 +229,10 @@ fi
 
 if [ "${AUTOSHUTDOWN_ENABLED:-}" ]; then
   sed -i "s/autostart=.*/autostart=true/" /etc/supervisor/db-only/supa-shutdown.conf
+fi
+
+if [ "${PLATFORM_DEPLOYMENT:-}" ]; then
+  enable_swap
 fi
 
 touch "$CONFIGURED_FLAG_PATH"


### PR DESCRIPTION
* Gated behind `$PLATFORM_DEPLOYMENT`
  * should probably start enabling features
* Skipping to `15.1.0.94` since apparently `15.1.0.93` was out already?