### PR TITLE
feat: bump gotrue version to v2.132.3

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -15,8 +15,8 @@ postgrest_release: "12.0.2"
 postgrest_arm_release_checksum: sha1:a08eaa2af548d44b4c8ea61b0223fb7019f5c768
 postgrest_x86_release_checksum: sha1:40f65ded06b9de6567fbe2cd7a317196e22dd595
 
-gotrue_release: 2.130.0
-gotrue_release_checksum: sha1:713b1e51cfb5caac5c3b2026278c3ee061795b02
+gotrue_release: 2.132.3
+gotrue_release_checksum: sha1:f2aff970ddf42729187771ec2eb6ccd35b5018da
 
 aws_cli_release: "2.2.7"
 

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.0.154"
+postgres-version = "15.1.0.155"


### PR DESCRIPTION
Bump auth/gotrue version and postgres version so that we can update the default gotrue version on all new auth projects
 
* [Default](?expand=1&template=default.md)
* [Extension Upgrade](?expand=1&template=extension_upgrade.md)