### PR TITLE
fix: pg_cron perms

### DIFF
--- a/ansible/files/postgresql_extension_custom_scripts/pg_cron/after-create.sql
+++ b/ansible/files/postgresql_extension_custom_scripts/pg_cron/after-create.sql
@@ -1,0 +1,13 @@
+grant usage on schema cron to postgres with grant option;
+grant all on all functions in schema cron to postgres with grant option;
+
+alter default privileges for user supabase_admin in schema cron grant all
+    on sequences to postgres with grant option;
+alter default privileges for user supabase_admin in schema cron grant all
+    on tables to postgres with grant option;
+alter default privileges for user supabase_admin in schema cron grant all
+    on functions to postgres with grant option;
+
+grant all privileges on all tables in schema cron to postgres with grant option;
+revoke all on table cron.job from postgres;
+grant select on table cron.job to postgres with grant option;

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.131"
+postgres-version = "15.1.0.132"

--- a/migrations/db/migrations/20231020085357_revoke_writes_on_cron_job_from_postgres.sql
+++ b/migrations/db/migrations/20231020085357_revoke_writes_on_cron_job_from_postgres.sql
@@ -1,0 +1,47 @@
+-- migrate:up
+do $$
+begin
+  if exists (select from pg_extension where extname = 'pg_cron') then
+    revoke all on table cron.job from postgres;
+    grant select on table cron.job to postgres with grant option;
+  end if;
+end $$;
+
+CREATE OR REPLACE FUNCTION extensions.grant_pg_cron_access() RETURNS event_trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  IF EXISTS (
+    SELECT
+    FROM pg_event_trigger_ddl_commands() AS ev
+    JOIN pg_extension AS ext
+    ON ev.objid = ext.oid
+    WHERE ext.extname = 'pg_cron'
+  )
+  THEN
+    grant usage on schema cron to postgres with grant option;
+
+    alter default privileges in schema cron grant all on tables to postgres with grant option;
+    alter default privileges in schema cron grant all on functions to postgres with grant option;
+    alter default privileges in schema cron grant all on sequences to postgres with grant option;
+
+    alter default privileges for user supabase_admin in schema cron grant all
+        on sequences to postgres with grant option;
+    alter default privileges for user supabase_admin in schema cron grant all
+        on tables to postgres with grant option;
+    alter default privileges for user supabase_admin in schema cron grant all
+        on functions to postgres with grant option;
+
+    grant all privileges on all tables in schema cron to postgres with grant option;
+    revoke all on table cron.job from postgres;
+    grant select on table cron.job to postgres with grant option;
+  END IF;
+END;
+$$;
+
+drop event trigger if exists issue_pg_cron_access;
+CREATE EVENT TRIGGER issue_pg_cron_access ON ddl_command_end
+         WHEN TAG IN ('CREATE EXTENSION')
+   EXECUTE FUNCTION extensions.grant_pg_cron_access();
+
+-- migrate:down

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -210,17 +210,14 @@ $$;
 CREATE FUNCTION extensions.grant_pg_cron_access() RETURNS event_trigger
     LANGUAGE plpgsql
     AS $$
-DECLARE
-  schema_is_cron bool;
 BEGIN
-  schema_is_cron = (
-    SELECT n.nspname = 'cron'
+  IF EXISTS (
+    SELECT
     FROM pg_event_trigger_ddl_commands() AS ev
-    LEFT JOIN pg_catalog.pg_namespace AS n
-      ON ev.objid = n.oid
-  );
-
-  IF schema_is_cron
+    JOIN pg_extension AS ext
+    ON ev.objid = ext.oid
+    WHERE ext.extname = 'pg_cron'
+  )
   THEN
     grant usage on schema cron to postgres with grant option;
 
@@ -236,9 +233,9 @@ BEGIN
         on functions to postgres with grant option;
 
     grant all privileges on all tables in schema cron to postgres with grant option;
-
+    revoke all on table cron.job from postgres;
+    grant select on table cron.job to postgres with grant option;
   END IF;
-
 END;
 $$;
 
@@ -1018,7 +1015,7 @@ CREATE EVENT TRIGGER issue_graphql_placeholder ON sql_drop
 --
 
 CREATE EVENT TRIGGER issue_pg_cron_access ON ddl_command_end
-         WHEN TAG IN ('CREATE SCHEMA')
+         WHEN TAG IN ('CREATE EXTENSION')
    EXECUTE FUNCTION extensions.grant_pg_cron_access();
 
 


### PR DESCRIPTION
Only grant `select` on `cron.job` to `postgres`. Also, make `grant_pg_cron_access` run on `CREATE EXTENSION` instead of `CREATE SCHEMA`, otherwise we can't run `revoke` on tables (since the tables haven't been created yet).