### PR TITLE
fix: kong deb url moved away

### DIFF
--- a/ansible/tasks/setup-kong.yml
+++ b/ansible/tasks/setup-kong.yml
@@ -12,7 +12,7 @@
 
 - name: Kong - download deb package
   get_url:
-    url: "https://download.konghq.com/gateway-2.x-ubuntu-{{ kong_release_target }}/pool/all/k/kong/{{ kong_deb }}"
+    url: "https://packages.konghq.com/public/gateway-28/deb/ubuntu/pool/{{ kong_release_target }}/main/k/ko/kong_2.8.1/{{ kong_deb }}"
     dest: /tmp/kong.deb
     checksum: "{{ kong_deb_checksum }}"
 


### PR DESCRIPTION
https://konghq.com/blog/product-releases/changes-to-kong-package-hosting

This caused errors [here](https://github.com/supabase/postgres/actions/runs/9463429519/job/26068591598)