### PR TITLE
fix: search_path /$user remove backslash

### DIFF
--- a/migrations/db/init-scripts/00000000000003-post-setup.sql
+++ b/migrations/db/init-scripts/00000000000003-post-setup.sql
@@ -1,7 +1,7 @@
 -- migrate:up
 
-ALTER ROLE supabase_admin SET search_path TO "\$user",public,auth,extensions;
-ALTER ROLE postgres SET search_path TO "\$user",public,extensions;
+ALTER ROLE supabase_admin SET search_path TO "$user",public,auth,extensions;
+ALTER ROLE postgres SET search_path TO "$user",public,extensions;
 
 -- Trigger for pg_cron
 CREATE OR REPLACE FUNCTION extensions.grant_pg_cron_access()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The current search_path has "/$user" rather than the default value

## What is the new behavior?

The search_path has "$user" with the slash removed
