### PR TITLE
chore: fix for sar making sure directory is available before service …

### DIFF
--- a/ansible/tasks/setup-system.yml
+++ b/ansible/tasks/setup-system.yml
@@ -32,6 +32,11 @@
     update-alternatives --set ebtables /usr/sbin/ebtables-nft
     systemctl restart ufw
 
+- name: Create Sysstat log directory
+  file:
+    path: /var/log/sysstat
+    state: directory
+    
 - name: Install other useful tools
   apt:
     pkg:
@@ -48,10 +53,6 @@
     src: files/default.sysstat
     dest: /etc/default/sysstat
 
-- name: Create Sysstat log directory
-  file:
-    path: /var/log/sysstat
-    state: directory
 
 - name: Adjust APT update intervals
   copy:

--- a/scripts/91-log_cleanup.sh
+++ b/scripts/91-log_cleanup.sh
@@ -4,6 +4,9 @@
 echo "Clearing all log files"
 rm -rf /var/log/*
 
+# creating system stats directory 
+mkdir /var/log/sysstat
+
 # https://github.com/fail2ban/fail2ban/issues/1593
 touch /var/log/auth.log
 


### PR DESCRIPTION
changing when the directory for sysstat gets created to insure it exists before the service starts

## What kind of change does this PR introduce?
Bug fix: should ensure sysstat logs are in the correct locations 
