### PR TITLE
fix: rebuild orioledb base image

### DIFF
--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.147"
+postgres-version = "15.1.0.148"

--- a/docker/orioledb/Dockerfile
+++ b/docker/orioledb/Dockerfile
@@ -1029,9 +1029,8 @@ RUN sed -i \
     -e "s|PGHOST= PGHOSTADDR=|PGHOST=\$POSTGRES_HOST|g" \
     /usr/local/bin/docker-entrypoint.sh
 
-# TODO: support s3 credentials once upstream is tested
-# COPY docker/orioledb/entrypoint.sh /
-# ENTRYPOINT ["/entrypoint.sh"]
+COPY docker/orioledb/entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]
 
 HEALTHCHECK --interval=2s --timeout=2s --retries=10 CMD pg_isready -U postgres -h localhost
 STOPSIGNAL SIGINT

--- a/docker/orioledb/Dockerfile
+++ b/docker/orioledb/Dockerfile
@@ -1007,13 +1007,16 @@ COPY ansible/files/walg_helper_scripts/wal_change_ownership.sh /root/wal_change_
 RUN sed -i \
     -e "s|#unix_socket_directories = '/tmp'|unix_socket_directories = '/var/run/postgresql'|g" \
     -e "s|#session_preload_libraries = ''|session_preload_libraries = 'supautils'|g" \
-    -e "s|shared_preload_libraries = '\(.*\)'|shared_preload_libraries = '\1, orioledb'|" \
+    -e "s|shared_preload_libraries = '\(.*\)'|shared_preload_libraries = '\1, orioledb'|g" \
+    -e "s|#max_wal_size = 1GB|max_wal_size = 8GB|g" \
     -e "s|#include = '/etc/postgresql-custom/supautils.conf'|include = '/etc/postgresql-custom/supautils.conf'|g" \
     -e "s|#include = '/etc/postgresql-custom/wal-g.conf'|include = '/etc/postgresql-custom/wal-g.conf'|g" /etc/postgresql/postgresql.conf && \
     echo "cron.database_name = 'postgres'" >> /etc/postgresql/postgresql.conf && \
     echo "pljava.libjvm_location = '/usr/lib/jvm/java-11-openjdk-${TARGETARCH}/lib/server/libjvm.so'" >> /etc/postgresql/postgresql.conf && \
     echo "pgsodium.getkey_script= '/usr/lib/postgresql/${postgresql_major}/bin/pgsodium_getkey.sh'" >> /etc/postgresql/postgresql.conf && \
     echo 'auto_explain.log_min_duration = 10s' >> /etc/postgresql/postgresql.conf && \
+    echo "orioledb.main_buffers = 1GB" >> /etc/postgresql/postgresql.conf && \
+    echo "orioledb.undo_buffers = 256MB" >> /etc/postgresql/postgresql.conf && \
     useradd --create-home --shell /bin/bash wal-g -G postgres && \
     mkdir -p /etc/postgresql-custom && \
     chown postgres:postgres /etc/postgresql-custom
@@ -1027,10 +1030,10 @@ COPY ansible/files/stat_extension.sql /docker-entrypoint-initdb.d/migrations/00-
 RUN sed -i \
     -e "s|su-exec|gosu|g" \
     -e "s|PGHOST= PGHOSTADDR=|PGHOST=\$POSTGRES_HOST|g" \
-    /usr/local/bin/docker-entrypoint.sh
+    /usr/local/bin/docker-entrypoint.sh && \
+    mv /usr/local/bin/docker-entrypoint.sh /usr/local/bin/orioledb-entrypoint.sh
 
-COPY docker/orioledb/entrypoint.sh /
-ENTRYPOINT ["/entrypoint.sh"]
+COPY docker/orioledb/entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 HEALTHCHECK --interval=2s --timeout=2s --retries=10 CMD pg_isready -U postgres -h localhost
 STOPSIGNAL SIGINT

