### PR TITLE
chore: bump postgrest to v11.2.1

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgresql_release_checksum: sha256:ea2cf059a85882654b989acd07edc121833164a30340
 pgbouncer_release: "1.19.0"
 pgbouncer_release_checksum: sha256:af0b05e97d0e1fd9ad45fe00ea6d2a934c63075f67f7e2ccef2ca59e3d8ce682
 
-postgrest_release: "11.2.0"
-postgrest_arm_release_checksum: sha1:42496254d6fb8aa5660b8b7586f1e6a40977e319
-postgrest_x86_release_checksum: sha1:6c09ba1b97830e794a28ad7e475f7f8d20e759cc
+postgrest_release: "11.2.1"
+postgrest_arm_release_checksum: sha1:d5d7f846977c0da8a92e644752aa5831bab4d316
+postgrest_x86_release_checksum: sha1:381078de33bf12c868c33c040488d6ad76fd197e
 
 gotrue_release: 2.99.0
 gotrue_release_checksum: sha1:2076accd8546612aae1f741b0335b9895cce1f01

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.122"
+postgres-version = "15.1.0.123"


### PR DESCRIPTION
Patch version for postgREST, see
https://github.com/PostgREST/postgrest/releases/tag/v11.2.1.