### PR TITLE
chore: check that version includes non-numeric characters for manual AMI builds

### DIFF
--- a/.github/workflows/ami-release.yml
+++ b/.github/workflows/ami-release.yml
@@ -30,6 +30,16 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
+      - name: Run checks if triggered manually
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        # Update `ci.yaml` too if changing constraints.
+        run: |
+          SUFFIX=$(sed -E 's/postgres-version = "[0-9\.]+(.*)"/\1/g' common.vars.pkr.hcl)
+          if [[ -z $SUFFIX ]] ; then
+            echo "Version must include non-numeric characters if built manually."
+            exit 1
+          fi
+
       - id: args
         uses: mikefarah/yq@master
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
 
 jobs:
-
   check-release-version:
     timeout-minutes: 5
     runs-on: ubuntu-latest
@@ -13,6 +12,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run checks
+        # Update `ami-release.yaml` too if changing constraints.
         run: |
           SUFFIX=$(sed -E 's/postgres-version = "[0-9\.]+(.*)"/\1/g' common.vars.pkr.hcl)
           if [[ -n $SUFFIX ]] ; then


### PR DESCRIPTION
To avoid situations such as https://github.com/supabase/postgres/pull/823. This also disallows simply appending .e.g ".1", which is against https://semver.org/ for pre-release versions, and it's good to have more descriptive identifiers.
