### PR TITLE
fix: correct permissions on pg_cron functions upon logical restoration

### DIFF
--- a/migrations/db/migrations/20220713082019_pg_cron-pg_net-temp-perms-fix.sql
+++ b/migrations/db/migrations/20220713082019_pg_cron-pg_net-temp-perms-fix.sql
@@ -14,6 +14,7 @@ BEGIN
   IF pg_cron_installed
   THEN
     grant usage on schema cron to postgres with grant option;
+    grant all on all functions in schema cron to postgres with grant option;
 
     alter default privileges in schema cron grant all on tables to postgres with grant option;
     alter default privileges in schema cron grant all on functions to postgres with grant option;


### PR DESCRIPTION
When restoring a logical backup of a project with `pg_cron` enabled, it can be observed that the `postgres` database user loses permissions to utilize the functions `cron.alter_job` and `cron.schedule_in_database` :
**Enabling pg_cron**
```
# functions found in the pg_cron extension
postgres=# SELECT proname, proacl FROM pg_proc WHERE proname in ('alter_job','schedule','schedule_in_database','unschedule');

       proname        |                                     proacl                                     
----------------------+--------------------------------------------------------------------------------
 alter_job            | {postgres=X*/supabase_admin,supabase_admin=X/supabase_admin}
 schedule             | {=X/supabase_admin,postgres=X*/supabase_admin,supabase_admin=X/supabase_admin}
 schedule             | {=X/supabase_admin,postgres=X*/supabase_admin,supabase_admin=X/supabase_admin}
 schedule_in_database | {postgres=X*/supabase_admin,supabase_admin=X/supabase_admin}
 unschedule           | {=X/supabase_admin,postgres=X*/supabase_admin,supabase_admin=X/supabase_admin}
 unschedule           | {=X/supabase_admin,postgres=X*/supabase_admin,supabase_admin=X/supabase_admin}
(6 rows)
```

**Restoring a project from a logical backup**
* Notice the missing `postgres=X*/supabase_admin` permission in `alter_job` and `schedule_in_database`.
```
postgres=# SELECT proname, proacl FROM pg_proc WHERE proname in ('alter_job','schedule','schedule_in_database','unschedule');
       proname        |                                     proacl                                     
----------------------+--------------------------------------------------------------------------------
 alter_job            | {supabase_admin=X/supabase_admin}
 schedule             | {=X/supabase_admin,supabase_admin=X/supabase_admin,postgres=X*/supabase_admin}
 schedule             | {=X/supabase_admin,supabase_admin=X/supabase_admin,postgres=X*/supabase_admin}
 schedule_in_database | {supabase_admin=X/supabase_admin}
 unschedule           | {=X/supabase_admin,supabase_admin=X/supabase_admin,postgres=X*/supabase_admin}
 unschedule           | {=X/supabase_admin,supabase_admin=X/supabase_admin,postgres=X*/supabase_admin}
(6 rows)
```
---
Solution put forward is to add the following query:
```
grant all on all functions in schema cron to postgres with grant option;
```
in `migrations/db/migrations/20220713082019_pg_cron-pg_net-temp-perms-fix.sql` which is run after every restoration. By doing this, it is ensured that the `postgres` database user has sufficient permissions to utilize `pg_cron`-made functions. Running the query above shows to restore the permission to the affected functions:
```
postgres=# grant all on all functions in schema cron to postgres with grant option;
GRANT
postgres=# SELECT proname, proacl FROM pg_proc WHERE proname in ('alter_job','schedule','schedule_in_database','unschedule');
       proname        |                                     proacl                                     
----------------------+--------------------------------------------------------------------------------
 alter_job            | {supabase_admin=X/supabase_admin,postgres=X*/supabase_admin}
 schedule             | {=X/supabase_admin,supabase_admin=X/supabase_admin,postgres=X*/supabase_admin}
 schedule             | {=X/supabase_admin,supabase_admin=X/supabase_admin,postgres=X*/supabase_admin}
 schedule_in_database | {supabase_admin=X/supabase_admin,postgres=X*/supabase_admin}
 unschedule           | {=X/supabase_admin,supabase_admin=X/supabase_admin,postgres=X*/supabase_admin}
 unschedule           | {=X/supabase_admin,supabase_admin=X/supabase_admin,postgres=X*/supabase_admin}
(6 rows)
```