### PR TITLE
chore: retry stopping PG if it initially fails

### DIFF
--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
@@ -299,7 +299,7 @@ EOF
         UPGRADE_COMMAND="$UPGRADE_COMMAND --check"
     else 
         echo "9. Stopping postgres; running pg_upgrade"
-        systemctl stop postgresql
+        retry 5 systemctl stop postgresql
     fi
 
     su -c "$UPGRADE_COMMAND" -s "$SHELL" postgres


### PR DESCRIPTION
* retries stopping PG pre-upgrade if if fails to stop initially for some reason.
* avoids `another postmaster servicing cluster` errors