### PR TITLE
chore: cut new release

### DIFF
--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,2 +1,1 @@
-
-postgres-version = "15.1.1.58-supautils-2.2.1"
+postgres-version = "15.1.1.59"


### PR DESCRIPTION
FLUP to https://github.com/supabase/postgres/pull/989, bump to a non-RC version number