### PR TITLE
fix: add per image scope to gha cache

### DIFF
--- a/.github/workflows/ami-release.yml
+++ b/.github/workflows/ami-release.yml
@@ -46,8 +46,8 @@ jobs:
           target: extensions
           tags: supabase/postgres:extensions
           platforms: linux/${{ matrix.arch }}
-          cache-from: type=gha,scope=${{ github.ref_name }}-extensions
-          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-extensions
+          cache-from: type=gha,scope=${{ github.ref_name }}-extensions-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-extensions-${{ matrix.arch }}
       - name: Extract built packages
         run: |
           mkdir -p /tmp/extensions ansible/files/extensions
@@ -72,8 +72,8 @@ jobs:
             CPPFLAGS=-mcpu=${{ matrix.mcpu }}
           tags: supabase/postgres:deb
           platforms: linux/${{ matrix.arch }}
-          cache-from: type=gha,scope=${{ github.ref_name }}-deb
-          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-deb
+          cache-from: type=gha,scope=${{ github.ref_name }}-deb-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-deb-${{ matrix.arch }}
       - name: Extract Postgres deb
         run: |
           mkdir -p /tmp/build ansible/files/postgres

--- a/.github/workflows/ami-release.yml
+++ b/.github/workflows/ami-release.yml
@@ -47,8 +47,8 @@ jobs:
           target: extensions
           tags: supabase/postgres:extensions
           platforms: linux/${{ matrix.arch }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ github.ref_name }}-extensions
+          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-extensions
       - name: Extract built packages
         run: |
           mkdir -p /tmp/extensions ansible/files/extensions
@@ -74,8 +74,8 @@ jobs:
             CPPFLAGS=-mcpu=${{ matrix.mcpu }}
           tags: supabase/postgres:deb
           platforms: linux/${{ matrix.arch }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ github.ref_name }}-deb
+          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-deb
       - name: Extract Postgres deb
         run: |
           mkdir -p /tmp/build ansible/files/postgres

--- a/.github/workflows/ami-release.yml
+++ b/.github/workflows/ami-release.yml
@@ -35,12 +35,11 @@ jobs:
         with:
           cmd: yq 'to_entries | map(select(.value|type == "!!str")) |  map(.key + "=" + .value) | join("\n")' 'ansible/vars.yml'
       - run: docker context create builders
-      - uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-buildx-action@v3
         with:
           endpoint: builders
-      - uses: docker/build-push-action@v3
+      - uses: docker/build-push-action@v5
         with:
-          push: false
           load: true
           build-args: |
             ${{ steps.args.outputs.result }}
@@ -60,9 +59,8 @@ jobs:
       - id: version
         run: echo "${{ steps.args.outputs.result }}" | grep "postgresql" >> "$GITHUB_OUTPUT"
       - name: Build Postgres deb
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
-          push: false
           load: true
           file: docker/Dockerfile
           target: pg-deb

--- a/.github/workflows/ami-release.yml
+++ b/.github/workflows/ami-release.yml
@@ -46,8 +46,8 @@ jobs:
           target: extensions
           tags: supabase/postgres:extensions
           platforms: linux/${{ matrix.arch }}
-          cache-from: type=gha,scope=${{ github.ref_name }}-extensions-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-extensions-${{ matrix.arch }}
+          cache-from: type=gha,scope=${{ github.ref_name }}-latest-${{ matrix.arch }}
+          # No need to export extensions cache because latest depends on it
       - name: Extract built packages
         run: |
           mkdir -p /tmp/extensions ansible/files/extensions
@@ -72,8 +72,8 @@ jobs:
             CPPFLAGS=-mcpu=${{ matrix.mcpu }}
           tags: supabase/postgres:deb
           platforms: linux/${{ matrix.arch }}
-          cache-from: type=gha,scope=${{ github.ref_name }}-deb-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-deb-${{ matrix.arch }}
+          cache-from: type=gha,scope=${{ github.ref_name }}-deb
+          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-deb
       - name: Extract Postgres deb
         run: |
           mkdir -p /tmp/build ansible/files/postgres

--- a/.github/workflows/build-ccache.yml
+++ b/.github/workflows/build-ccache.yml
@@ -44,7 +44,7 @@ jobs:
       image_digest: ${{ steps.build.outputs.digest }}
     steps:
       - run: docker context create builders
-      - uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-buildx-action@v3
         with:
           endpoint: builders
       - name: Configure AWS credentials - prod
