### PR TITLE
chore: bump gotrue version to v2.82.4

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -14,8 +14,8 @@ postgrest_release: "11.1.0"
 postgrest_arm_release_checksum: sha1:70b8d5a2589450f8aff2f68ef6b7c2b85f0ccc8a
 postgrest_x86_release_checksum: sha1:c3eeb95c9054e9a94738deec78179abd19125824
 
-gotrue_release: 2.82.1
-gotrue_release_checksum: sha1:04ccc43cd42501a79284105974c8965b4e0cfed1
+gotrue_release: 2.82.4
+gotrue_release_checksum: sha1:7cfa5f06406b5eb7d37c07c935bad5a5e53e4c53
 
 aws_cli_release: "2.2.7"
 

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.102"
+postgres-version = "15.1.0.103"


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Bump gotrue to the v2.82.4