### PR TITLE
fix: set explicit group and permissions for Envoy-related files

### DIFF
--- a/ansible/tasks/setup-envoy.yml
+++ b/ansible/tasks/setup-envoy.yml
@@ -6,6 +6,7 @@
   ansible.builtin.get_url:
     checksum: "{{ envoy_release_checksum }}"
     dest: /opt/envoy
+    group: envoy
     mode: u+x
     owner: envoy
     # yamllint disable-line rule:line-length
@@ -15,6 +16,7 @@
   ansible.builtin.get_url:
     checksum: "{{ envoy_hot_restarter_release_checksum }}"
     dest: /opt/envoy-hot-restarter.py
+    group: envoy
     mode: u+x
     owner: envoy
     # yamllint disable-line rule:line-length
@@ -30,6 +32,7 @@
 - name: Envoy - create script to start envoy
   ansible.builtin.copy:
     dest: /opt/start-envoy.sh
+    group: envoy
     mode: u+x
     owner: envoy
     src: files/start-envoy.sh
@@ -37,6 +40,8 @@
 - name: Envoy - create configuration files
   ansible.builtin.copy:
     dest: /etc/envoy/
+    directory_mode: u=rw,g=rw,o=r
+    group: envoy
     mode: u=rw,g=rw,o=r
     owner: envoy
     src: files/envoy_config/

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.142"
+postgres-version = "15.1.0.143"

--- a/docker/all-in-one/Dockerfile
+++ b/docker/all-in-one/Dockerfile
@@ -201,7 +201,7 @@ COPY --chown=postgrest:postgrest docker/all-in-one/etc/postgrest/generated.conf 
 COPY docker/all-in-one/etc/gotrue.env /etc/gotrue.env
 
 # Customizations for envoy
-COPY --chown=envoy:envoy ansible/files/envoy_config/ /etc/envoy/
+COPY --chmod=644 --chown=envoy:envoy ansible/files/envoy_config/ /etc/envoy/
 
 # Customizations for kong
 COPY docker/all-in-one/etc/kong/kong.conf /etc/kong/kong.conf


### PR DESCRIPTION
This avoids having to set them elsewhere.
