### PR TITLE
chore: configure aws creds before running tests

### DIFF
--- a/.github/workflows/testinfra.yml
+++ b/.github/workflows/testinfra.yml
@@ -123,6 +123,7 @@ jobs:
       #     packer build -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${GITHUB_RUN_ID}" -var-file="development-arm.vars.pkr.hcl" -var-file="common.vars.pkr.hcl" -var "ansible_arguments=" -var "postgres-version=ci-ami-test" -var "region=ap-southeast-1" -var 'ami_regions=["ap-southeast-1"]' -var "force-deregister=true" amazon-arm64.pkr.hcl
 
       - name: Run tests
+        timeout-minutes: 5
         run: |
           # TODO: use poetry for pkg mgmt
           pip3 install boto3 boto3-stubs[essential] docker ec2instanceconnectcli pytest pytest-testinfra[paramiko,docker] requests

--- a/.github/workflows/testinfra.yml
+++ b/.github/workflows/testinfra.yml
@@ -49,84 +49,78 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
 
-      - id: args
-        uses: mikefarah/yq@master
-        with:
-          cmd: yq 'to_entries | map(select(.value|type == "!!str")) |  map(.key + "=" + .value) | join("\n")' 'ansible/vars.yml'
+      # - id: args
+      #   uses: mikefarah/yq@master
+      #   with:
+      #     cmd: yq 'to_entries | map(select(.value|type == "!!str")) |  map(.key + "=" + .value) | join("\n")' 'ansible/vars.yml'
 
-      - run: docker context create builders
+      # - run: docker context create builders
 
-      - uses: docker/setup-buildx-action@v3
-        with:
-          endpoint: builders
+      # - uses: docker/setup-buildx-action@v3
+      #   with:
+      #     endpoint: builders
 
-      - uses: docker/build-push-action@v5
-        with:
-          load: true
-          build-args: |
-            ${{ steps.args.outputs.result }}
-          target: extensions
-          tags: supabase/postgres:extensions
-          platforms: linux/${{ matrix.arch }}
-          cache-from: |
-            type=gha,scope=${{ github.ref_name }}-extensions
-            type=gha,scope=${{ github.base_ref }}-extensions
-            type=gha,scope=develop-extensions
-          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-extensions
+      # - uses: docker/build-push-action@v5
+      #   with:
+      #     load: true
+      #     build-args: |
+      #       ${{ steps.args.outputs.result }}
+      #     target: extensions
+      #     tags: supabase/postgres:extensions
+      #     platforms: linux/${{ matrix.arch }}
+      #     cache-from: |
+      #       type=gha,scope=${{ github.ref_name }}-extensions
+      #       type=gha,scope=${{ github.base_ref }}-extensions
+      #       type=gha,scope=develop-extensions
+      #     cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-extensions
 
-      - name: Extract built packages
-        run: |
-          mkdir -p /tmp/extensions ansible/files/extensions
-          docker save supabase/postgres:extensions | tar xv -C /tmp/extensions
-          for layer in /tmp/extensions/*/layer.tar; do
-            tar xvf "$layer" -C ansible/files/extensions --strip-components 1
-          done
+      # - name: Extract built packages
+      #   run: |
+      #     mkdir -p /tmp/extensions ansible/files/extensions
+      #     docker save supabase/postgres:extensions | tar xv -C /tmp/extensions
+      #     for layer in /tmp/extensions/*/layer.tar; do
+      #       tar xvf "$layer" -C ansible/files/extensions --strip-components 1
+      #     done
 
-      - id: version
-        run: echo "${{ steps.args.outputs.result }}" | grep "postgresql" >> "$GITHUB_OUTPUT"
+      # - id: version
+      #   run: echo "${{ steps.args.outputs.result }}" | grep "postgresql" >> "$GITHUB_OUTPUT"
 
