### PR TITLE
chore: temporarily disable AMI tests

### DIFF
--- a/.github/workflows/testinfra.yml
+++ b/.github/workflows/testinfra.yml
@@ -30,6 +30,7 @@ jobs:
           pytest -vv testinfra/test_all_in_one.py
 
   test-ami:
+    if: false
     strategy:
       matrix:
         include:


### PR DESCRIPTION
Pending on https://www.notion.so/supabase/Insufficient-perms-on-self-hosted-runner-s-AWS-role-to-launch-instance-f951e5bd750440c189ab5a1c6b9055dd?pvs=4