### PR TITLE
fix: Kong - gracefully shutdown and ensure stopped before Envoy started; Envoy - check if ports 80 or 443 already in use

### DIFF
--- a/ansible/files/envoy.service
+++ b/ansible/files/envoy.service
@@ -7,6 +7,8 @@ Conflicts=kong.service
 [Service]
 Type=simple
 
+ExecStartPre=sh -c 'if ss -lnt | grep -Eq ":(80|443) "; then echo "Port 80 or 443 already in use"; exit 1; fi'
+
 # Need to run via a restarter script to support hot restart when using a process
 # manager, see:
 # https://www.envoyproxy.io/docs/envoy/latest/operations/hot_restarter
@@ -20,8 +22,8 @@ Restart=always
 RestartSec=3
 LimitNOFILE=100000
 
-# The envoy user is unpriviledged and thus not permited to bind on ports < 1024
-# Via systemd we grant the process a set of priviledges to bind to 80/443
+# The envoy user is unprivileged and thus not permitted to bind on ports < 1024
+# Via systemd we grant the process a set of privileges to bind to 80/443
 # See http://archive.vn/36zJU
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 

--- a/ansible/files/kong_config/kong.service.j2
+++ b/ansible/files/kong_config/kong.service.j2
@@ -8,7 +8,7 @@ Conflicts=envoy.service
 Type=forking
 ExecStart=/usr/local/bin/kong start -c /etc/kong/kong.conf
 ExecReload=/usr/local/bin/kong reload -c /etc/kong/kong.conf
-ExecStop=/usr/local/bin/kong stop
+ExecStop=/usr/local/bin/kong quit
 User=kong
 EnvironmentFile=/etc/kong/kong.env
 Slice=services.slice
@@ -16,8 +16,8 @@ Restart=always
 RestartSec=3
 LimitNOFILE=100000
 
-# The kong user is unpriviledged and thus not permited to bind on ports < 1024
-# Via systemd we grant the process a set of priviledges to bind to 80/443
+# The kong user is unprivileged and thus not permitted to bind on ports < 1024
+# Via systemd we grant the process a set of privileges to bind to 80/443
 # See http://archive.vn/36zJU
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 

--- a/ansible/files/kong_config/kong.service.j2
+++ b/ansible/files/kong_config/kong.service.j2
@@ -4,6 +4,9 @@ After=postgrest.service gotrue.service adminapi.service
 Wants=postgrest.service gotrue.service adminapi.service
 Conflicts=envoy.service
 
+# Ensures that Kong service is stopped before Envoy service is started
+Before=envoy.service
+
 [Service]
 Type=forking
 ExecStart=/usr/local/bin/kong start -c /etc/kong/kong.conf

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.1.20"
+postgres-version = "15.1.1.21"

--- a/docker/all-in-one/etc/supervisor/services/envoy.conf
+++ b/docker/all-in-one/etc/supervisor/services/envoy.conf
@@ -1,6 +1,4 @@
 [program:envoy]
-# Workaround using `tee` to get `/dev/stdout` access logging to work, see:
-# https://github.com/envoyproxy/envoy/issues/8297#issuecomment-620659781
 command=/opt/envoy-hot-restarter.py /opt/start-envoy.sh
 user=envoy
 autorestart=true


### PR DESCRIPTION
**fix: gracefully shutdown Kong on service stop**

`kong quit` is already used within `start-kong.sh` for the all-in-one image. The sole purpose of `start-kong.sh` is to trap exit to run `kong quit`, perhaps `stopsignal=QUIT` in the supervisord config would be equivalent, but it ain't broke.

**fix: ensure that Kong service is stopped before Envoy service is started**

Per https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#Before=, "Given two units with any ordering dependency between them, if one unit is shut down and the other is started up, the shutdown is ordered before the start-up. It doesn't matter if the ordering dependency is After= or Before=, in this case. It also doesn't matter which of the two is shut down, as long as one is shut down and the other is started up; the shutdown is ordered before the start-up in all cases. If two units have no ordering dependencies between them, they are shut down or started up simultaneously, and no ordering takes place."

Also ensures that Envoy will take priority over Kong on reboot if both are enabled.

**fix: check if port 80 or 443 is already in use before starting Envoy**

Envoy doesn't exit if it can't bind ports for all its listeners, and I couldn't find any configuration option to make it do so.

With this, auto-restart will kick in until both ports are no longer in use.

May not be necessary after the previous fix to ensure that Kong service is stopped before Envoy service is started, but doesn't hurt to have multiple defensive measures, since it's somewhat unexpected that Envoy doesn't exit on such failures.