### PR TITLE
chore: drop nixConfig from the flake, we config on install now

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,16 +8,6 @@
     nix-editor.url = "github:snowfallorg/nix-editor";
   };
 
-  nixConfig = {
-    extra-substituters = [
-      "https://nix-postgres-artifacts.s3.amazonaws.com"
-    ];
-
-    extra-trusted-public-keys = [
-      "nix-cache.supabase.com-1:ZfEc7Qb7SN+qOTJGMtCz54rnVQ1W2ZI2ROCSSD6YQYc="
-    ];
-  };
-
   outputs = { self, nixpkgs, flake-utils, nix2container, nix-editor, ...}:
     let
       gitRev = "vcs=${self.shortRev or "dirty"}+${builtins.substring 0 8 (self.lastModifiedDate or self.lastModified or "19700101")}";


### PR DESCRIPTION
## What kind of change does this PR introduce?

This is just a maint. PR to remove a bit of our nix expression that we no longer need

if we keep nixConfig in the expression, nix will launch an interactive prompt asking us if we're sure we want to do it

Instead going forward, we configure this in our Dockerfile for CI, or as `--extra-args` for the installer when building AMI