### PR TITLE
chore: stop postgresql restart during upgrades

### DIFF
--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
@@ -95,7 +95,8 @@ cleanup() {
 
     if [ "$IS_DRY_RUN" = false ]; then
         echo "Restarting postgresql"
-        systemctl restart postgresql
+        systemctl enable postgresql
+        retry 5 systemctl restart postgresql
     fi
 
     echo "Re-enabling extensions"
@@ -299,6 +300,8 @@ EOF
         UPGRADE_COMMAND="$UPGRADE_COMMAND --check"
     else 
         echo "9. Stopping postgres; running pg_upgrade"
+        retry 5 systemctl restart postgresql
+        systemctl disable postgresql
         retry 5 systemctl stop postgresql
     fi
 


### PR DESCRIPTION
Follow up to #789 
Some long-running PG12 processes might restart even if issued a stop - issue seems to be fixed with a restart.
This pre-emptively restarts PG once before disabling and stoping the service before running the upgrade.