### PR TITLE
chore: allow manual workflows for Release Docker AIO image [GEN-8551]

### DIFF
--- a/.github/workflows/dockerhub-release-aio.yml
+++ b/.github/workflows/dockerhub-release-aio.yml
@@ -13,6 +13,7 @@ on:
       - develop
     types:
       - completed
+  workflow_dispatch:
 
 jobs:
   settings:


### PR DESCRIPTION
To allow manually triggering a new docker aio image from other branches, in order to test new images in Fly, similar to Release AMI workflow.

This change will only affect the AIO image, not the base Dockerfile/image.