### PR TITLE
Build PG debug symbols at PG build

### DIFF
--- a/.github/workflows/ami-release.yml
+++ b/.github/workflows/ami-release.yml
@@ -76,6 +76,7 @@ jobs:
             postgresql_major=${{ steps.version.outputs.postgresql_major }}
             postgresql_release=${{ steps.version.outputs.postgresql_release }}
             CPPFLAGS=-mcpu=${{ matrix.mcpu }}
+            CFLAGS=-g3
           tags: supabase/postgres:deb
           platforms: linux/${{ matrix.arch }}
           outputs: type=tar,dest=/tmp/pg-deb.tar

--- a/.github/workflows/testinfra.yml
+++ b/.github/workflows/testinfra.yml
@@ -103,6 +103,7 @@ jobs:
             postgresql_major=${{ steps.version.outputs.postgresql_major }}
             postgresql_release=${{ steps.version.outputs.postgresql_release }}
             CPPFLAGS=-mcpu=${{ matrix.mcpu }}
+            CFLAGS=-g3
           tags: supabase/postgres:deb
           platforms: linux/${{ matrix.arch }}
           outputs: type=tar,dest=/tmp/pg-deb.tar

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,6 +37,7 @@ ENV DEB_BUILD_OPTIONS="nocheck parallel=$(nproc)"
 # Configure processor optimised build
 ARG CPPFLAGS=""
 ENV DEB_CPPFLAGS_APPEND="${CPPFLAGS} -fsigned-char"
+ENV DEB_CFLAGS_APPEND="-g3"
 ARG DEB_BUILD_PROFILES="pkg.postgresql.nozstd"
 ENV DEB_BUILD_PROFILES="${DEB_BUILD_PROFILES}"
 

--- a/testinfra/README.md
+++ b/testinfra/README.md
@@ -37,6 +37,7 @@ docker buildx build \
   --build-arg postgresql_major=15 \
   --build-arg postgresql_release=15.1 \
   --build-arg CPPFLAGS=-mcpu=neoverse-n1 \
+  --build-arg CFLAGS=-g3
   --file=docker/Dockerfile \
   --target=pg-deb \
   --tag=supabase/postgres:deb \


### PR DESCRIPTION
Debug symbols make it possible to use the debugger to investigate Postgres issues. This doesn't affect code performance.
