### PR TITLE
Upgrade pgvector to 0.6.0

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -132,8 +132,8 @@ wrappers_release: "0.2.0"
 hypopg_release: "1.3.1"
 hypopg_release_checksum: sha256:e7f01ee0259dc1713f318a108f987663d60f3041948c2ada57a94b469565ca8e
 
-pgvector_release: "0.5.1"
-pgvector_release_checksum: sha256:cc7a8e034a96e30a819911ac79d32f6bc47bdd1aa2de4d7d4904e26b83209dc8
+pgvector_release: "0.6.0"
+pgvector_release_checksum: sha256:b0cf4ba1ab016335ac8fb1cada0d2106235889a194fffeece217c5bda90b2f19
 
 pg_tle_release: "1.3.2"
 pg_tle_release_checksum: sha256:d04f72d88b21b954656609743560684ac42645b64a36c800d4d2f84d1f180de1


### PR DESCRIPTION
Upgrades pgvector to 0.6.0

It is a backwards compatible release