### PR TITLE
fix: directly copy file instead of streaming to stdin

### DIFF
--- a/.github/workflows/collect-u18-binaries.yml
+++ b/.github/workflows/collect-u18-binaries.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Copy binary tarball
         run: |
           CONTAINER_ID=$(docker create supabase/postgres:u18-binaries)
-          docker cp "${CONTAINER_ID}:/tmp/pg_binaries/${{ matrix.ubuntu_version }}.tar.gz" - > /tmp/pg_binaries.tar.gz
+          docker cp "${CONTAINER_ID}:/tmp/pg_binaries/${{ matrix.ubuntu_version }}.tar.gz" /tmp/pg_binaries.tar.gz
           docker rm "${CONTAINER_ID}"
 
       - name: configure aws credentials - staging

--- a/.github/workflows/collect-u18-binaries.yml
+++ b/.github/workflows/collect-u18-binaries.yml
@@ -39,6 +39,12 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
+      - name: Grab release version
+        id: process_release_version
+        run: |
+          VERSION=$(sed -e 's/postgres-version = "\(.*\)"/\1/g' common.vars.pkr.hcl)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
       - id: args
         uses: mikefarah/yq@master
         with:


### PR DESCRIPTION
* Streaming to stdin has the habit of tarballing the targeted file, ending up with nested tarballs