### PR TITLE
chore: Adding Envoy to the all-in-one image, not running be default

### DIFF
--- a/docker/all-in-one/Dockerfile
+++ b/docker/all-in-one/Dockerfile
@@ -8,6 +8,7 @@ ARG adminapi_release=0.46.0
 ARG adminmgr_release=0.5.0
 ARG vector_release=0.22.3
 ARG postgres_exporter_release=0.9.0
+ARG envoy_release=1.26.0
 
 FROM supabase/postgres:${postgres_version} as base
 ARG TARGETARCH
@@ -69,6 +70,15 @@ ADD "https://download.konghq.com/gateway-2.x-ubuntu-focal/pool/all/k/kong/kong_$
     /tmp/kong.deb
 
 ####################
+# Install Envoy
+####################
+FROM base as envoy
+ARG envoy_release
+ADD "https://github.com/envoyproxy/envoy/releases/download/v${envoy_release}/envoy-${envoy_release}-linux-aarch_64" /tmp/envoy.app
+RUN chmod +x /tmp/envoy.app
+
+
+####################
 # Install admin api
 ####################
 FROM base as adminapi
@@ -122,6 +132,7 @@ COPY --from=pgbouncer /tmp/*.deb /tmp/
 COPY --from=vector /tmp/*.deb /tmp/
 COPY --from=kong /tmp/*.deb /tmp/
 COPY --from=supervisor /tmp/*.deb /tmp/
+COPY --from=envoy /tmp/*.app /tmp/
 
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -145,6 +156,7 @@ COPY --from=pgrst /bin/postgrest /opt/
 COPY --from=gotrue /usr/local/bin/gotrue /opt/gotrue/
 COPY --from=gotrue /usr/local/etc/gotrue /opt/gotrue/
 COPY --from=adminapi /tmp/supabase-admin-api /opt/
+COPY --from=envoy /tmp/envoy.app /usr/local/bin/envoy
 COPY --chown=root:root --from=adminmgr /tmp/admin-mgr /usr/bin/
 COPY --from=exporter /tmp/postgres_exporter /opt/postgres_exporter/
 COPY docker/all-in-one/opt/postgres_exporter /opt/postgres_exporter/
@@ -185,6 +197,9 @@ COPY docker/all-in-one/etc/gotrue.env /etc/gotrue.env
 COPY docker/all-in-one/etc/kong/kong.conf /etc/kong/kong.conf
 COPY docker/all-in-one/etc/kong/kong.yml /etc/kong/kong.yml
 
+# Configuration for envoy
+COPY docker/all-in-one/etc/envoy/envoy.yml /etc/envoy/envoy.yml
+
 # Customizations for vector
 COPY --chown=vector:vector docker/all-in-one/etc/vector/vector.yaml /etc/vector/vector.yaml
 
@@ -222,9 +237,10 @@ ENV VECTOR_API_PORT=9001
 # Create system users
 RUN useradd --create-home --shell /bin/bash postgrest && \
     useradd --create-home --shell /bin/bash gotrue && \
+    useradd --create-home --shell /bin/bash envoy && \
     useradd --create-home --shell /bin/bash pgbouncer -G postgres,ssl-cert && \
     # root,admin,kong,pgbouncer,postgres,postgrest,systemd-journal,wal-g
-    useradd --create-home --shell /bin/bash adminapi -G root,kong,pgbouncer,postgres,postgrest,wal-g && \
+    useradd --create-home --shell /bin/bash adminapi -G root,kong,envoy,pgbouncer,postgres,postgrest,wal-g && \
     usermod --append --shell /bin/bash -G postgres vector
 RUN mkdir -p /etc/wal-g && \
     chown -R adminapi:adminapi /etc/wal-g && \

--- a/docker/all-in-one/README.md
+++ b/docker/all-in-one/README.md
@@ -3,9 +3,9 @@
 All Supabase backend services bundled in a single Docker image for quick local testing and edge deployment.
 
 ## Build
-
+## build is set from postgres root so use the followign command to build
 ```bash
-docker build . -t supabase/all-in-one
+docker build -t supabase/all-in-one -f docker/all-in-one/Dockerfile .
 ```
 
 ## Run
@@ -13,6 +13,8 @@ docker build . -t supabase/all-in-one
 ```bash
 docker run --rm \
     -e POSTGRES_PASSWORD=postgres \
+    -e DATA_VOLUME_MOUNTPOINT=/data \
+    -e MACHINE_TYPE=shared_cpu_1x_1g \
     -e JWT_SECRET=super-secret-jwt-token-with-at-least-32-characters-long \
     -e ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJhbm9uIiwKICAgICJpc3MiOiAic3VwYWJhc2UtZGVtbyIsCiAgICAiaWF0IjogMTY0MTc2OTIwMCwKICAgICJleHAiOiAxNzk5NTM1NjAwCn0.dc_X5iR_VP_qT0zsiyj_I_OZ2T9FtRU2BBNWN8Bu4GE \
     -e SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJzZXJ2aWNlX3JvbGUiLAogICAgImlzcyI6ICJzdXBhYmFzZS1kZW1vIiwKICAgICJpYXQiOiAxNjQxNzY5MjAwLAogICAgImV4cCI6IDE3OTk1MzU2MDAKfQ.DaYlNEoUrrEn2Ig7tqibS-PHK5vgusbcbo7X36XVt4Q \

--- a/docker/all-in-one/etc/envoy/envoy.yml
+++ b/docker/all-in-one/etc/envoy/envoy.yml
@@ -1,0 +1,136 @@
+static_resources:
+  listeners:
+  - name: listener_0
+    address:
+      socket_address: { address: 0.0.0.0, port_value: 80 }
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: ingress_http
+          access_log:
+              - name: envoy.clearaccess_log
+                typed_config:
+                  "@type": "type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog"
+                  log_format:
+                    json_format:
+                      authority: '%REQ(:AUTHORITY)%'
+                      bytes_received: '%BYTES_RECEIVED%'
+                      bytes_sent: '%BYTES_SENT%'
+                      connection_termination_details: '%CONNECTION_TERMINATION_DETAILS%'
+                      downstream_local_address: '%DOWNSTREAM_LOCAL_ADDRESS%'
+                      downstream_remote_address: '%DOWNSTREAM_REMOTE_ADDRESS%'
+                      duration: '%DURATION%'
+                      method: '%REQ(:METHOD)%'
+                      path: '%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%'
+                      protocol: '%PROTOCOL%'
+                      request_id: '%REQ(X-REQUEST-ID)%'
+                      requested_server_name: '%REQUESTED_SERVER_NAME%'
+                      response_code: '%RESPONSE_CODE%'
+                      response_code_details: '%RESPONSE_CODE_DETAILS%'
+                      response_flags: '%RESPONSE_FLAGS%'
+                      route_name: '%ROUTE_NAME%'
+                      start_time: '%START_TIME%'
+                      upstream_cluster: '%UPSTREAM_CLUSTER%'
+                      upstream_host: '%UPSTREAM_HOST%'
+                      upstream_local_address: '%UPSTREAM_LOCAL_ADDRESS%'
+                      upstream_service_time: '%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%'
+                      upstream_transport_failure_reason: '%UPSTREAM_TRANSPORT_FAILURE_REASON%'
+                      user_agent: '%REQ(USER-AGENT)%'
+                      x_forwarded_for: '%REQ(X-FORWARDED-FOR)%'
+          codec_type: AUTO
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains: ["*"]
+              routes:
+              - match:
+                  prefix: "/health"
+                direct_response:
+                  status: 200
+                  body:
+                    inline_string: "Healthy"
+              - match:
+                  prefix: "/rest/v1/"
+                  headers:
+                  - name: apikey
+                    safe_regex_match:
+                      google_re2: { "max_program_size": 700}
+                      regex: "service_key|supabase_admin_key|anon_key"
+                route:
+                  cluster: rest
+                  prefix_rewrite: "/"
+              - match:
+                  prefix: "/auth/v1/admin/"
+                  headers:
+                  - name: apikey
+                    safe_regex_match:
+                      google_re2: { "max_program_size": 700}
+                      regex: "service_key|supabase_admin_key|anon_key"
+                route:
+                  cluster: gotrue
+                  prefix_rewrite: "/"
+              - match:
+                  prefix: "/auth/v1/"
+                route:
+                  cluster: gotrue
+                  prefix_rewrite: "/"
+              - match:
+                  prefix: "/pg/"
+                  headers:
+                  - name: apikey
+                    safe_regex_match:
+                      google_re2: { "max_program_size": 700}
+                      regex: "service_key|supabase_admin_key|anon_key"
+                route:
+                  cluster: pg-v1
+                  prefix_rewrite: "/"
+          http_filters:
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+  clusters:
+  - name: gotrue
+    connect_timeout: 0.25s
+    type: STATIC
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: gotrue
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 9998
+
+  - name: rest
+    connect_timeout: 0.25s
+    type: STATIC
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: rest
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 3000
+
+  - name: pg-v1
+    connect_timeout: 0.25s
+    type: STATIC
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: pg-v1
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 1337

--- a/docker/all-in-one/etc/supervisor/services/envoy.conf
+++ b/docker/all-in-one/etc/supervisor/services/envoy.conf
@@ -1,0 +1,8 @@
+[program:envoy]
+command=bash -c '/usr/local/bin/envoy --config-path /etc/envoy/envoy.yml | tee'
+user=envoy
+autorestart=false
+autostart=false
+stdout_logfile=/var/log/services/envoy.log
+redirect_stderr=true
+stdout_logfile_maxbytes=10MB

--- a/docker/all-in-one/init/configure-envoy.sh
+++ b/docker/all-in-one/init/configure-envoy.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -eou pipefail
+
+ENVOY_CONF=/etc/envoy/envoy.yml
+touch /var/log/services/envoy.log
+
+
+
+
+if [ -f "${INIT_PAYLOAD_PATH:-}" ]; then
+  echo "init envoy payload"
+  # Setup ssl termination
+  tar -xzvf "$INIT_PAYLOAD_PATH" -C / ./etc/envoy/
+  chown -R adminapi:adminapi ./etc/envoy/envoy.yml
+  #chown -R adminapi:adminapi ./etc/envoy/*pem
+  #echo "ssl_cipher_suite = intermediate" >> /etc/envoy/kong.conf
+  #echo "ssl_cert = /etc/kong/fullChain.pem" >> /etc/kong/kong.conf
+  #echo "ssl_cert_key = /etc/kong/privKey.pem" >> /etc/kong/kong.conf
+else
+  # Default gateway config
+  export KONG_DNS_ORDER=LAST,A,CNAME
+  export KONG_PROXY_ERROR_LOG=syslog:server=unix:/dev/log
+  export KONG_ADMIN_ERROR_LOG=syslog:server=unix:/dev/log
+fi
+
+# Inject project specific configuration
+sed -i -e "s|anon_key|$ANON_KEY|g" \
+  -e "s|service_key|$SERVICE_ROLE_KEY|g" \
+  -e "s|supabase_admin_key|$ADMIN_API_KEY|g" \
+  $ENVOY_CONF
+
+# Update envoy ports
+sed -i "s|80 |:$KONG_HTTP_PORT |g" /etc/envoy/envoy.yml
+sed -i "s|443 |:$KONG_HTTPS_PORT |g" /etc/envoy/envoy.yml

--- a/docker/all-in-one/init/configure-envoy.sh
+++ b/docker/all-in-one/init/configure-envoy.sh
@@ -30,5 +30,5 @@ sed -i -e "s|anon_key|$ANON_KEY|g" \
   $ENVOY_CONF
 
 # Update envoy ports
-sed -i "s|80 |:$KONG_HTTP_PORT |g" /etc/envoy/envoy.yml
-sed -i "s|443 |:$KONG_HTTPS_PORT |g" /etc/envoy/envoy.yml
+sed -i "s|80 |$KONG_HTTP_PORT |g" /etc/envoy/envoy.yml
+sed -i "s|443 |$KONG_HTTPS_PORT |g" /etc/envoy/envoy.yml


### PR DESCRIPTION
## What kind of change does this PR introduce?
This is adding envoy as service to the all-in-one docker image. Envoy is is not enabled by default and should not effect/change any functionality with the container at the moment but will make it easier to change between them when testing envoy at fly.
Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
