### PR TITLE
perf(envoy): only log when status code >=400, switch from file to stdout access logger

### DIFF
--- a/ansible/files/envoy_config/lds.yaml
+++ b/ansible/files/envoy_config/lds.yaml
@@ -12,7 +12,7 @@ resources:
               '@type': >-
                 type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
               access_log:
-                - name: envoy.file_access_log
+                - name: envoy.access_loggers.stdout
                   filter:
                     status_code_filter:
                       comparison:
@@ -22,8 +22,7 @@ resources:
                           runtime_key: unused
                   typed_config:
                     '@type': >-
-                      type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
-                    path: /dev/stdout
+                      type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
               generate_request_id: false
               http_filters:
                 - name: envoy.filters.http.cors

--- a/ansible/files/envoy_config/lds.yaml
+++ b/ansible/files/envoy_config/lds.yaml
@@ -13,36 +13,16 @@ resources:
                 type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
               access_log:
                 - name: envoy.file_access_log
+                  filter:
+                    status_code_filter:
+                      comparison:
+                        op: GE
+                        value:
+                          default_value: 400
+                          runtime_key: unused
                   typed_config:
                     '@type': >-
                       type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
-                    log_format:
-                      json_format:
-                        authority: '%REQ(:AUTHORITY)%'
-                        bytes_received: '%BYTES_RECEIVED%'
-                        bytes_sent: '%BYTES_SENT%'
-                        connection_termination_details: '%CONNECTION_TERMINATION_DETAILS%'
-                        downstream_local_address: '%DOWNSTREAM_LOCAL_ADDRESS%'
-                        downstream_remote_address: '%DOWNSTREAM_REMOTE_ADDRESS%'
-                        duration: '%DURATION%'
-                        method: '%REQ(:METHOD)%'
-                        path: '%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%'
-                        protocol: '%PROTOCOL%'
-                        request_id: '%REQ(X-REQUEST-ID)%'
-                        requested_server_name: '%REQUESTED_SERVER_NAME%'
-                        response_code: '%RESPONSE_CODE%'
-                        response_code_details: '%RESPONSE_CODE_DETAILS%'
-                        response_flags: '%RESPONSE_FLAGS%'
-                        route_name: '%ROUTE_NAME%'
-                        start_time: '%START_TIME%'
-                        upstream_cluster: '%UPSTREAM_CLUSTER%'
-                        upstream_host: '%UPSTREAM_HOST%'
-                        upstream_local_address: '%UPSTREAM_LOCAL_ADDRESS%'
-                        upstream_remote_address: '%UPSTREAM_REMOTE_ADDRESS%'
-                        upstream_service_time: '%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%'
-                        upstream_transport_failure_reason: '%UPSTREAM_TRANSPORT_FAILURE_REASON%'
-                        user_agent: '%REQ(USER-AGENT)%'
-                        x_forwarded_for: '%REQ(X-FORWARDED-FOR)%'
                     path: /dev/stdout
               generate_request_id: false
               http_filters:
@@ -331,3 +311,4 @@ resources:
                     filename: /etc/envoy/fullChain.pem
                   private_key:
                     filename: /etc/envoy/privKey.pem
+

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.147"
+postgres-version = "15.1.0.148"


### PR DESCRIPTION
Quick checks using the simple-update k6 benchmark from https://github.com/thebengeu/simple-supabase-benchmarks on t4g.nano, with SCALE=30 and 100 VUs over 3 minutes:

- Kong: 442 rps, req duration med=129ms p(90)=410ms p(95)=668ms
- Envoy log all: 613 rps, req duration med=155ms p(90)=207ms p(95)=250ms
- Envoy log errors: 761 rps, req duration med=126ms, p(90)=154ms, p(95)=179ms

So on this benchmark, this change results in ~24% more rps than Envoy logging all requests, ~72% more rps than Kong. Kong is also configured to only log errors, `proxy_access_log = off` here: https://github.com/supabase/postgres/blob/a3938dc906010ce197c240d0052b3eda9ecac339/docker/all-in-one/etc/kong/kong.conf#L12.