### PR TITLE
fix: remove auth stats collection from postgres_exporter

### DIFF
--- a/docker/all-in-one/opt/postgres_exporter/queries.yml
+++ b/docker/all-in-one/opt/postgres_exporter/queries.yml
@@ -179,30 +179,6 @@ auth_users:
         usage: "GAUGE"
         description: "Number of users in the project db"
 
-auth_stats:
-  master: true
-  cache_seconds: 3600
-  query: |
-    select
-      count(*) filter (
-        where payload ->> 'action' = 'user_invited'
-           or (payload ->> 'action' in ('user_confirmation_requested', 'user_recovery_requested')
-               and payload ->> 'actor_username' like '%@%')
-      ) as total_auth_emails,
-      count(*) filter (
-        where payload ->> 'action' in ('user_confirmation_requested', 'user_recovery_requested')
-          and payload ->> 'actor_username' not like '%@%'
-        ) as total_auth_texts
-    from
-      auth.audit_log_entries
-  metrics:
-    - total_auth_emails:
-        usage: "COUNTER"
-        description: "Total number of auth emails sent"
-    - total_auth_texts:
-        usage: "COUNTER"
-        description: "Total number of auth texts sent"
-
 realtime:
   master: true
   cache_seconds: 60


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to remove auth stats collection from postgres_exporter, which caused performance issue on user's db with a large `auth.audit_log_entries` table. Below 2 metrics will be removed after this PR:

total_auth_emails
total_auth_texts

Context: https://supabase.slack.com/archives/C022071RB2L/p1709132413873409

HubSpot ticket: https://app.hubspot.com/live-messages/19953346/inbox/6610456592#comment

## What is the current behavior?

This regular stats collection query caused high cpu spikes on user's db, which has a large `auth.audit_log_entries` table.

## What is the new behavior?

Removed that stats collection query should remove high cpu spikes it casued.

## Additional context

Also raised same PR on infra repo: https://github.com/supabase/infrastructure/pull/17391