### PR TITLE
feat: grant predefined roles to postgres

### DIFF
--- a/migrations/db/migrations/20240606060239_grant_predefined_roles_to_postgres.sql
+++ b/migrations/db/migrations/20240606060239_grant_predefined_roles_to_postgres.sql
@@ -1,0 +1,4 @@
+-- migrate:up
+grant pg_read_all_data, pg_signal_backend to postgres;
+
+-- migrate:down

--- a/migrations/tests/database/privs.sql
+++ b/migrations/tests/database/privs.sql
@@ -1,4 +1,3 @@
-
 SELECT database_privs_are(
     'postgres', 'postgres', ARRAY['CONNECT', 'TEMPORARY', 'CREATE']
 );
@@ -28,3 +27,7 @@ SELECT schema_privs_are('extensions', 'postgres', array['CREATE', 'USAGE']);
 SELECT schema_privs_are('extensions', 'anon', array['USAGE']);
 SELECT schema_privs_are('extensions', 'authenticated', array['USAGE']);
 SELECT schema_privs_are('extensions', 'service_role', array['USAGE']);
+
+-- Role memberships
+SELECT is_member_of('pg_read_all_data', 'postgres');
+SELECT is_member_of('pg_signal_backend', 'postgres');

--- a/migrations/tests/test.sql
+++ b/migrations/tests/test.sql
@@ -5,7 +5,7 @@ BEGIN;
 
 CREATE EXTENSION IF NOT EXISTS pgtap;
 
-SELECT plan(34);
+SELECT no_plan();
 
 \ir fixtures.sql
 \ir database/test.sql


### PR DESCRIPTION
Decouples some changes from
https://github.com/supabase/postgres/pull/994/files

`postgres` can already grant these roles to itself; granting these by default removes one step if users need to read Storage migrations, kill running queries from non-superusers, etc.