### PR TITLE
chore: bump gotrue version to v2.153.0

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -16,8 +16,8 @@ postgrest_release: "12.0.2-listeners-alpha"
 postgrest_arm_release_checksum: sha1:a61633a4118eaefd5351ad236744fd84fbb7886e
 postgrest_x86_release_checksum: sha1:d57eecdf732b7fd2a38889b35f1ed484a719d003
 
-gotrue_release: 2.152.0
-gotrue_release_checksum: sha1:5f220e9f322cc13f93401ab927d32dd0d1f85b40
+gotrue_release: 2.153.0
+gotrue_release_checksum: sha1:334483141b8c03f24ebe7ecb24519bbb6b704cf4
 
 aws_cli_release: "2.2.7"
 

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.1.59"
+postgres-version = "15.1.1.60"


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Bump gotrue version to v2.153.0 (see [changelog](https://github.com/supabase/auth/releases/tag/v2.153.0)) 