### PR TITLE
fix: use dedicated role for pg_upgrade

### DIFF
--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.1.24"
+postgres-version = "15.1.1.24-pg-upgrade-1"


### PR DESCRIPTION
[Context](https://supabase.slack.com/archives/C01D6TWFFFW/p1702959923630909)

The hypothesis is pg_upgrade changes all extensions' owner to whichever username was used for the upgrade. If that's the case, performing the pg_upgrade with a dedicated role and then `REASSIGN OWNED`-ing it should (🤞) solve the above issue.