### PR TITLE
fix: readd missing step to ubuntu 18 binary collection workflow

### DIFF
--- a/.github/workflows/collect-u18-binaries.yml
+++ b/.github/workflows/collect-u18-binaries.yml
@@ -39,6 +39,12 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
+      - name: Grab release version
+        id: process_release_version
+        run: |
+          VERSION=$(sed -e 's/postgres-version = "\(.*\)"/\1/g' common.vars.pkr.hcl)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
       - id: args
         uses: mikefarah/yq@master
         with:


### PR DESCRIPTION
Please go the the `Preview` tab and select the appropriate sub-template:

* [Default](?expand=1&template=default.md)
* [Extension Upgrade](?expand=1&template=extension_upgrade.md)