### PR TITLE
Upgrade pg_graphql to v1.2.3

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -105,7 +105,7 @@ libsodium_release_checksum: sha256:6f504490b342a4f8a4c4a02fc9b866cbef8622d5df4e5
 pgsodium_release: "3.1.7"
 pgsodium_release_checksum: sha256:0a10aeda67d35cc7228b98c87d71ed6ebddfd51f037772eb373ec7e1e1626b8f
 
-pg_graphql_release: "1.2.2"
+pg_graphql_release: "1.2.3"
 
 pg_jsonschema_release: "0.1.4"
 

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.101"
+postgres-version = "15.1.0.102"


### PR DESCRIPTION
## What kind of change does this PR introduce?
Upgrade pg_graphql to v1.2.3 resolving bug

https://github.com/supabase/pg_graphql/issues/377

This is a significant issue as it blocks schema introspection and need to be rolled out as soon as possible