### PR TITLE
chore: remove postgres role perms post-upgrade

### DIFF
--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/complete.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/complete.sh
@@ -45,6 +45,8 @@ function complete_pg_upgrade {
     echo "4. Running generated SQL files"
     retry 3 run_generated_sql
 
+    run_sql -c "ALTER USER postgres WITH NOSUPERUSER;"
+
     echo "4.1. Applying authentication scheme updates"
     retry 3 apply_auth_scheme_updates
 

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.130"
+postgres-version = "15.1.0.131"


### PR DESCRIPTION
* pg_upgrade requires superuser perms
* we grant postgres superuser perms pre-upgrade
* perms are ported over to the new instance through the migrated data dir