-      - name: Build Postgres deb
-        uses: docker/build-push-action@v5
-        with:
-          load: true
-          file: docker/Dockerfile
-          target: pg-deb
-          build-args: |
-            ubuntu_release=${{ matrix.ubuntu_release }}
-            ubuntu_release_no=${{ matrix.ubuntu_version }}
-            postgresql_major=${{ steps.version.outputs.postgresql_major }}
-            postgresql_release=${{ steps.version.outputs.postgresql_release }}
-            CPPFLAGS=-mcpu=${{ matrix.mcpu }}
-          tags: supabase/postgres:deb
-          platforms: linux/${{ matrix.arch }}
-          cache-from: |
-            type=gha,scope=${{ github.ref_name }}-deb
-            type=gha,scope=${{ github.base_ref }}-deb
-            type=gha,scope=develop-deb
-          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-deb
+      # - name: Build Postgres deb
+      #   uses: docker/build-push-action@v5
+      #   with:
+      #     load: true
+      #     file: docker/Dockerfile
+      #     target: pg-deb
+      #     build-args: |
+      #       ubuntu_release=${{ matrix.ubuntu_release }}
+      #       ubuntu_release_no=${{ matrix.ubuntu_version }}
+      #       postgresql_major=${{ steps.version.outputs.postgresql_major }}
+      #       postgresql_release=${{ steps.version.outputs.postgresql_release }}
+      #       CPPFLAGS=-mcpu=${{ matrix.mcpu }}
+      #     tags: supabase/postgres:deb
+      #     platforms: linux/${{ matrix.arch }}
+      #     cache-from: |
+      #       type=gha,scope=${{ github.ref_name }}-deb
+      #       type=gha,scope=${{ github.base_ref }}-deb
+      #       type=gha,scope=develop-deb
+      #     cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-deb
 
-      - name: Extract Postgres deb
-        run: |
-          mkdir -p /tmp/build ansible/files/postgres
-          docker save supabase/postgres:deb | tar xv -C /tmp/build
-          for layer in /tmp/build/*/layer.tar; do
-            tar xvf "$layer" -C ansible/files/postgres --strip-components 1
-          done
+      # - name: Extract Postgres deb
+      #   run: |
+      #     mkdir -p /tmp/build ansible/files/postgres
+      #     docker save supabase/postgres:deb | tar xv -C /tmp/build
+      #     for layer in /tmp/build/*/layer.tar; do
+      #       tar xvf "$layer" -C ansible/files/postgres --strip-components 1
+      #     done
 
-      # Packer doesn't support skipping registering the AMI for the ebssurrogate
-      # builder, so we register an AMI with a fixed name and run tests on an
-      # instance launched from that
-      # https://github.com/hashicorp/packer/issues/4899
-      - name: Build AMI
-        run: |
-          GIT_SHA=${{github.sha}}
-          packer build -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${GITHUB_RUN_ID}" -var-file="development-arm.vars.pkr.hcl" -var-file="common.vars.pkr.hcl" -var "ansible_arguments=" -var "postgres-version=ci-ami-test" -var "region=ap-southeast-1" -var 'ami_regions=["ap-southeast-1"]' -var "force-deregister=true" amazon-arm64.pkr.hcl
-
-      - name: configure aws credentials - staging
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          role-to-assume: ${{ secrets.DEV_AWS_ROLE }}
-          aws-region: "us-east-1"
+      # # Packer doesn't support skipping registering the AMI for the ebssurrogate
+      # # builder, so we register an AMI with a fixed name and run tests on an
+      # # instance launched from that
+      # # https://github.com/hashicorp/packer/issues/4899
+      # - name: Build AMI
+      #   run: |
+      #     GIT_SHA=${{github.sha}}
+      #     packer build -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${GITHUB_RUN_ID}" -var-file="development-arm.vars.pkr.hcl" -var-file="common.vars.pkr.hcl" -var "ansible_arguments=" -var "postgres-version=ci-ami-test" -var "region=ap-southeast-1" -var 'ami_regions=["ap-southeast-1"]' -var "force-deregister=true" amazon-arm64.pkr.hcl
 
       - name: Run tests
         run: |

--- a/.github/workflows/testinfra.yml
+++ b/.github/workflows/testinfra.yml
@@ -30,7 +30,6 @@ jobs:
           pytest -vv testinfra/test_all_in_one.py
 
   test-ami:
