### PR TITLE
feat: bump image version (pgsodium 3.1.8)

### DIFF
--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.105"
+postgres-version = "15.1.0.106"


### PR DESCRIPTION
Followup to https://github.com/supabase/postgres/pull/702 (image version didn't get bumped)