### PR TITLE
fix: ensure default PG logrotate config is removed

### DIFF
--- a/ansible/tasks/finalize-ami.yml
+++ b/ansible/tasks/finalize-ami.yml
@@ -71,6 +71,11 @@
     - { file: "logrotate-walg.conf" }
     - { file: "logrotate-postgres-auth.conf" }
 
+- name: Ensure default Postgres logrotate config is removed
+  file:
+    path: /etc/logrotate.d/postgresql-common
+    state: absent
+
 - name: Disable cron access
   copy:
     src: files/cron.deny

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.110"
+postgres-version = "15.1.0.111-rc1"

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.111-rc1"
+postgres-version = "15.1.0.111"


### PR DESCRIPTION
## What kind of change does this PR introduce?

* Removed default logrotate config installed by Postgres, as it clashes with our custom logrotate configs