### PR TITLE
chore: bump gotrue version to 2.149.0

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -15,8 +15,8 @@ postgrest_release: "12.0.2"
 postgrest_arm_release_checksum: sha1:a08eaa2af548d44b4c8ea61b0223fb7019f5c768
 postgrest_x86_release_checksum: sha1:40f65ded06b9de6567fbe2cd7a317196e22dd595
 
-gotrue_release: 2.148.0
-gotrue_release_checksum: sha1:e3ab39c10605b6a00a953528022b563c8fa1ca33
+gotrue_release: 2.149.0
+gotrue_release_checksum: sha1:ab6868c4358524427e4ac0de925d7831241848c0
 
 aws_cli_release: "2.2.7"
 

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.1.42"
+postgres-version = "15.1.1.43"


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Bump gotrue to v2.149.0 ([changelog](https://github.com/supabase/auth/releases/tag/v2.149.0))
* Fixes an issue with the linkedin oauth provider