### PR TITLE
fix: set lc_collate to c.utf-8 explicitly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,6 +100,7 @@ ENV PGDATA=/var/lib/postgresql/data
 RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG=en_US.UTF-8
 ENV LC_CTYPE=C.UTF-8
+ENV LC_COLLATE=C.UTF-8
 
 FROM base as builder
 # Install build dependencies

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.103"
+postgres-version = "15.1.0.104"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

`LC_COLLATE` is set to `C.UTF-8` on AMI

```bash
postgres=> show lc_collate;
 lc_collate
------------
 C.UTF-8
```

But docker build uses `en_US.UTF-8`. This affects how strings are sorted etc.

## Additional context

Add any other context or screenshots.

resolves https://github.com/supabase/cli/issues/1309
