### PR TITLE
fix: use C collation for compiling extensions with orioledb

### DIFF
--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.149"
+postgres-version = "15.1.0.150"

--- a/docker/orioledb/Dockerfile
+++ b/docker/orioledb/Dockerfile
@@ -53,7 +53,7 @@ ENV PGDATA=/var/lib/postgresql/data
 # RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG=en_US.UTF-8
 ENV LC_CTYPE=C.UTF-8
-ENV LC_COLLATE=C.UTF-8
+ENV LC_COLLATE=C
 
 FROM base as builder
 # Install build dependencies


### PR DESCRIPTION
https://supabase.slack.com/archives/C0625QCGRGF/p1702481860706139