### PR TITLE
fix: remove pgbouncer test from ami tests

### DIFF
--- a/testinfra/test_ami.py
+++ b/testinfra/test_ami.py
@@ -293,11 +293,6 @@ runcmd:
             logger.warning("kong not ready")
             return False
 
-        cmd = host.run("printf \\\\0 > '/dev/tcp/localhost/6543'")
-        if cmd.failed is True:
-            logger.warning("pgbouncer not ready")
-            return False
-
         cmd = host.run("sudo fail2ban-client status")
         if cmd.failed is True:
             logger.warning("fail2ban not ready")


### PR DESCRIPTION
we're not enabling / starting pgbouncer anymore, test would always fail with: `WARNING  pgbouncer not ready`

https://github.com/supabase/postgres/actions/runs/7790473620/job/21258468293?pr=878