### PR TITLE
chore: bump PostgREST to devel release

### DIFF
--- a/ansible/manifest-playbook.yml
+++ b/ansible/manifest-playbook.yml
@@ -40,7 +40,7 @@
 
     - name: PostgREST - download ubuntu binary archive (arm)
       get_url:
-        url: "https://github.com/PostgREST/postgrest/releases/download/v{{ postgrest_release }}/postgrest-v{{ postgrest_release }}-ubuntu-aarch64.tar.xz"
+        url: "https://github.com/PostgREST/postgrest/releases/download/{{ postgrest_release }}/postgrest-{{ postgrest_release }}-ubuntu-aarch64.tar.xz"
         dest: /tmp/postgrest-{{ postgrest_release }}-arm64.tar.xz
         checksum: "{{ postgrest_arm_release_checksum }}"
         timeout: 60

--- a/ansible/manifest-playbook.yml
+++ b/ansible/manifest-playbook.yml
@@ -40,7 +40,8 @@
 
     - name: PostgREST - download ubuntu binary archive (arm)
       get_url:
-        url: "https://github.com/PostgREST/postgrest/releases/download/{{ postgrest_release }}/postgrest-{{ postgrest_release }}-ubuntu-aarch64.tar.xz"
+        url: "https://supabase-public-artifacts-bucket.s3.amazonaws.com/postgrest/postgrest-v{{ postgrest_release }}-ubuntu-aarch64.tar.xz"
+        # url: "https://github.com/PostgREST/postgrest/releases/download/{{ postgrest_release }}/postgrest-{{ postgrest_release }}-ubuntu-aarch64.tar.xz"
         dest: /tmp/postgrest-{{ postgrest_release }}-arm64.tar.xz
         checksum: "{{ postgrest_arm_release_checksum }}"
         timeout: 60

--- a/ansible/tasks/setup-postgrest.yml
+++ b/ansible/tasks/setup-postgrest.yml
@@ -17,7 +17,8 @@
 
 - name: PostgREST - download ubuntu binary archive (arm)
   get_url:
-    url: "https://github.com/PostgREST/postgrest/releases/download/{{ postgrest_release }}/postgrest-{{ postgrest_release }}-ubuntu-aarch64.tar.xz"
+    url: "https://supabase-public-artifacts-bucket.s3.amazonaws.com/postgrest/postgrest-v{{ postgrest_release }}-ubuntu-aarch64.tar.xz"
+    # url: "https://github.com/PostgREST/postgrest/releases/download/v{{ postgrest_release }}/postgrest-v{{ postgrest_release }}-ubuntu-aarch64.tar.xz"
     dest: /tmp/postgrest.tar.xz
     checksum: "{{ postgrest_arm_release_checksum }}"
     timeout: 60
@@ -25,7 +26,8 @@
 
 - name: PostgREST - download ubuntu binary archive (x86)
   get_url:
-    url: "https://github.com/PostgREST/postgrest/releases/download/{{ postgrest_release }}/postgrest-{{ postgrest_release }}-linux-static-x64.tar.xz"
+    url: "https://supabase-public-artifacts-bucket.s3.amazonaws.com/postgrest/postgrest-v{{ postgrest_release }}-linux-static-x64.tar.xz"
+    # url: "https://github.com/PostgREST/postgrest/releases/download/v{{ postgrest_release }}/postgrest-v{{ postgrest_release }}-linux-static-x64.tar.xz"
     dest: /tmp/postgrest.tar.xz
     checksum: "{{ postgrest_x86_release_checksum }}"
     timeout: 60    

--- a/ansible/tasks/setup-postgrest.yml
+++ b/ansible/tasks/setup-postgrest.yml
@@ -17,7 +17,7 @@
 
 - name: PostgREST - download ubuntu binary archive (arm)
   get_url:
-    url: "https://github.com/PostgREST/postgrest/releases/download/v{{ postgrest_release }}/postgrest-v{{ postgrest_release }}-ubuntu-aarch64.tar.xz"
+    url: "https://github.com/PostgREST/postgrest/releases/download/{{ postgrest_release }}/postgrest-{{ postgrest_release }}-ubuntu-aarch64.tar.xz"
     dest: /tmp/postgrest.tar.xz
     checksum: "{{ postgrest_arm_release_checksum }}"
     timeout: 60
@@ -25,7 +25,7 @@
 
 - name: PostgREST - download ubuntu binary archive (x86)
   get_url:
-    url: "https://github.com/PostgREST/postgrest/releases/download/v{{ postgrest_release }}/postgrest-v{{ postgrest_release }}-linux-static-x64.tar.xz"
+    url: "https://github.com/PostgREST/postgrest/releases/download/{{ postgrest_release }}/postgrest-{{ postgrest_release }}-linux-static-x64.tar.xz"
     dest: /tmp/postgrest.tar.xz
     checksum: "{{ postgrest_x86_release_checksum }}"
     timeout: 60    

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -11,9 +11,9 @@ pgbouncer_release: "1.19.0"
 pgbouncer_release_checksum: sha256:af0b05e97d0e1fd9ad45fe00ea6d2a934c63075f67f7e2ccef2ca59e3d8ce682
 
 # to get these use `wget https://github.com/PostgREST/postgrest/releases/download/v12.0.2/postgrest-v12.0.2-ubuntu-aarch64.tar.xz -q -O- | sha1sum`
-postgrest_release: "12.0.2"
-postgrest_arm_release_checksum: sha1:a08eaa2af548d44b4c8ea61b0223fb7019f5c768
-postgrest_x86_release_checksum: sha1:40f65ded06b9de6567fbe2cd7a317196e22dd595
+postgrest_release: "devel"
+postgrest_arm_release_checksum: sha1:a61633a4118eaefd5351ad236744fd84fbb7886e
+postgrest_x86_release_checksum: sha1:d57eecdf732b7fd2a38889b35f1ed484a719d003
 
 gotrue_release: 2.151.0
 gotrue_release_checksum: sha1:5a43a9879499d85714ba34356f62f5e8063b549d

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -11,7 +11,7 @@ pgbouncer_release: "1.19.0"
 pgbouncer_release_checksum: sha256:af0b05e97d0e1fd9ad45fe00ea6d2a934c63075f67f7e2ccef2ca59e3d8ce682
 
 # to get these use `wget https://github.com/PostgREST/postgrest/releases/download/v12.0.2/postgrest-v12.0.2-ubuntu-aarch64.tar.xz -q -O- | sha1sum`
-postgrest_release: "devel"
+postgrest_release: "12.0.2-listeners-alpha"
 postgrest_arm_release_checksum: sha1:a61633a4118eaefd5351ad236744fd84fbb7886e
 postgrest_x86_release_checksum: sha1:d57eecdf732b7fd2a38889b35f1ed484a719d003
 

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.1.53"
+postgres-version = "15.1.1.54"


### PR DESCRIPTION
* Bump PostgREST to the devel release: https://github.com/PostgREST/postgrest/releases/tag/devel