### PR TITLE
chore: update docker aio entrypoint to handle GOTRUE_DISABLED

### DIFF
--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.134-rc-1"
+postgres-version = "15.1.0.134"

--- a/docker/all-in-one/entrypoint.sh
+++ b/docker/all-in-one/entrypoint.sh
@@ -246,6 +246,11 @@ if [ "${FAIL2BAN_DISABLED:-}" == "true" ]; then
   sed -i "s/autorestart=.*/autorestart=false/" /etc/supervisor/services/fail2ban.conf
 fi
 
+if [ "${GOTRUE_DISABLED:-}" == "true" ]; then
+  sed -i "s/autostart=.*/autostart=false/" /etc/supervisor/services/gotrue.conf
+  sed -i "s/autorestart=.*/autorestart=false/" /etc/supervisor/services/gotrue.conf
+fi
+
 if [ "${PLATFORM_DEPLOYMENT:-}" == "true" ]; then
   enable_swap
   create_lsn_checkpoint_file


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore

## What is the current behavior?

Currently, the docker AIO image always assume gotrue will be running.

## What is the new behavior?

Gotrue running will be based in an env var called `GOTRUE_DISABLED`. The default, when nothing is passed over, will be `false`, so gotrue will be running.