### PR TITLE
feat: bump supautils to v1.8.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ ARG hypopg_release=1.3.1
 ARG pg_repack_release=1.4.8
 ARG pgvector_release=0.4.0
 ARG pg_tle_release=1.0.3
-ARG supautils_release=1.7.2
+ARG supautils_release=1.8.0
 ARG wal_g_release=2.0.1
 
 ####################

--- a/ansible/files/postgresql_config/supautils.conf.j2
+++ b/ansible/files/postgresql_config/supautils.conf.j2
@@ -7,6 +7,6 @@ supautils.privileged_extensions = 'address_standardizer, address_standardizer_da
 supautils.privileged_extensions_custom_scripts_path = '/etc/postgresql-custom/extension-custom-scripts'
 supautils.privileged_extensions_superuser = 'supabase_admin'
 supautils.privileged_role = 'postgres'
-supautils.privileged_role_allowed_configs = 'pgaudit.log, pgaudit.log_catalog, pgaudit.log_client, pgaudit.log_level, pgaudit.log_relation, pgaudit.log_rows, pgaudit.log_statement, pgaudit.log_statement_once, pgaudit.role, pgrst.*, session_replication_role, track_io_timing'
+supautils.privileged_role_allowed_configs = 'log_min_messages, pgaudit.log, pgaudit.log_catalog, pgaudit.log_client, pgaudit.log_level, pgaudit.log_relation, pgaudit.log_rows, pgaudit.log_statement, pgaudit.log_statement_once, pgaudit.role, pgrst.*, session_replication_role, track_io_timing'
 supautils.reserved_memberships = 'pg_read_server_files, pg_write_server_files, pg_execute_server_program, authenticator'
 supautils.reserved_roles = 'supabase_admin, supabase_auth_admin, supabase_storage_admin, supabase_read_only_user, supabase_replication_admin, dashboard_user, pgbouncer, service_role*, authenticator*, authenticated*, anon*'

--- a/ansible/files/postgresql_extension_custom_scripts/before-create.sql
+++ b/ansible/files/postgresql_extension_custom_scripts/before-create.sql
@@ -1,4 +1,11 @@
--- If extension is a TLE, create extension dependencies in supautils.privileged_extensions.
+-- If the following are true:
+-- * the extension to be created is a TLE
+-- * the extension is created with `cascade`
+--
+-- then we pre-`create` all nested extension dependencies which are part of
+-- `supautils.privileged_extensions`. This is because supautils can't intercept
+-- the extension creation for dependencies - it can only intercept the `create
+-- extension` statement.
 do $$
 declare
   _extname text := @extname@;

