### PR TITLE
chore: restart gotrue and postgrest after pg_upgrade

### DIFF
--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/complete.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/complete.sh
@@ -55,6 +55,10 @@ function complete_pg_upgrade {
     echo "5. Restarting postgresql"
     retry 3 service postgresql restart
 
+    echo "5.1. Restarting gotrue and postgrest"
+    retry 3 service gotrue restart
+    retry 3 service postgrest restart
+
     echo "6. Starting vacuum analyze"
     retry 3 start_vacuum_analyze
 }


### PR DESCRIPTION
* avoids edge case where gotrue migrations and postgrest schema might be outdated post-upgrade

[Slack thread](https://supabase.slack.com/archives/C022071RB2L/p1699945871194079)