### PR TITLE
Update pgvector to 0.7.0

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -135,8 +135,8 @@ hypopg_release_checksum: sha256:e7f01ee0259dc1713f318a108f987663d60f3041948c2ada
 pg_repack_release: "1.5.0"
 pg_repack_release_checksum: sha256:9a14d6a95bfa29f856aa10538238622c1f351d38eb350b196c06720a878ccc52
 
-pgvector_release: "0.6.2"
-pgvector_release_checksum: sha256:a11cc249a9f3f3d7b13069a1696f2915ac28991a72d7ba4e2bcfdceddbaeae49
+pgvector_release: "0.7.0"
+pgvector_release_checksum: sha256:1b5503a35c265408b6eb282621c5e1e75f7801afc04eecb950796cfee2e3d1d8
 
 pg_tle_release: "1.3.2"
 pg_tle_release_checksum: sha256:d04f72d88b21b954656609743560684ac42645b64a36c800d4d2f84d1f180de1

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.1.44"
+postgres-version = "15.1.1.45"

--- a/nix/ext/pgvector.nix
+++ b/nix/ext/pgvector.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "pgvector";
-  version = "0.6.0";
+  version = "0.7.0";
 
   buildInputs = [ postgresql ];
 
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner = "pgvector";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-hXm+k0BZ9xZP1Tnek14jPoKCPQkA5ovscu9IX2mW7Kc=";
+    hash = "sha256-vFn7sNphOYyig6Jl1HILMaC2t9strFQBQ8ywL8Ibx1M=";
   };
 
   installPhase = ''


### PR DESCRIPTION
Updates pgvector to 0.7.0 for halfvec and sparsevec types

- [x] Confirmed backwards compatible

