### PR TITLE
chore: bump postgrest to v11.2.0

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgresql_release_checksum: sha256:ea2cf059a85882654b989acd07edc121833164a30340
 pgbouncer_release: "1.19.0"
 pgbouncer_release_checksum: sha256:af0b05e97d0e1fd9ad45fe00ea6d2a934c63075f67f7e2ccef2ca59e3d8ce682
 
-postgrest_release: "11.1.0"
-postgrest_arm_release_checksum: sha1:70b8d5a2589450f8aff2f68ef6b7c2b85f0ccc8a
-postgrest_x86_release_checksum: sha1:c3eeb95c9054e9a94738deec78179abd19125824
+postgrest_release: "11.2.0"
+postgrest_arm_release_checksum: sha1:42496254d6fb8aa5660b8b7586f1e6a40977e319
+postgrest_x86_release_checksum: sha1:6c09ba1b97830e794a28ad7e475f7f8d20e759cc
 
 gotrue_release: 2.92.0
 gotrue_release_checksum: sha1:f7b08877557fe6559d6ef36f8d50d1974e8e923b


### PR DESCRIPTION
https://github.com/PostgREST/postgrest/releases/tag/v11.2.0