--- a/docker/orioledb/entrypoint.sh
+++ b/docker/orioledb/entrypoint.sh
@@ -6,9 +6,9 @@ PG_CONF=/etc/postgresql/postgresql.conf
 function configure_orioledb {
   echo "Configuring OrioleDB..."
 
+  # -e "s|#log_min_messages = .*|log_min_messages = debug1 # will log all S3 requests|" \
   sed -i \
     -e "s|#max_worker_processes = .*|max_worker_processes = 50 # should fit orioledb.s3_num_workers as long as other workers|" \
-    -e "s|#log_min_messages = .*|log_min_messages = debug1 # will log all S3 requests|" \
     -e "s|#archive_mode = off\(.*\)|archive_mode = on\1|" \
     "$PG_CONF"
 
@@ -25,7 +25,7 @@ orioledb.s3_secretkey = '$S3_SECRET_KEY' # replace with your S3 secret key
 " >> "$PG_CONF"
 }
 
-if ! grep -q orioledb "$PG_CONF"; then
+if ! grep -q "orioledb.s3_mode" "$PG_CONF"; then
   configure_orioledb
 fi
 

--- a/docker/orioledb/entrypoint.sh
+++ b/docker/orioledb/entrypoint.sh
@@ -3,19 +3,13 @@ set -eou pipefail
 
 PG_CONF=/etc/postgresql/postgresql.conf
 
-function configure_orioledb {
-  echo "Configuring OrioleDB..."
-
-  # -e "s|#log_min_messages = .*|log_min_messages = debug1 # will log all S3 requests|" \
-  sed -i \
-    -e "s|#max_worker_processes = .*|max_worker_processes = 50 # should fit orioledb.s3_num_workers as long as other workers|" \
-    -e "s|#archive_mode = off\(.*\)|archive_mode = on\1|" \
-    "$PG_CONF"
+if [ "${S3_ENABLED:-}" == "true" ]; then
+  echo "Enabling OrioleDB S3 Backend..."
 
   echo "
+archive_mode = on
 archive_library = 'orioledb'
-orioledb.main_buffers = 1GB
-orioledb.undo_buffers = 256MB
+max_worker_processes = 50 # should fit orioledb.s3_num_workers as long as other workers
 orioledb.s3_num_workers = 20 # should be enough for comfortable work
 orioledb.s3_mode = true
 orioledb.s3_host = '$S3_HOST' # replace with your bucket URL, accelerated buckets are recommended
@@ -23,10 +17,20 @@ orioledb.s3_region = '$S3_REGION' # replace with your S3 region
 orioledb.s3_accesskey = '$S3_ACCESS_KEY' # replace with your S3 key
 orioledb.s3_secretkey = '$S3_SECRET_KEY' # replace with your S3 secret key
 " >> "$PG_CONF"
-}
+else
+  echo "Disabling OrioleDB S3 Backend..."
 
-if ! grep -q "orioledb.s3_mode" "$PG_CONF"; then
-  configure_orioledb
+  sed -i \
+    -e "/^archive_mode = on/d" \
+    -e "/^archive_library = 'orioledb'/d" \
+    -e "/^max_worker_processes = 50/d" \
+    -e "/^orioledb.s3_num_workers = /d" \
+    -e "/^orioledb.s3_mode = /d" \
+    -e "/^orioledb.s3_host = /d" \
+    -e "/^orioledb.s3_region = /d" \
+    -e "/^orioledb.s3_accesskey = /d" \
+    -e "/^orioledb.s3_secretkey = /d" \
+    "$PG_CONF"
 fi
 
-docker-entrypoint.sh "$@"
+orioledb-entrypoint.sh "$@"


### PR DESCRIPTION
S3 config support is now complete.

There's runtime error when enabling timescaledb extension but will investigate after LWX

```
psql:/tests/extensions/10-timescaledb.sql:2: ERROR:  could not load library "/usr/local/lib/postgresql/timescaledb-2.9.1.so": /usr/local/lib/postgresql/timescaledb-2.9.1.so: undefined symbol: table_tuple_complete_speculative
```