### PR TITLE
fix: fix invalid keys in systemd service

### DIFF
--- a/ansible/files/systemd-networkd/systemd-networkd-check-and-fix.service
+++ b/ansible/files/systemd-networkd/systemd-networkd-check-and-fix.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Check if systemd-networkd has broken NDisc routes and fix
+Requisite=systemd-networkd.service
+After=systemd-networkd.service
 
 [Service]
 Type=oneshot
@@ -7,5 +9,3 @@ Type=oneshot
 User=root
 Group=root
 ExecStart=/usr/local/bin/systemd-networkd-check-and-fix.sh
-
-Requisite=systemd-networkd.service


### PR DESCRIPTION
Requisite does not impose ordering, so I've added After as well.