@@ -56,7 +56,7 @@ jobs:
         with:
           registry: public.ecr.aws
       - id: build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           push: true
           target: buildcache
@@ -70,7 +70,7 @@ jobs:
     needs: build_image
     runs-on: ubuntu-latest
     steps:
-      - uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-buildx-action@v3
       - name: Configure AWS credentials - prod
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/collect-u18-binaries.yml
+++ b/.github/workflows/collect-u18-binaries.yml
@@ -49,7 +49,6 @@ jobs:
           endpoint: builders
       - uses: docker/build-push-action@v5
         with:
-          push: false
           load: true
           file: Dockerfile-u18
           build-args: |
@@ -73,7 +72,6 @@ jobs:
       - name: Build Postgres deb
         uses: docker/build-push-action@v5
         with:
-          push: false
           load: true
           file: docker/Dockerfile
           target: pg-deb
@@ -98,7 +96,6 @@ jobs:
       - name: Build surrogate Docker image
         uses: docker/build-push-action@v5
         with:
-          push: false
           load: true
           file: Dockerfile-u18
           target: pg_binary_collection

--- a/.github/workflows/collect-u18-binaries.yml
+++ b/.github/workflows/collect-u18-binaries.yml
@@ -44,10 +44,10 @@ jobs:
         with:
           cmd: yq 'to_entries | map(select(.value|type == "!!str")) |  map(.key + "=" + .value) | join("\n")' 'ansible/vars.yml'
       - run: docker context create builders
-      - uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-buildx-action@v3
         with:
-          endpoint: builders          
-      - uses: docker/build-push-action@v3
+          endpoint: builders
+      - uses: docker/build-push-action@v5
         with:
           push: false
           load: true
