### PR TITLE
feat: bump auth version to v2.140.0

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -15,8 +15,8 @@ postgrest_release: "12.0.2"
 postgrest_arm_release_checksum: sha1:a08eaa2af548d44b4c8ea61b0223fb7019f5c768
 postgrest_x86_release_checksum: sha1:40f65ded06b9de6567fbe2cd7a317196e22dd595
 
-gotrue_release: 2.139.2
-gotrue_release_checksum: sha1:93e77fc720a97885f252a4a43203fc601adbf03c
+gotrue_release: 2.140.0
+gotrue_release_checksum: sha1:de65b2366db647e1f8992b4c496e87268833cfc9
 
 aws_cli_release: "2.2.7"
 

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.1.14"
+postgres-version = "15.1.1.15"


### PR DESCRIPTION
We recently published v2.140.0 as we had issues publishing auth v2.139.2. This resulted in build failure on AIO image This PR attempts a release of postgres with v2.140.0 so that AIO image goes through