### PR TITLE
Adds pg archivecleanup

### DIFF
--- a/ansible/files/postgresql_config/postgresql.conf.j2
+++ b/ansible/files/postgresql_config/postgresql.conf.j2
@@ -259,7 +259,7 @@ checkpoint_flush_after = 256kB		# measured in pages, 0 disables
 				# placeholders: %p = path of file to restore
 				#               %f = file name only
 				# e.g. 'cp /mnt/server/archivedir/%f %p'
-#archive_cleanup_command = ''	# command to execute at every restartpoint
+archive_cleanup_command = 'echo "$(date) - pg_archivecleanup %r" >> /var/lib/postgresql/data/pg_archivecleanup.log && pg_archivecleanup /var/lib/postgresql/data/pg_wal %r' # command to execute at every restartpoint
 #recovery_end_command = ''	# command to execute at completion of recovery
 
 # - Recovery Target -

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.116"
+postgres-version = "15.1.0.117-archivecleanup"


### PR DESCRIPTION
### What
Adds pg_archivecleanup command to delete unused WAL on each checkpoint.

Currently it also logs to a file every time the command executes so we can investigate how frequently its running but that will be removed before this (maybe) merges.

### Why
 users frequently try to reclaim disk space by deleting or truncating tables to stay under supabase disk usage limits. They are surprised to find that up to 4 GB of disk usage is potentially consumed by WAL files. Those files are ultimately recycled, but they can't be removed, so the dbsize does not appear to be under user control. pg_archivecleanup is a utility that deletes WAL files no longer referenced (including by replication slots).