-    if: false
     strategy:
       matrix:
         include:
@@ -122,6 +121,12 @@ jobs:
         run: |
           GIT_SHA=${{github.sha}}
           packer build -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${GITHUB_RUN_ID}" -var-file="development-arm.vars.pkr.hcl" -var-file="common.vars.pkr.hcl" -var "ansible_arguments=" -var "postgres-version=ci-ami-test" -var "region=ap-southeast-1" -var 'ami_regions=["ap-southeast-1"]' -var "force-deregister=true" amazon-arm64.pkr.hcl
+
+      - name: configure aws credentials - staging
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.DEV_AWS_ROLE }}
+          aws-region: "us-east-1"
 
       - name: Run tests
         run: |

--- a/.github/workflows/testinfra.yml
+++ b/.github/workflows/testinfra.yml
@@ -49,78 +49,78 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
 
-      # - id: args
-      #   uses: mikefarah/yq@master
-      #   with:
-      #     cmd: yq 'to_entries | map(select(.value|type == "!!str")) |  map(.key + "=" + .value) | join("\n")' 'ansible/vars.yml'
+      - id: args
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq 'to_entries | map(select(.value|type == "!!str")) |  map(.key + "=" + .value) | join("\n")' 'ansible/vars.yml'
 
-      # - run: docker context create builders
+      - run: docker context create builders
 
-      # - uses: docker/setup-buildx-action@v3
-      #   with:
-      #     endpoint: builders
+      - uses: docker/setup-buildx-action@v3
+        with:
+          endpoint: builders
 
-      # - uses: docker/build-push-action@v5
-      #   with:
-      #     load: true
-      #     build-args: |
-      #       ${{ steps.args.outputs.result }}
-      #     target: extensions
-      #     tags: supabase/postgres:extensions
-      #     platforms: linux/${{ matrix.arch }}
-      #     cache-from: |
-      #       type=gha,scope=${{ github.ref_name }}-extensions
-      #       type=gha,scope=${{ github.base_ref }}-extensions
-      #       type=gha,scope=develop-extensions
-      #     cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-extensions
+      - uses: docker/build-push-action@v5
+        with:
+          load: true
+          build-args: |
+            ${{ steps.args.outputs.result }}
+          target: extensions
+          tags: supabase/postgres:extensions
+          platforms: linux/${{ matrix.arch }}
+          cache-from: |
+            type=gha,scope=${{ github.ref_name }}-extensions
+            type=gha,scope=${{ github.base_ref }}-extensions
+            type=gha,scope=develop-extensions
+          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-extensions
 
