### PR TITLE
chore: re-bump `postgres-version` since it's used by an existing AMI

### DIFF
--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.139"
+postgres-version = "15.1.0.140"


### PR DESCRIPTION
https://github.com/supabase/postgres/actions/runs/7117692724/job/19379008532: "Error: AMI Name: 'supabase-postgres-15.1.0.139' is used by an existing AMI". The existing AMI was released manually in https://github.com/supabase/postgres/actions/runs/7111334625.
