### PR TITLE
fix: wrappers workaround if files are the same

### DIFF
--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
@@ -266,7 +266,10 @@ function initiate_upgrade {
             OLD_WRAPPER_LIB_PATH=$(find "$PGLIBOLD" -name "wrappers*so" -print -quit)
             if [ -f "$OLD_WRAPPER_LIB_PATH" ]; then
                 LIB_FILE_NAME=$(basename "$OLD_WRAPPER_LIB_PATH")
-                cp "$WRAPPERS_LIB_PATH" "$PGLIBNEW/${LIB_FILE_NAME}"
+                if [ "$WRAPPERS_LIB_PATH" != "$PGLIBNEW/${LIB_FILE_NAME}" ]; then
+                    echo "Copying $OLD_WRAPPER_LIB_PATH to $WRAPPERS_LIB_PATH"
+                    cp "$OLD_WRAPPER_LIB_PATH" "$WRAPPERS_LIB_PATH"
+                fi
             fi
         fi
     fi


### PR DESCRIPTION
* If wrappers is already at the latest version, the lib naming workaround fails with the following error:
* `cp: '/tmp/pg_upgrade_bin/15/lib/wrappers-0.1.18.so' and '/tmp/pg_upgrade_bin/15/lib/wrappers-0.1.18.so' are the same file`