### PR TITLE
Bump pgvector to 0.4.4

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -129,8 +129,7 @@ hypopg_release_checksum: sha256:e7f01ee0259dc1713f318a108f987663d60f3041948c2ada
 pg_repack_release: "1.4.8"
 pg_repack_release_checksum: sha256:18b4d871c1abf78cf0b1b1fe6081d435d183a8dc5eb977576e7a47fe113dd4ec
 
-pgvector_release: "0.4.0"
-pgvector_release_checksum: sha256:b76cf84ddad452cc880a6c8c661d137ddd8679c000a16332f4f03ecf6e10bcc8
+pgvector_release: "0.4.4"
 
 pg_tle_release: "1.0.4"
 pg_tle_release_checksum: sha256:679559584d83fb629c3b56825849fca4ff1fa3355b350aaaf8aa0b7b3460b08a


### PR DESCRIPTION
(Checksum is not used in install, so I removed it)
