### PR TITLE
WIP: prevent postgres from mutating migration history

### DIFF
--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.1.69"
+postgres-version = "15.1.1.69-revoke-auth-admin"

--- a/migrations/db/migrations/20240627101908_revoke_supabase_auth_admin_from_postgres.sql
+++ b/migrations/db/migrations/20240627101908_revoke_supabase_auth_admin_from_postgres.sql
@@ -1,0 +1,6 @@
+-- migrate:up
+revoke supabase_auth_admin from postgres;
+revoke create on schema auth from postgres;
+revoke all on auth.schema_migrations from dashboard_user, postgres;
+
+-- migrate:down

--- a/migrations/tests/database/privs.sql
+++ b/migrations/tests/database/privs.sql
@@ -31,3 +31,4 @@ SELECT schema_privs_are('extensions', 'service_role', array['USAGE']);
 -- Role memberships
 SELECT is_member_of('pg_read_all_data', 'postgres');
 SELECT is_member_of('pg_signal_backend', 'postgres');
+SELECT isnt_member_of('supabase_auth_admin', 'postgres');


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Adds RLS policy to auth and storage schema to prevent postgres from accidentally updating migration history.

## Additional context

Add any other context or screenshots.