### PR TITLE
chore: bump auth version to v2.146.0

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -15,8 +15,8 @@ postgrest_release: "12.0.2"
 postgrest_arm_release_checksum: sha1:a08eaa2af548d44b4c8ea61b0223fb7019f5c768
 postgrest_x86_release_checksum: sha1:40f65ded06b9de6567fbe2cd7a317196e22dd595
 
-gotrue_release: 2.145.0
-gotrue_release_checksum: sha1:b3301a41637008f1f2b0c3c2969fd2ddf28a2f7a
+gotrue_release: 2.146.0
+gotrue_release_checksum: sha1:d9538779ae954516fccc38fdd6be89f5db522499
 
 aws_cli_release: "2.2.7"
 

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.1.36"
+postgres-version = "15.1.1.37"


### PR DESCRIPTION
## What kind of change does this PR introduce?
* bump the auth version to [v2.146.0](https://github.com/supabase/auth/releases/tag/v2.146.0)

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