-      # - name: Extract built packages
-      #   run: |
-      #     mkdir -p /tmp/extensions ansible/files/extensions
-      #     docker save supabase/postgres:extensions | tar xv -C /tmp/extensions
-      #     for layer in /tmp/extensions/*/layer.tar; do
-      #       tar xvf "$layer" -C ansible/files/extensions --strip-components 1
-      #     done
+      - name: Extract built packages
+        run: |
+          mkdir -p /tmp/extensions ansible/files/extensions
+          docker save supabase/postgres:extensions | tar xv -C /tmp/extensions
+          for layer in /tmp/extensions/*/layer.tar; do
+            tar xvf "$layer" -C ansible/files/extensions --strip-components 1
+          done
 
-      # - id: version
-      #   run: echo "${{ steps.args.outputs.result }}" | grep "postgresql" >> "$GITHUB_OUTPUT"
+      - id: version
+        run: echo "${{ steps.args.outputs.result }}" | grep "postgresql" >> "$GITHUB_OUTPUT"
 
-      # - name: Build Postgres deb
-      #   uses: docker/build-push-action@v5
-      #   with:
-      #     load: true
-      #     file: docker/Dockerfile
-      #     target: pg-deb
-      #     build-args: |
-      #       ubuntu_release=${{ matrix.ubuntu_release }}
-      #       ubuntu_release_no=${{ matrix.ubuntu_version }}
-      #       postgresql_major=${{ steps.version.outputs.postgresql_major }}
-      #       postgresql_release=${{ steps.version.outputs.postgresql_release }}
-      #       CPPFLAGS=-mcpu=${{ matrix.mcpu }}
-      #     tags: supabase/postgres:deb
-      #     platforms: linux/${{ matrix.arch }}
-      #     cache-from: |
-      #       type=gha,scope=${{ github.ref_name }}-deb
-      #       type=gha,scope=${{ github.base_ref }}-deb
-      #       type=gha,scope=develop-deb
-      #     cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-deb
+      - name: Build Postgres deb
+        uses: docker/build-push-action@v5
+        with:
+          load: true
+          file: docker/Dockerfile
+          target: pg-deb
+          build-args: |
+            ubuntu_release=${{ matrix.ubuntu_release }}
+            ubuntu_release_no=${{ matrix.ubuntu_version }}
+            postgresql_major=${{ steps.version.outputs.postgresql_major }}
+            postgresql_release=${{ steps.version.outputs.postgresql_release }}
+            CPPFLAGS=-mcpu=${{ matrix.mcpu }}
+          tags: supabase/postgres:deb
+          platforms: linux/${{ matrix.arch }}
+          cache-from: |
+            type=gha,scope=${{ github.ref_name }}-deb
+            type=gha,scope=${{ github.base_ref }}-deb
+            type=gha,scope=develop-deb
+          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-deb
 
-      # - name: Extract Postgres deb
-      #   run: |
-      #     mkdir -p /tmp/build ansible/files/postgres
-      #     docker save supabase/postgres:deb | tar xv -C /tmp/build
-      #     for layer in /tmp/build/*/layer.tar; do
-      #       tar xvf "$layer" -C ansible/files/postgres --strip-components 1
-      #     done
+      - name: Extract Postgres deb
+        run: |
+          mkdir -p /tmp/build ansible/files/postgres
+          docker save supabase/postgres:deb | tar xv -C /tmp/build
+          for layer in /tmp/build/*/layer.tar; do
+            tar xvf "$layer" -C ansible/files/postgres --strip-components 1
+          done
 
-      # # Packer doesn't support skipping registering the AMI for the ebssurrogate
-      # # builder, so we register an AMI with a fixed name and run tests on an
-      # # instance launched from that
-      # # https://github.com/hashicorp/packer/issues/4899
-      # - name: Build AMI
-      #   run: |
-      #     GIT_SHA=${{github.sha}}
-      #     packer build -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${GITHUB_RUN_ID}" -var-file="development-arm.vars.pkr.hcl" -var-file="common.vars.pkr.hcl" -var "ansible_arguments=" -var "postgres-version=ci-ami-test" -var "region=ap-southeast-1" -var 'ami_regions=["ap-southeast-1"]' -var "force-deregister=true" amazon-arm64.pkr.hcl
+      # Packer doesn't support skipping registering the AMI for the ebssurrogate
+      # builder, so we register an AMI with a fixed name and run tests on an
+      # instance launched from that
+      # https://github.com/hashicorp/packer/issues/4899
+      - name: Build AMI
+        run: |
+          GIT_SHA=${{github.sha}}
+          packer build -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${GITHUB_RUN_ID}" -var-file="development-arm.vars.pkr.hcl" -var-file="common.vars.pkr.hcl" -var "ansible_arguments=" -var "postgres-version=ci-ami-test" -var "region=ap-southeast-1" -var 'ami_regions=["ap-southeast-1"]' -var "force-deregister=true" amazon-arm64.pkr.hcl
 
       - name: Run tests
         timeout-minutes: 5
@@ -134,7 +134,7 @@ jobs:
         run: |
           aws ec2 --region ap-southeast-1 describe-instances --filters "Name=tag:packerExecutionId,Values=${GITHUB_RUN_ID}" --query "Reservations[].Instances[].InstanceId" --output text | xargs -I {} aws ec2 terminate-instances --instance-ids {}
 
-      # - name: Cleanup resources on build cancellation
-      #   if: ${{ always() }}
-      #   run: |
-      #     aws ec2 --region ap-southeast-1 describe-instances --filters "Name=tag:testinfra-run-id,Values=${GITHUB_RUN_ID}" --query "Reservations[].Instances[].InstanceId" --output text | xargs -I {} aws ec2 terminate-instances --instance-ids {}
+      - name: Cleanup resources on build cancellation
+        if: ${{ always() }}
+        run: |
+          aws ec2 --region ap-southeast-1 describe-instances --filters "Name=tag:testinfra-run-id,Values=${GITHUB_RUN_ID}" --query "Reservations[].Instances[].InstanceId" --output text | xargs -I {} aws ec2 terminate-instances --instance-ids {}

--- a/.github/workflows/testinfra.yml
+++ b/.github/workflows/testinfra.yml
@@ -132,3 +132,8 @@ jobs:
         if: ${{ cancelled() }}
         run: |
           aws ec2 --region ap-southeast-1 describe-instances --filters "Name=tag:packerExecutionId,Values=${GITHUB_RUN_ID}" --query "Reservations[].Instances[].InstanceId" --output text | xargs -I {} aws ec2 terminate-instances --instance-ids {}
+
+      # - name: Cleanup resources on build cancellation
+      #   if: ${{ always() }}
+      #   run: |
+      #     aws ec2 --region ap-southeast-1 describe-instances --filters "Name=tag:testinfra-run-id,Values=${GITHUB_RUN_ID}" --query "Reservations[].Instances[].InstanceId" --output text | xargs -I {} aws ec2 terminate-instances --instance-ids {}

--- a/testinfra/test_ami.py
+++ b/testinfra/test_ami.py
@@ -209,7 +209,10 @@ runcmd:
             TagSpecifications=[
                 {
                     "ResourceType": "instance",
-                    "Tags": [{"Key": "Name", "Value": "ci-ami-test"}],
+                    "Tags": [
+                        {"Key": "Name", "Value": "ci-ami-test"},
+                        {"Key": "creator", "Value": "testinfra-ci"}
+                    ],
                 }
             ],
         )

--- a/testinfra/test_ami.py
+++ b/testinfra/test_ami.py
@@ -1,12 +1,15 @@
 import base64
 import boto3
 import gzip
+import os
 import pytest
 import requests
 import testinfra
 from ec2instanceconnectcli.EC2InstanceConnectLogger import EC2InstanceConnectLogger
 from ec2instanceconnectcli.EC2InstanceConnectKey import EC2InstanceConnectKey
 from time import sleep
+
+RUN_ID = os.environ["GITHUB_RUN_ID"] if os.environ["GITHUB_RUN_ID"] else "unknown-ci-run"
 
 postgresql_schema_sql_content = """
 ALTER DATABASE postgres SET "app.settings.jwt_secret" TO  'my_jwt_secret_which_is_not_so_secret';
@@ -211,7 +214,8 @@ runcmd:
                     "ResourceType": "instance",
                     "Tags": [
                         {"Key": "Name", "Value": "ci-ami-test"},
-                        {"Key": "creator", "Value": "testinfra-ci"}
+                        {"Key": "creator", "Value": "testinfra-ci"},
+                        {"Key": "testinfra-run-id", "Value": RUN_ID}
                     ],
                 }
             ],

--- a/testinfra/test_ami.py
+++ b/testinfra/test_ami.py
@@ -231,8 +231,8 @@ runcmd:
     )[0]
     instance.wait_until_running()
 
-    logger = EC2InstanceConnectLogger(debug=False)
-    temp_key = EC2InstanceConnectKey(logger.get_logger())
+    ec2logger = EC2InstanceConnectLogger(debug=False)
+    temp_key = EC2InstanceConnectKey(ec2logger.get_logger())
     ec2ic = boto3.client("ec2-instance-connect", region_name="ap-southeast-1")
     response = ec2ic.send_ssh_public_key(
         InstanceId=instance.id,


### PR DESCRIPTION
@soedirgo this fixes the "run an instance, test on it" aspect of things. However, additional changes are going to be needed, as you can't republish AMIs with the same name. You'll likely want to tag them with the run ID, and also deregister the AMIs after the test.