### PR TITLE
chore: upgrade to latest auth version (v2.154.2)

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -17,8 +17,8 @@ postgrest_release: "12.2.0"
 postgrest_arm_release_checksum: sha1:c3d8b4ac4c7d8b064c20e2bbde4d660c65e4cc38
 postgrest_x86_release_checksum: sha1:ae68ff8739daa3f705c4120972f1c2bf1fecc94b
 
-gotrue_release: 2.154.1
-gotrue_release_checksum: sha1:c03ffd0831f392ec6715021bd7b876903a5d0fee
+gotrue_release: 2.154.2
+gotrue_release_checksum: sha1:fd974d9d3b7c0a989b53e7902abdf787e97c865c
 
 aws_cli_release: "2.2.7"
 

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.1.68"
+postgres-version = "15.1.1.69"


### PR DESCRIPTION
Bumps Auth to v2.154.2 which fixes an issue with the `auth.uid()` and related functions.