### PR TITLE
chore: ensure fail2ban stays disabled when FAIL2BAN_DISABLED is set 

### DIFF
--- a/docker/all-in-one/Dockerfile
+++ b/docker/all-in-one/Dockerfile
@@ -179,6 +179,7 @@ COPY --chown=postgres:postgres docker/all-in-one/etc/postgresql.schema.sql /etc/
 # Customizations for postgres_exporter
 COPY --chown=postgres:postgres docker/all-in-one/opt/postgres_exporter/queries.yml /opt/postgres_exporter/queries.yml
 
+# Customizations for fail2ban
 COPY docker/all-in-one/etc/fail2ban/filter.d /etc/fail2ban/filter.d/
 COPY docker/all-in-one/etc/fail2ban/jail.d /etc/fail2ban/jail.d/
 

--- a/docker/all-in-one/entrypoint.sh
+++ b/docker/all-in-one/entrypoint.sh
@@ -241,6 +241,11 @@ if [ "${AUTOSHUTDOWN_ENABLED:-}" ]; then
   sed -i "s/autostart=.*/autostart=true/" /etc/supervisor/db-only/supa-shutdown.conf
 fi
 
+if [ "${FAIL2BAN_DISABLED:-}" ]; then
+  sed -i "s/autostart=.*/autostart=false/" /etc/supervisor/services/fail2ban.conf
+  sed -i "s/autorestart=.*/autorestart=false/" /etc/supervisor/services/fail2ban.conf
+fi
+
 if [ "${PLATFORM_DEPLOYMENT:-}" ]; then
   enable_swap
   create_lsn_checkpoint_file

--- a/docker/all-in-one/entrypoint.sh
+++ b/docker/all-in-one/entrypoint.sh
@@ -227,26 +227,26 @@ find /etc/supervisor/ -type d -exec chmod 0770 {} +
 find /etc/supervisor/ -type f -exec chmod 0660 {} +
 
 # Start services in the background
-if [ -z "${POSTGRES_ONLY:-}" ]; then
-  sed -i "s|  #  - postgrest|    - postgrest|g" /etc/adminapi/adminapi.yaml
-  sed -i "s|files = db-only/\*.conf|files = services/\*.conf db-only/\*.conf|g" $SUPERVISOR_CONF
-  configure_services
-else
+if [ "${POSTGRES_ONLY:-}" == "true" ]; then
   sed -i "s|    - postgrest|  #  - postgrest|g" /etc/adminapi/adminapi.yaml
   sed -i "s|files = services/\*.conf db-only/\*.conf|files = db-only/\*.conf|g" $SUPERVISOR_CONF
   /init/configure-adminapi.sh
+else
+  sed -i "s|  #  - postgrest|    - postgrest|g" /etc/adminapi/adminapi.yaml
+  sed -i "s|files = db-only/\*.conf|files = services/\*.conf db-only/\*.conf|g" $SUPERVISOR_CONF
+  configure_services
 fi
 
-if [ "${AUTOSHUTDOWN_ENABLED:-}" ]; then
+if [ "${AUTOSHUTDOWN_ENABLED:-}" == "true" ]; then
   sed -i "s/autostart=.*/autostart=true/" /etc/supervisor/db-only/supa-shutdown.conf
 fi
 
-if [ "${FAIL2BAN_DISABLED:-}" ]; then
+if [ "${FAIL2BAN_DISABLED:-}" == "true" ]; then
   sed -i "s/autostart=.*/autostart=false/" /etc/supervisor/services/fail2ban.conf
   sed -i "s/autorestart=.*/autorestart=false/" /etc/supervisor/services/fail2ban.conf
 fi
 
-if [ "${PLATFORM_DEPLOYMENT:-}" ]; then
+if [ "${PLATFORM_DEPLOYMENT:-}" == "true" ]; then
   enable_swap
   create_lsn_checkpoint_file
 fi


### PR DESCRIPTION
Ensure Fail2ban stays disabled when `FAIL2BAN_DISABLED` is set to true.,

Similarly to what already happen with `AUTOSHUTDOWN_ENABLED`, as mentioned by @pcnc .

Currently opening as a DRAFT.