### PR TITLE
Update postgresql.conf to increase max_slot_wal_keep_size

### DIFF
--- a/ansible/files/postgresql_config/postgresql.conf.j2
+++ b/ansible/files/postgresql_config/postgresql.conf.j2
@@ -300,7 +300,7 @@ max_wal_senders = 10		# max number of walsender processes
 max_replication_slots = 5	# max number of replication slots
 				# (change requires restart)
 #wal_keep_size = 0		# in megabytes; 0 disables
-max_slot_wal_keep_size = 1024   # in megabytes; -1 disables
+max_slot_wal_keep_size = 4096   # in megabytes; -1 disables
 #wal_sender_timeout = 60s	# in milliseconds; 0 disables
 #track_commit_timestamp = off	# collect timestamp of transaction commit
 				# (change requires restart)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Increases `max_slot_wal_keep_size` default from 1GB

## What is the current behavior?

Current behaviour is 1GB by default.

As this is a setting we do not expose, the current default is too low to successfully replicate using a tool like Airbyte (as the WAL will grow too large during the Hourly sync window).

## What is the new behavior?

Proposing to set this as 4GB by default but 2GB could be a conservative option.


## Additional context

Some relevant issues are noted in the (internal) [Notion document](https://www.notion.so/supabase/RFC-Billing-DB-space-based-on-allocated-disk-space-84a13bd070ac4eaba2c1ef24c35ea98d?pvs=4)