### PR TITLE
chore: update gha test-infra timeout to 60min

### DIFF
--- a/.github/workflows/testinfra.yml
+++ b/.github/workflows/testinfra.yml
@@ -14,7 +14,7 @@ jobs:
           - runner: arm-runner
             arch: arm64
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
- Increase testinfra gha timeout from 30 to 60 based on previous runs.