### PR TITLE
chore: run logrotate every 5 mins

### DIFF
--- a/ansible/tasks/finalize-ami.yml
+++ b/ansible/tasks/finalize-ami.yml
@@ -67,7 +67,7 @@
   shell:
     cmd: |
         cp  /usr/lib/systemd/system/logrotate.timer /etc/systemd/system/logrotate.timer
-        sed -i -e 's;daily;*:0/10;' /etc/systemd/system/logrotate.timer
+        sed -i -e 's;daily;*:0/5;' /etc/systemd/system/logrotate.timer
         systemctl reenable logrotate.timer
   become: yes
 


### PR DESCRIPTION
Some log files get produced at a rate faster than can be handled under
our current 10min freq.