### PR TITLE
[GEN-1995] chore: upgrade postgres_exporter

### DIFF
--- a/ansible/files/postgres_exporter.service.j2
+++ b/ansible/files/postgres_exporter.service.j2
@@ -3,7 +3,7 @@ Description=Postgres Exporter
 
 [Service]
 Type=simple
-ExecStart=/opt/postgres_exporter/postgres_exporter --disable-settings-metrics --extend.query-path="/opt/postgres_exporter/queries.yml" --disable-default-metrics
+ExecStart=/opt/postgres_exporter/postgres_exporter --disable-settings-metrics --extend.query-path="/opt/postgres_exporter/queries.yml" --disable-default-metrics --no-collector.locks --no-collector.replication --no-collector.replication_slot --no-collector.stat_bgwriter --no-collector.stat_database --no-collector.stat_user_tables --no-collector.statio_user_tables --no-collector.wal
 User=root
 Restart=always
 RestartSec=3

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -36,10 +36,10 @@ wal_g_release: "2.0.1"
 sfcgal_release: "1.3.10"
 sfcgal_release_checksum: sha256:4e39b3b2adada6254a7bdba6d297bb28e1a9835a9f879b74f37e2dab70203232
 
-postgres_exporter_release: "0.9.0"
+postgres_exporter_release: "0.15.0"
 postgres_exporter_release_checksum:
-  arm64: sha256:d869c16791481dc8475487ad84ae4371a63f9b399898ca1c666eead5cccf7182
-  amd64: sha256:ff541bd3ee19c0ae003d71424a75edfcc8695e828dd20d5b4555ce433c89d60b
+  arm64: sha256:29ba62d538b92d39952afe12ee2e1f4401250d678ff4b354ff2752f4321c87a0
+  amd64: sha256:cb89fc5bf4485fb554e0d640d9684fae143a4b2d5fa443009bd29c59f9129e84
 
 adminapi_release: 0.51.0
 adminmgr_release: 0.10.2

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.133-rc1.pg_exporter"
+postgres-version = "15.1.0.133"

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.133"
+postgres-version = "15.1.0.133-rc1.pg_exporter"


### PR DESCRIPTION
Upgrade `postgres_exporter`
Custom queries are being deprecated, but they are still operational in this version.

Metrics collection has been migrated to `collectors`, some of which clash in name with our metrics.
To keep things sane, all the collectors are disabled with the additions to the CLI switches in the systemd unit file
