### PR TITLE
Removes remaining references to pg_repack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,6 @@ ARG groonga_release=12.0.8
 ARG pgroonga_release=2.4.0
 ARG wrappers_release=0.2.0
 ARG hypopg_release=1.3.1
-ARG pg_repack_release=1.4.8
 ARG pgvector_release=0.4.0
 ARG pg_tle_release=1.0.3
 ARG supautils_release=1.9.0
@@ -735,32 +734,6 @@ RUN --mount=type=cache,target=/ccache,from=public.ecr.aws/supabase/postgres:ccac
 RUN checkinstall -D --install=no --fstrans=no --backup=no --pakdir=/tmp --nodoc
 
 ####################
-# 27-pg_repack.yml
-####################
-FROM ccache as pg_repack-source
-ARG pg_repack_release
-ARG pg_repack_release_checksum
-ADD --checksum=${pg_repack_release_checksum} \
-    "https://github.com/reorg/pg_repack/archive/refs/tags/ver_${pg_repack_release}.tar.gz" \
-    /tmp/pg_repack.tar.gz
-RUN tar -xvf /tmp/pg_repack.tar.gz -C /tmp && \
-    rm -rf /tmp/pg_repack.tar.gz
-# Install build dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    liblz4-dev \
-    libz-dev \
-    libzstd-dev \
-    libreadline-dev \
-    && rm -rf /var/lib/apt/lists/*
-# Build from source
-WORKDIR /tmp/pg_repack-ver_${pg_repack_release}
-ENV USE_PGXS=1
-RUN --mount=type=cache,target=/ccache,from=public.ecr.aws/supabase/postgres:ccache \
-    make -j$(nproc)
-# Create debian package
-RUN checkinstall -D --install=no --fstrans=no --backup=no --pakdir=/tmp --pkgversion=${pg_repack_release} --nodoc
-
-####################
 # 28-pgvector.yml
 ####################
 FROM ccache as pgvector-source
@@ -850,7 +823,6 @@ COPY --from=vault-source /tmp/*.deb /tmp/
 COPY --from=pgroonga-source /tmp/*.deb /tmp/
 COPY --from=wrappers /tmp/*.deb /tmp/
 COPY --from=hypopg-source /tmp/*.deb /tmp/
-COPY --from=pg_repack-source /tmp/*.deb /tmp/
 COPY --from=pgvector-source /tmp/*.deb /tmp/
 COPY --from=pg_tle-source /tmp/*.deb /tmp/
 COPY --from=supautils /tmp/*.deb /tmp/

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ Unmodified Postgres with some useful plugins. Our goal with this repo is not to 
 | [pgsodium](https://github.com/michelp/pgsodium) | [3.1.0](https://github.com/michelp/pgsodium/releases/tag/2.0.0) | Modern encryption API using libsodium. |
 | [pg_stat_monitor](https://github.com/percona/pg_stat_monitor) | [1.0.1](https://github.com/percona/pg_stat_monitor/releases/tag/1.0.1) | Query Performance Monitoring Tool for PostgreSQL
 | [pgvector](https://github.com/pgvector/pgvector) | [v0.4.0](https://github.com/pgvector/pgvector/releases/tag/v0.4.0) | Open-source vector similarity search for Postgres
-| [pg_repack](https://github.com/reorg/pg_repack) | [ver_1.4.8](https://github.com/reorg/pg_repack/releases/tag/ver_1.4.8) | Tool to remove bloat from tables and indexes 
 
 
 Can't find your favorite extension? Suggest for it to be added into future releases [here](https://github.com/supabase/supabase/discussions/679)!

--- a/docker/orioledb/Dockerfile
+++ b/docker/orioledb/Dockerfile
@@ -32,7 +32,6 @@ ARG groonga_release=12.0.8
 ARG pgroonga_release=2.4.0
 ARG wrappers_release=0.2.0
 ARG hypopg_release=1.3.1
-ARG pg_repack_release=1.4.8
 ARG pgvector_release=0.4.0
 ARG pg_tle_release=1.0.3
 ARG supautils_release=1.9.0
@@ -840,34 +839,6 @@ RUN --mount=type=cache,target=/ccache,from=public.ecr.aws/supabase/postgres:ccac
 RUN checkinstall -D --install=no --fstrans=no --backup=no --pakdir=/tmp --nodoc
 
 ####################
-# 27-pg_repack.yml
-####################
-FROM ccache as pg_repack-source
-ARG pg_repack_release
-ARG pg_repack_release_checksum
-ADD --checksum=${pg_repack_release_checksum} \
-    "https://github.com/reorg/pg_repack/archive/refs/tags/ver_${pg_repack_release}.tar.gz" \
-    /tmp/pg_repack.tar.gz
-RUN tar -xvf /tmp/pg_repack.tar.gz -C /tmp && \
-    rm -rf /tmp/pg_repack.tar.gz
-# Install build dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    liblz4-dev \
-    libz-dev \
-    libzstd-dev \
-    libreadline-dev \
-    && rm -rf /var/lib/apt/lists/*
-# Build from source
-WORKDIR /tmp/pg_repack-ver_${pg_repack_release}
-# Makefile:29: *** pg_repack requires PostgreSQL 9.4 or later. This is 3.  Stop.
-RUN sed -i -e "s|904|3|g" Makefile
-ENV USE_PGXS=1
-RUN --mount=type=cache,target=/ccache,from=public.ecr.aws/supabase/postgres:ccache \
-    make -j$(nproc)
-# Create debian package
-RUN checkinstall -D --install=no --fstrans=no --backup=no --pakdir=/tmp --pkgversion=${pg_repack_release} --nodoc
-
-####################
 # 28-pgvector.yml
 ####################
 FROM ccache as pgvector-source
@@ -972,7 +943,6 @@ COPY --from=vault-source /tmp/*.deb /tmp/
 COPY --from=pgroonga-source /tmp/*.deb /tmp/
 COPY --from=wrappers-source /tmp/*.deb /tmp/
 COPY --from=hypopg-source /tmp/*.deb /tmp/
-COPY --from=pg_repack-source /tmp/*.deb /tmp/
 COPY --from=pgvector-source /tmp/*.deb /tmp/
 COPY --from=pg_tle-source /tmp/*.deb /tmp/
 COPY --from=supautils-source /tmp/*.deb /tmp/


### PR DESCRIPTION
We attempted to remove pg_repack in:
https://github.com/supabase/postgres/pull/757
https://github.com/supabase/supabase/pull/18476

but missed a few (important) references. It is non-functional on hosted supabase as it requires superuser and has no SQL bindings that would allow end-users to trigger a repack