### PR TITLE
chore: remove pgBouncer pg_hba rules

### DIFF
--- a/ansible/tasks/setup-pgbouncer.yml
+++ b/ansible/tasks/setup-pgbouncer.yml
@@ -103,12 +103,12 @@
   lineinfile:
     path: /etc/postgresql/pg_hba.conf
     state: present
-    insertafter: '^# TYPE'
+    insertafter: '# Default:'
     line: "{{ item }}"
   with_items:
-    - "# Connection configuration for pgbouncer user"
     - "host  all  pgbouncer  0.0.0.0/0  reject"
     - "host  all  pgbouncer  127.0.0.1/32  scram-sha-256"
+    - "# Connection configuration for pgbouncer user"
 
 - name: PgBouncer - By default allow ssl connections.
   become: yes

--- a/ansible/tasks/setup-pgbouncer.yml
+++ b/ansible/tasks/setup-pgbouncer.yml
@@ -98,18 +98,6 @@
     dest: /etc/tmpfiles.d/pgbouncer.conf
   become: yes
 
-- name: PgBouncer - add permissions for pgbouncer user
-  become: yes
-  lineinfile:
-    path: /etc/postgresql/pg_hba.conf
-    state: present
-    insertafter: '# Default:'
-    line: "{{ item }}"
-  with_items:
-    - "host  all  pgbouncer  0.0.0.0/0  reject"
-    - "host  all  pgbouncer  127.0.0.1/32  scram-sha-256"
-    - "# Connection configuration for pgbouncer user"
-
 - name: PgBouncer - By default allow ssl connections.
   become: yes
   copy:

--- a/docker/all-in-one/etc/postgresql/pg_hba.conf
+++ b/docker/all-in-one/etc/postgresql/pg_hba.conf
@@ -78,10 +78,6 @@
 
 # TYPE  DATABASE        USER            ADDRESS                 METHOD
 
-# Connection configuration for pgbouncer user
-host  all  pgbouncer  127.0.0.1/32  scram-sha-256
-host  all  pgbouncer  0.0.0.0/0  reject
-
 # trust local connections
 local all  supabase_admin     scram-sha-256
 local all  all                peer map=supabase_map


### PR DESCRIPTION
* Removed pgBouncer rules present in pg_hba for both AWS AMIs and AIO Docker images, allowing all incoming connections for this user