### PR TITLE
chore: set lock_timeout to authentictor role

### DIFF
--- a/migrations/db/migrations/20231130133139_set_lock_timeout_to_authenticator_role.sql
+++ b/migrations/db/migrations/20231130133139_set_lock_timeout_to_authenticator_role.sql
@@ -1,0 +1,1 @@
+ALTER ROLE authenticator set lock_timeout to '8s';


### PR DESCRIPTION
`lock_timeout` is currently set to 0, which enables locks to exist indefinitely.

Given the authenticator role has a value set for `statement_timeout` to 8s , `lock_timeout` should be set similarly, to ensure locks are not maintained after the initial statement times out