### PR TITLE
fix: remove spurious newline

### DIFF
--- a/.github/workflows/publish-pgupgrade-scripts.yml
+++ b/.github/workflows/publish-pgupgrade-scripts.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Grab release version
         id: process_release_version
         run: |
-          VERSION=$(sed -e 's/postgres-version = "\(.*\)"/\1/g' common.vars.pkr.hcl)
+          VERSION=$(grep 'postgres-version' common.vars.pkr.hcl | sed -e 's/postgres-version = "\(.*\)"/\1/g')
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Create a tarball containing pg_upgrade scripts

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,2 +1,1 @@
-
 postgres-version = "15.1.1.47"


### PR DESCRIPTION
Not immediately obvious why, but causes the version string extraction
to break for upgrade script publication

https://github.com/supabase/postgres/actions/runs/8900354674/job/24441719357