### PR TITLE
fix: drop obsolete pg_graphql function signature

### DIFF
--- a/.github/workflows/testinfra.yml
+++ b/.github/workflows/testinfra.yml
@@ -137,4 +137,4 @@ jobs:
       - name: Cleanup resources on build cancellation
         if: ${{ always() }}
         run: |
-          aws ec2 --region ap-southeast-1 describe-instances --filters "Name=tag:testinfra-run-id,Values=${GITHUB_RUN_ID}" --query "Reservations[].Instances[].InstanceId" --output text | xargs -I {} aws ec2 terminate-instances --instance-ids {}
+          aws ec2 --region ap-southeast-1 describe-instances --filters "Name=tag:testinfra-run-id,Values=${GITHUB_RUN_ID}" --query "Reservations[].Instances[].InstanceId" --output text | xargs -I {} aws ec2 terminate-instances --instance-ids {} || true

--- a/.github/workflows/testinfra.yml
+++ b/.github/workflows/testinfra.yml
@@ -123,7 +123,7 @@ jobs:
           packer build -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${GITHUB_RUN_ID}" -var-file="development-arm.vars.pkr.hcl" -var-file="common.vars.pkr.hcl" -var "ansible_arguments=" -var "postgres-version=ci-ami-test" -var "region=ap-southeast-1" -var 'ami_regions=["ap-southeast-1"]' -var "force-deregister=true" amazon-arm64.pkr.hcl
 
       - name: Run tests
-        timeout-minutes: 5
+        timeout-minutes: 10
         run: |
           # TODO: use poetry for pkg mgmt
           pip3 install boto3 boto3-stubs[essential] docker ec2instanceconnectcli pytest pytest-testinfra[paramiko,docker] requests

--- a/migrations/db/migrations/20220317095840_pg_graphql.sql
+++ b/migrations/db/migrations/20220317095840_pg_graphql.sql
@@ -1,6 +1,8 @@
 -- migrate:up
 create schema if not exists graphql_public;
 
+-- obsolete signature: https://github.com/supabase/infrastructure/pull/5524/files
+drop function if exists graphql_public.graphql(text, text, jsonb);
 -- GraphQL Placeholder Entrypoint
 create or replace function graphql_public.graphql(
     "operationName" text default null,

--- a/testinfra/test_ami.py
+++ b/testinfra/test_ami.py
@@ -247,7 +247,7 @@ runcmd:
 
     host = testinfra.get_host(
         # paramiko is an ssh backend
-        f"paramiko://ubuntu@{instance.public_ip_address}",
+        f"paramiko://ubuntu@{instance.public_ip_address}?timeout=60",
         ssh_identity_file=temp_key.get_priv_key_file(),
     )
 

--- a/testinfra/test_ami.py
+++ b/testinfra/test_ami.py
@@ -8,9 +8,10 @@ import requests
 import testinfra
 from ec2instanceconnectcli.EC2InstanceConnectLogger import EC2InstanceConnectLogger
 from ec2instanceconnectcli.EC2InstanceConnectKey import EC2InstanceConnectKey
+from paramiko.ssh_exception import NoValidConnectionsError
 from time import sleep
 
-RUN_ID = os.environ["GITHUB_RUN_ID"] if os.environ["GITHUB_RUN_ID"] else "unknown-ci-run"
+RUN_ID = os.environ.get("GITHUB_RUN_ID", "unknown-ci-run")
 
 postgresql_schema_sql_content = """
 ALTER DATABASE postgres SET "app.settings.jwt_secret" TO  'my_jwt_secret_which_is_not_so_secret';
@@ -251,39 +252,43 @@ runcmd:
     )
 
     def is_healthy(host) -> bool:
-        cmd = host.run("pg_isready -U postgres")
-        if cmd.failed is True:
-            logger.warn("pg not ready")
-            return False
+        try:
+            cmd = host.run("pg_isready -U postgres")
+            if cmd.failed is True:
+                logger.warn("pg not ready")
+                return False
 
-        cmd = host.run(f"curl -sf -k https://localhost:8085/health -H 'apikey: {supabase_admin_key}'")
-        if cmd.failed is True:
-            logger.warn("adminapi not ready")
-            return False
+            cmd = host.run(f"curl -sf -k https://localhost:8085/health -H 'apikey: {supabase_admin_key}'")
+            if cmd.failed is True:
+                logger.warn("adminapi not ready")
+                return False
 
-        cmd = host.run("curl -sf http://localhost:3001/ready")
-        if cmd.failed is True:
-            logger.warn("postgrest not ready")
-            return False
+            cmd = host.run("curl -sf http://localhost:3001/ready")
+            if cmd.failed is True:
+                logger.warn("postgrest not ready")
+                return False
 
-        cmd = host.run("curl -sf http://localhost:8081/health")
-        if cmd.failed is True:
-            logger.warn("gotrue not ready")
-            return False
+            cmd = host.run("curl -sf http://localhost:8081/health")
+            if cmd.failed is True:
+                logger.warn("gotrue not ready")
+                return False
 
-        cmd = host.run("sudo kong health")
-        if cmd.failed is True:
-            logger.warn("kong not ready")
-            return False
+            cmd = host.run("sudo kong health")
+            if cmd.failed is True:
+                logger.warn("kong not ready")
+                return False
 
-        cmd = host.run("printf \\\\0 > '/dev/tcp/localhost/6543'")
-        if cmd.failed is True:
-            logger.warn("pgbouncer not ready")
-            return False
+            cmd = host.run("printf \\\\0 > '/dev/tcp/localhost/6543'")
+            if cmd.failed is True:
+                logger.warn("pgbouncer not ready")
+                return False
 
-        cmd = host.run("sudo fail2ban-client status")
-        if cmd.failed is True:
-            logger.warn("fail2ban not ready")
+            cmd = host.run("sudo fail2ban-client status")
+            if cmd.failed is True:
+                logger.warn("fail2ban not ready")
+                return False
+        except NoValidConnectionsError:
+            logger.warn("unable to connect via ssh")
             return False
 
         return True


### PR DESCRIPTION
It's breaking some restores because the `grant_pg_graphql_access` expects only one function signature on this line:

https://github.com/supabase/postgres/blob/87ee42dda7082be8957fd2936c2f23ff6ed7ab77/migrations/schema.sql#L270

Error:
```
ERROR:  function name "graphql_public.graphql" is not uniqueHINT:  Specify the argument list to select the function unambiguously.
CONTEXT:  SQL statement "DROP FUNCTION IF EXISTS graphql_public.graphql"
PL/pgSQL function grant_pg_graphql_access() line 22 at SQL statement
SQL statement "create extension if not exists pg_graphql"
PL/pgSQL function inline_code_block line 13 at SQL statement
```