### PR TITLE
Allow replication in pg_hba for pg_basebackup

### DIFF
--- a/docker/all-in-one/etc/postgresql/pg_hba.conf
+++ b/docker/all-in-one/etc/postgresql/pg_hba.conf
@@ -89,3 +89,7 @@ host  all  all  10.0.0.0/8  scram-sha-256
 host  all  all  172.16.0.0/12  scram-sha-256
 host  all  all  192.168.0.0/16  scram-sha-256
 host  all  all  0.0.0.0/0     scram-sha-256
+
+# Allow replication for pg_basebackup
+host  replication  all        trust
+host  replication  0.0.0.0/0  scram-sha-256 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add an entry in `pg_hba.conf` to allow replication connections. This allows fast andeasy backups using pg_basebackup (`pg_basebackup -D /tmp/mybasebackup -U postgres -h 127.0.0.1`)

## What is the current behavior?

Trying to create backups with pg_basebackup fails due to the lack of permissions for replication ("all" does not match replication, as the comment in pg_hba.conf states)

## What is the new behavior?

Backups using pg_basebackup can be created without authentication inside the container and with password authentication outside the container

## Additional context

Creating backups with a classic dump can be challenging with all the features supabase uses in Postgres. Basebackups copy the whole data directory of the Postgres instance and can easily (and fast!) be restored by copying it back.