### PR TITLE
fix: insert pgbouncer pg_hba entries before any other rules

### DIFF
--- a/ansible/tasks/setup-pgbouncer.yml
+++ b/ansible/tasks/setup-pgbouncer.yml
@@ -103,12 +103,12 @@
   lineinfile:
     path: /etc/postgresql/pg_hba.conf
     state: present
-    insertafter: '# Default:'
+    insertafter: '^# TYPE'
     line: "{{ item }}"
   with_items:
+    - "# Connection configuration for pgbouncer user"
     - "host  all  pgbouncer  0.0.0.0/0  reject"
     - "host  all  pgbouncer  127.0.0.1/32  scram-sha-256"
-    - "# Connection configuration for pgbouncer user"
 
 - name: PgBouncer - By default allow ssl connections.
   become: yes


### PR DESCRIPTION
* There is no line containing `# Default` in pg_hba.conf
* This change inserts the rules right before the other rules [here](https://github.com/supabase/postgres/blob/develop/ansible/files/postgresql_config/pg_hba.conf.j2#L79)