### PR TITLE
feat: postgis built in our bundle again and matching version we need

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,6 +51,7 @@
             # want to have an arbitrary order, since it might matter. being
             # explicit is better.
             (import ./nix/overlays/cargo-pgrx-0-11-3.nix)
+            # (import ./nix/overlays/postgis.nix)
             #(import ./nix/overlays/gdal-small.nix)
 
           ];
@@ -78,7 +79,7 @@
         # may also bring in new versions of the extensions.
         psqlExtensions = [
           /* pljava */
-          "postgis"
+          /*"postgis"*/
         ];
 
         #FIXME for now, timescaledb is not included in the orioledb version of supabase extensions, as there is an issue
@@ -108,7 +109,7 @@
           ./nix/ext/plpgsql-check.nix
           ./nix/ext/pgjwt.nix
           ./nix/ext/pgaudit.nix
-          #./nix/ext/postgis.nix
+          ./nix/ext/postgis.nix
           ./nix/ext/pgrouting.nix
           ./nix/ext/pgtap.nix
           ./nix/ext/pg_cron.nix
@@ -135,7 +136,7 @@
 
         #this var is a convenience setting to import the orioledb patched version of postgresql
         postgresql_orioledb_16 = oriole_pkgs.postgresql_orioledb_16;
-        postgis_override = pkgs.postgis_override;
+        #postgis_override = pkgs.postgis_override;
 
         # Create a 'receipt' file for a given postgresql package. This is a way
         # of adding a bit of metadata to the package, which can be used by other

--- a/nix/ext/postgis.nix
+++ b/nix/ext/postgis.nix
@@ -5,38 +5,44 @@
 , postgresql
 , geos
 , proj
-, gdal
+, gdalMinimal
 , json_c
 , pkg-config
 , file
 , protobufc
 , libiconv
+, pcre2
 , nixosTests
 }:
+
+let
+  gdal = gdalMinimal;
+in
 stdenv.mkDerivation rec {
   pname = "postgis";
   version = "3.3.2";
 
   outputs = [ "out" "doc" ];
 
-    src = fetchurl {
+  src = fetchurl {
     url = "https://download.osgeo.org/postgis/source/postgis-${version}.tar.gz";
     sha256 = "sha256-miohnaAFoXMKOdGVmhx87GGbHvsAm2W+gP/CW60pkGg=";
   };
 
-  buildInputs = [ libxml2 postgresql geos proj gdal json_c protobufc ]
+  buildInputs = [ libxml2 postgresql geos proj gdal json_c protobufc pcre2.dev ]
                 ++ lib.optional stdenv.isDarwin libiconv;
-  nativeBuildInputs = [ perl pkg-config ] ++ lib.optional postgresql.jitSupport postgresql.llvm;
+  nativeBuildInputs = [ perl pkg-config ];
   dontDisableStatic = true;
 
   # postgis config directory assumes /include /lib from the same root for json-c library
-  NIX_LDFLAGS = "-L${lib.getLib json_c}/lib";
+  env.NIX_LDFLAGS = "-L${lib.getLib json_c}/lib";
+
 
   preConfigure = ''
     sed -i 's@/usr/bin/file@${file}/bin/file@' configure
-    configureFlags="--datadir=$out/share/postgresql --datarootdir=$out/share/postgresql --bindir=$out/bin --with-gdalconfig=${gdal}/bin/gdal-config --with-jsondir=${json_c.dev}"
+    configureFlags="--datadir=$out/share/postgresql --datarootdir=$out/share/postgresql --bindir=$out/bin --docdir=$doc/share/doc/${pname} --with-gdalconfig=${gdal}/bin/gdal-config --with-jsondir=${json_c.dev} --disable-extension-upgrades-install"
 
-    makeFlags="PERL=${perl}/bin/perl datadir=$out/share/postgresql pkglibdir=$out/lib bindir=$out/bin"
+    makeFlags="PERL=${perl}/bin/perl datadir=$out/share/postgresql pkglibdir=$out/lib bindir=$out/bin docdir=$doc/share/doc/${pname}"
   '';
   postConfigure = ''
     sed -i "s|@mkdir -p \$(DESTDIR)\$(PGSQL_BINDIR)||g ;
@@ -50,7 +56,7 @@ stdenv.mkDerivation rec {
 
     # postgis' build system assumes it is being installed to the same place as postgresql, and looks
     # for the postgres binary relative to $PREFIX. We gently support this system using an illusion.
-    ln -s ${postgresql_15}/bin/postgres $out/bin/postgres
+    ln -s ${postgresql}/bin/postgres $out/bin/postgres
   '';
 
   # create aliases for all commands adding version information
@@ -73,7 +79,7 @@ stdenv.mkDerivation rec {
     homepage = "https://postgis.net/";
     changelog = "https://git.osgeo.org/gitea/postgis/postgis/raw/tag/${version}/NEWS";
     license = licenses.gpl2;
-    maintainers = [ samrose ];
+    maintainers = with maintainers; teams.geospatial.members ++ [ marcweber wolfgangwalther ];
     inherit (postgresql.meta) platforms;
   };
 }

--- a/nix/overlays/postgis.nix
+++ b/nix/overlays/postgis.nix
@@ -1,0 +1,7 @@
+final: prev: {
+  postgis = prev.postgresqlPackages.postgis.overrideAttrs (old: {
+    version = "3.3.2";
+    sha256 = "";
+  });
+  postgresqlPackages.postgis = final.postgis;
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

In order to control specific versions we need to package all extensions ourselves 

So, we brought postgis from upstream to building it within our package set. 