### PR TITLE
fix: install packer plugins

### DIFF
--- a/.github/workflows/ami-release.yml
+++ b/.github/workflows/ami-release.yml
@@ -88,6 +88,7 @@ jobs:
 
       - name: Build AMI
         run: |
+          packer init amazon-arm64.pkr.hcl
           GIT_SHA=${{github.sha}}
           packer build -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${GITHUB_RUN_ID}" -var-file="development-arm.vars.pkr.hcl" -var-file="common.vars.pkr.hcl" -var "ansible_arguments="  amazon-arm64.pkr.hcl
 

--- a/.github/workflows/testinfra.yml
+++ b/.github/workflows/testinfra.yml
@@ -123,6 +123,7 @@ jobs:
       # https://github.com/hashicorp/packer/issues/4899
       - name: Build AMI
         run: |
+          packer init amazon-arm64.pkr.hcl
           GIT_SHA=${{github.sha}}
           packer build -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${GITHUB_RUN_ID}" -var-file="development-arm.vars.pkr.hcl" -var-file="common.vars.pkr.hcl" -var "ansible_arguments=" -var "postgres-version=ci-ami-test" -var "region=ap-southeast-1" -var 'ami_regions=["ap-southeast-1"]' -var "force-deregister=true" amazon-arm64.pkr.hcl
 

--- a/amazon-arm64.pkr.hcl
+++ b/amazon-arm64.pkr.hcl
@@ -92,6 +92,15 @@ variable "force-deregister" {
   default = false
 }
 
+packer {
+  required_plugins {
+    amazon = {
+      source  = "github.com/hashicorp/amazon"
+      version = "~> 1"
+    }
+  }
+}
+
 # source block
 source "amazon-ebssurrogate" "source" {
   profile = "${var.profile}"


### PR DESCRIPTION
Bundled version of the `amazon` plugin is likely too old. We need at least [v1.2.3](https://github.com/hashicorp/packer-plugin-amazon/releases/tag/v1.2.3) for auto assign public ip to correctly work with the default vpc. This change should explicitly install the latest version.

Tested with latest `v1.3.0` version

Also needs `ec2:DescribeVpcs`, `ec2:DescribeInstanceTypeOfferings` permissions