### PR TITLE
chore: add some network debugging tools, clean out unused pkgs

### DIFF
--- a/ansible/tasks/clean-build-dependencies.yml
+++ b/ansible/tasks/clean-build-dependencies.yml
@@ -15,6 +15,7 @@
       - manpages
       - manpages-dev
       - ninja-build
+      - patch
       - python2
     state: absent
     autoremove: yes

--- a/ansible/tasks/clean-build-dependencies.yml
+++ b/ansible/tasks/clean-build-dependencies.yml
@@ -11,6 +11,9 @@
       - g++-10
       - g++-9
       - gcc-10
+      - make
+      - manpages
+      - manpages-dev
       - ninja-build
       - python2
     state: absent

--- a/ansible/tasks/setup-system.yml
+++ b/ansible/tasks/setup-system.yml
@@ -40,6 +40,10 @@
 - name: Install other useful tools
   apt:
     pkg:
+      - bwm-ng
+      - htop
+      - net-tools
+      - ngrep
       - sysstat
       - vim-tiny
     update_cache: yes


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adding tools to the AMI to aid debugging

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?
### Additions
```
apt-get install bwm-ng ngrep htop net-tools
Reading package lists... Done
Building dependency tree
Reading state information... Done
The following additional packages will be installed:
  libnet1
Suggested packages:
  lsof strace
The following NEW packages will be installed:
  bwm-ng htop libnet1 net-tools ngrep
0 upgraded, 5 newly installed, 0 to remove and 2 not upgraded.
Need to get 114 kB/384 kB of archives.
After this operation, 1376 kB of additional disk space will be used.
```

### Removals
```
pt-get remove manpages manpages-dev patch
Reading package lists... Done
Building dependency tree
Reading state information... Done
The following packages were automatically installed and are no longer required:
  fakeroot libalgorithm-diff-perl libalgorithm-diff-xs-perl libalgorithm-merge-perl libfakeroot
Use 'apt autoremove' to remove them.
The following packages will be REMOVED:
  dpkg-dev manpages manpages-dev patch
0 upgraded, 0 newly installed, 4 to remove and 2 not upgraded.
After this operation, 7921 kB disk space will be freed.
```

## Additional context

Add any other context or screenshots.