--- a/ansible/files/postgresql_extension_custom_scripts/before-create.sql
+++ b/ansible/files/postgresql_extension_custom_scripts/before-create.sql
@@ -1,0 +1,77 @@
+-- If extension is a TLE, create extension dependencies in supautils.privileged_extensions.
+do $$
+declare
+  _extname text := @extname@;
+  _extschema text := @extschema@;
+  _extversion text := @extversion@;
+  _extcascade bool := @extcascade@;
+  _r record;
+begin
+  if not _extcascade then
+    return;
+  end if;
+
+  if not exists (select from pg_extension where extname = 'pg_tle') then
+    return;
+  end if;
+
+  if not exists (select from pgtle.available_extensions() where name = _extname) then
+    return;
+  end if;
+
+  if _extversion is null then
+    select default_version
+    from pgtle.available_extensions()
+    where name = _extname
+    into _extversion;
+  end if;
+
+  if _extschema is null then
+    select schema
+    from pgtle.available_extension_versions()
+    where name = _extname and version = _extversion
+    into _extschema;
+  end if;
+
+  for _r in (
+    with recursive available_extensions(name, default_version) as (
+      select name, default_version
+      from pg_available_extensions
+      union
+      select name, default_version
+      from pgtle.available_extensions()
+    )
+    , available_extension_versions(name, version, requires) as (
+      select name, version, requires
+      from pg_available_extension_versions
+      union
+      select name, version, requires
+      from pgtle.available_extension_versions()
+    )
+    , all_dependencies(name, dependency) as (
+      select e.name, unnest(ev.requires) as dependency
+      from available_extensions e
+      join available_extension_versions ev on ev.name = e.name and ev.version = e.default_version
+    )
+    , dependencies(name) AS (
+        select unnest(requires)
+        from available_extension_versions
+        where name = _extname and version = _extversion
+        union
+        select all_dependencies.dependency
+        from all_dependencies
+        join dependencies d on d.name = all_dependencies.name
+    )
+    select name
+    from dependencies
+    intersect
+    select name
+    from regexp_split_to_table(current_setting('supautils.privileged_extensions', true), '\s*,\s*') as t(name)
+  ) loop
+    if _extschema is null then
+      execute(format('create extension if not exists %I cascade', _r.name));
+    else
+      execute(format('create extension if not exists %I schema %I cascade', _r.name, _extschema));
+    end if;
+  end loop;
+end $$;

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -77,8 +77,8 @@ timescaledb_release_checksum: sha256:883638f2e79d25ec88ee58f603f3c81c999b6364cb4
 wal2json_release: "2_5"
 wal2json_release_checksum: sha256:b516653575541cf221b99cf3f8be9b6821f6dbcfc125675c85f35090f824f00e
 
-supautils_release: "1.7.2"
-supautils_release_checksum: sha256:527e645112e1348ea4b6be6740037b444797fbbc5d3ed98103ca582419e06084
+supautils_release: "1.8.0"
+supautils_release_checksum: sha256:63e82826179bf2ceac33abd73fccbd915b7d0f92438a46b59c90b9f4c9274cef
 
 pljava_release: master
 pljava_release_checksum: sha256:e99b1c52f7b57f64c8986fe6ea4a6cc09d78e779c1643db060d0ac66c93be8b6

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.113"
+postgres-version = "15.1.0.114-supautils"

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.114-supautils"
+postgres-version = "15.1.0.114"


### PR DESCRIPTION
## What kind of change does this PR introduce?

- upgrade supautils from v1.7.2 to v1.8.0
- add `log_min_messages` to allowed configs

## Action Items

- [x] **New extension releases** were Checked for any breaking changes
- [x] **Extensions compatibility** Checked
    * Proceed to [extensions compatibility testing](#extensions-compatibility-testing), mark as done after everything is completed
- [x] **Backup and Restore** Checked
    * Proceed to [backup testing](#backup-testing) while extensions are enabled
        - After every restore, re-run the tests specified at point [3.1](#extensions-compatibility-testing)

### Extensions compatibility testing

1. Enable every extension
    1. Check Postgres’ log output for any error messages while doing so
        1. This might unearth incompatibilities due to unsupported internal functions, missing libraries, or missing permissions
2. Disable every extension
    1. Check Postgres’ log output for any cleanup-related error messages
3. Re-enable each extension
    1. Run basic tests against the features they offer, e.g.:
        1. `pg_net` - execute HTTP requests
        2. `pg_graphql` - execute queries and mutations
        3. …to be filled in

### Backup Testing

Follow the testing steps steps for all the following cases:

- Pause on new Postgres version, restore on new Postgres version
- Pause on older Postgres version, restore on new Postgres version
- Run a single-file backup backup, restore the backup

#### Testing steps

1. Generate dummy data 
    * the ‘Countries’ or ‘Slack clone’ SQL editor snippets are decent datasets to work with, albeit limited
2. Save a db stats snapshot file
    * Do this by running `supa db-stats gather -p <project_ref>`
3. Backup the database, through pausing the project, or otherwise
4. Restore the backup, through unpausing the project or cli
5. Check the data has been recovered successfully
    1. Visual checks/navigating through the tables works
    2. Run `supa db-stats verify` against the project and the previously saved file