### PR TITLE
feat: add auth generated env file

### DIFF
--- a/ansible/files/gotrue.service.j2
+++ b/ansible/files/gotrue.service.j2
@@ -12,6 +12,7 @@ RestartSec=3
 MemoryAccounting=true
 MemoryMax=50%
 
+EnvironmentFile=-/etc/gotrue.generated.env
 EnvironmentFile=/etc/gotrue.env
 EnvironmentFile=-/etc/gotrue.overrides.env
 


### PR DESCRIPTION
Registers the optional `/etc/gotrue/gotrue.generated.env` file on the Auth (`gotrue`) service. This file can be used by the Supabase Admin API to generate a base configuration, which then can be overriden by the Supabase Platform via `/etc/gotrue/gotrue.env` or Supabase Staff when necessary in `/etc/gotrue/gotrue.overrides.env`.