### PR TITLE
fix: grant authenticator to supabase_storage_admin

### DIFF
--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.124"
+postgres-version = "15.1.0.125"

--- a/migrations/db/migrations/20231013070755_grant_authenticator_to_supabase_storage_admin.sql
+++ b/migrations/db/migrations/20231013070755_grant_authenticator_to_supabase_storage_admin.sql
@@ -1,0 +1,5 @@
+-- migrate:up
+grant authenticator to supabase_storage_admin;
+revoke anon, authenticated, service_role from supabase_storage_admin;
+
+-- migrate:down

--- a/migrations/tests/storage/privs.sql
+++ b/migrations/tests/storage/privs.sql
@@ -1,3 +1,1 @@
-select is_member_of('anon', 'supabase_storage_admin');
-select is_member_of('authenticated', 'supabase_storage_admin');
-select is_member_of('service_role', 'supabase_storage_admin');
+select is_member_of('authenticator', 'supabase_storage_admin');

--- a/migrations/tests/test.sql
+++ b/migrations/tests/test.sql
@@ -5,7 +5,7 @@ BEGIN;
 
 CREATE EXTENSION IF NOT EXISTS pgtap;
 
-SELECT plan(36);
+SELECT plan(34);
 
 \ir fixtures.sql
 \ir database/test.sql


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`supabase_storage_admin` can't assume custom PostgREST roles: https://github.com/supabase/storage-api/issues/369

## What is the new behavior?

`supabase_storage_admin` can assume custom PostgREST roles


Smoke tested on a personal project:
- upload a file to a private bucket
- create signed url
- view file from signed url