### PR TITLE
fix: typo - missing space on dockerhub-release-aio.yml [GEN-8551]

### DIFF
--- a/.github/workflows/dockerhub-release-aio.yml
+++ b/.github/workflows/dockerhub-release-aio.yml
@@ -35,7 +35,7 @@ jobs:
         run: sed -r 's/(\s|\")+//g' common.vars.pkr.hcl >> $GITHUB_OUTPUT
       - id: base_docker
         run: |
-          if [[ "${{ inputs.baseDockerVersion }}" != ""]]; then
+          if [[ "${{ inputs.baseDockerVersion }}" != "" ]]; then
             echo "base-docker-version=${{ inputs.baseDockerVersion }}" >> $GITHUB_OUTPUT
           else
             echo "base-docker-version=${{ steps.settings.outputs.postgres-version }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Fixing a typo on dockerhub-release-aio.yml that was making actions fail.