@@ -57,8 +57,8 @@ jobs:
           target: extensions
           tags: supabase/postgres:extensions-u18
           platforms: linux/${{ matrix.arch }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=${{ github.ref_name }}-extensions-u18
+          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-extensions-u18,ignore-error=true
 
       - name: Extract built packages
         run: |
@@ -71,7 +71,7 @@ jobs:
       - id: version
         run: echo "${{ steps.args.outputs.result }}" | grep "postgresql" >> "$GITHUB_OUTPUT"
       - name: Build Postgres deb
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           push: false
           load: true
@@ -85,8 +85,8 @@ jobs:
             DEB_BUILD_PROFILES=pkg.postgresql.nozstd
           tags: supabase/postgres:deb-u18
           platforms: linux/${{ matrix.arch }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=${{ github.ref_name }}-deb-u18
+          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-deb-u18,ignore-error=true
       - name: Extract Postgres deb
         run: |
           mkdir -p /tmp/build ansible/files/postgres
@@ -94,9 +94,9 @@ jobs:
           for layer in /tmp/build/*/layer.tar; do
             tar xvf "$layer" -C ansible/files/postgres --strip-components 1
           done
-        
+
       - name: Build surrogate Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           push: false
           load: true
@@ -109,8 +109,8 @@ jobs:
             postgresql_release=${{ steps.version.outputs.postgresql_release }}
           tags: supabase/postgres:u18-binaries
           platforms: linux/${{ matrix.arch }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=${{ github.ref_name }}-u18-binaries
+          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-u18-binaries,ignore-error=true
 
       - name: Copy binary tarball
         run: |

--- a/.github/workflows/dockerhub-release-aio.yml
+++ b/.github/workflows/dockerhub-release-aio.yml
@@ -81,7 +81,7 @@ jobs:
     needs: [settings, build_image]
     runs-on: ubuntu-latest
     steps:
-      - uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/dockerhub-release-aio.yml
+++ b/.github/workflows/dockerhub-release-aio.yml
@@ -47,7 +47,7 @@ jobs:
       image_digest: ${{ steps.build.outputs.digest }}
     steps:
       - run: docker context create builders
-      - uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-buildx-action@v3
         with:
           endpoint: builders
       - uses: docker/login-action@v2
@@ -55,7 +55,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - id: build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           file: docker/all-in-one/Dockerfile
           push: true
@@ -65,8 +65,8 @@ jobs:
           target: production
           tags: ${{ needs.settings.outputs.image_tag }}_${{ matrix.arch }}
           platforms: linux/${{ matrix.arch }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ github.ref_name }}-aio
+          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-aio
       - name: Slack Notification
         if: ${{ failure() }}
         uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/dockerhub-release-aio.yml
+++ b/.github/workflows/dockerhub-release-aio.yml
@@ -65,8 +65,8 @@ jobs:
           target: production
           tags: ${{ needs.settings.outputs.image_tag }}_${{ matrix.arch }}
           platforms: linux/${{ matrix.arch }}
-          cache-from: type=gha,scope=${{ github.ref_name }}-aio
-          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-aio
+          cache-from: type=gha,scope=${{ github.ref_name }}-aio-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-aio-${{ matrix.arch }}
       - name: Slack Notification
         if: ${{ failure() }}
         uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/dockerhub-release.yml
+++ b/.github/workflows/dockerhub-release.yml
@@ -40,7 +40,7 @@ jobs:
       image_digest: ${{ steps.build.outputs.digest }}
     steps:
       - run: docker context create builders
-      - uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-buildx-action@v3
         with:
           endpoint: builders
       - uses: docker/login-action@v2
@@ -48,7 +48,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - id: build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           push: true
           build-args: |
@@ -56,8 +56,8 @@ jobs:
           target: production
           tags: ${{ needs.settings.outputs.image_tag }}_${{ matrix.arch }}
           platforms: linux/${{ matrix.arch }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ github.ref_name }}-latest
+          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-latest
       - name: Slack Notification
         if: ${{ failure() }}
         uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/dockerhub-release.yml
+++ b/.github/workflows/dockerhub-release.yml
@@ -56,8 +56,8 @@ jobs:
           target: production
           tags: ${{ needs.settings.outputs.image_tag }}_${{ matrix.arch }}
           platforms: linux/${{ matrix.arch }}
-          cache-from: type=gha,scope=${{ github.ref_name }}-latest
-          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-latest
+          cache-from: type=gha,scope=${{ github.ref_name }}-latest-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-latest-${{ matrix.arch }}
       - name: Slack Notification
         if: ${{ failure() }}
         uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/dockerhub-release.yml
+++ b/.github/workflows/dockerhub-release.yml
@@ -72,7 +72,7 @@ jobs:
     needs: [settings, build_image]
     runs-on: ubuntu-latest
     steps:
-      - uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/package-plv8.yml
+++ b/.github/workflows/package-plv8.yml
@@ -43,7 +43,7 @@ jobs:
       image_digest: ${{ steps.build.outputs.digest }}
     steps:
       - run: docker context create builders
-      - uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-buildx-action@v3
         with:
           endpoint: builders
       - uses: docker/login-action@v2
@@ -52,7 +52,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - id: build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           push: true
           target: plv8-deb
@@ -64,7 +64,7 @@ jobs:
     needs: [settings, build_image]
     runs-on: ubuntu-latest
     steps:
-      - uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v2
         with:
           registry: ghcr.io

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,20 +29,21 @@ jobs:
           cmd: yq 'to_entries | map(select(.value|type == "!!str")) |  map(.key + "=" + .value) | join("\n")' 'ansible/vars.yml'
 
       - run: docker context create builders
-      - uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-buildx-action@v3
         with:
           endpoint: builders
-      - uses: docker/build-push-action@v3
+      - uses: docker/build-push-action@v5
         with:
-          push: false
           load: true
           context: .
           target: production
           build-args: |
             ${{ steps.args.outputs.result }}
           tags: supabase/postgres:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: |
+            type=gha,scope=${{ github.ref_name }}-latest
+            type=gha,scope=${{ github.base_ref }}-latest
+          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-latest
 
       - name: Start Postgres
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,9 +41,9 @@ jobs:
             ${{ steps.args.outputs.result }}
           tags: supabase/postgres:latest
           cache-from: |
-            type=gha,scope=${{ github.ref_name }}-latest
-            type=gha,scope=${{ github.base_ref }}-latest
-          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-latest
+            type=gha,scope=${{ github.ref_name }}-latest-${{ matrix.arch }}
+            type=gha,scope=${{ github.base_ref }}-latest-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-latest-${{ matrix.arch }}
 
       - name: Start Postgres
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.5-labs
+# syntax=docker/dockerfile:1.6
 ARG postgresql_major=15
 ARG postgresql_release=${postgresql_major}.1
 


### PR DESCRIPTION
Since we are building multiple docker images from this repo, we need to specify [scope](https://docs.docker.com/build/cache/backends/gha/#scope) to avoid GHA from overriding the cache across different image builds.