### PR TITLE
Chore: adding sysctl params for rebooting the OS after oomkiller kill…

### DIFF
--- a/ansible/tasks/setup-system.yml
+++ b/ansible/tasks/setup-system.yml
@@ -131,3 +131,18 @@
     mode: 0644
     owner: root
     group: root
+
+#Set Sysctl params for restarting the OS on oom after 10
+- name: Set vm.panic_on_oom=1
+  ansible.builtin.sysctl:
+    name: vm.panic_on_oom
+    value: '1'
+    state: present
+    reload: yes
+
+- name: Set kernel.panic=10
+  ansible.builtin.sysctl:
+    name: kernel.panic
+    value: '10'
+    state: present
+    reload: yes


### PR DESCRIPTION
adding sysctl params to restart the system on OOM.
tested the machine does restart on OOM.

Please go the the `Preview` tab and select the appropriate sub-template:

* [Default](?expand=1&template=default.md)
* [Extension Upgrade](?expand=1&template=extension_upgrade.md)