### PR TITLE
feat: add `safeupdate` to `shared_preload_libraries`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -614,10 +614,6 @@ RUN --mount=type=cache,target=/ccache,from=public.ecr.aws/supabase/postgres:ccac
 RUN checkinstall -D --install=no --fstrans=no --backup=no --pakdir=/tmp --nodoc
 
 ####################
-# 21-auto_explain.yml
-####################
-
-####################
 # 22-pg_jsonschema.yml
 ####################
 FROM base as pg_jsonschema
@@ -937,10 +933,8 @@ RUN sed -i \
     -e "s|#session_preload_libraries = ''|session_preload_libraries = 'supautils'|g" \
     -e "s|#include = '/etc/postgresql-custom/supautils.conf'|include = '/etc/postgresql-custom/supautils.conf'|g" \
     -e "s|#include = '/etc/postgresql-custom/wal-g.conf'|include = '/etc/postgresql-custom/wal-g.conf'|g" /etc/postgresql/postgresql.conf && \
-    echo "cron.database_name = 'postgres'" >> /etc/postgresql/postgresql.conf && \
     echo "pljava.libjvm_location = '/usr/lib/jvm/java-11-openjdk-${TARGETARCH}/lib/server/libjvm.so'" >> /etc/postgresql/postgresql.conf && \
     echo "pgsodium.getkey_script= '/usr/lib/postgresql/${postgresql_major}/bin/pgsodium_getkey.sh'" >> /etc/postgresql/postgresql.conf && \
-    echo 'auto_explain.log_min_duration = 10s' >> /etc/postgresql/postgresql.conf && \
     useradd --create-home --shell /bin/bash wal-g -G postgres && \
     mkdir -p /etc/postgresql-custom && \
     chown postgres:postgres /etc/postgresql-custom

--- a/ansible/files/postgresql_config/postgresql.conf.j2
+++ b/ansible/files/postgresql_config/postgresql.conf.j2
@@ -774,4 +774,6 @@ include = '/etc/postgresql-custom/read-replica.conf'
 #------------------------------------------------------------------------------
 
 # Add settings for extensions here
+auto_explain.log_min_duration = 10s
+cron.database_name = 'postgres'
 safeupdate.enabled = off

--- a/ansible/files/postgresql_config/postgresql.conf.j2
+++ b/ansible/files/postgresql_config/postgresql.conf.j2
@@ -688,7 +688,7 @@ default_text_search_config = 'pg_catalog.english'
 #local_preload_libraries = ''
 #session_preload_libraries = ''
 
-shared_preload_libraries = 'pg_stat_statements, pg_stat_monitor, pgaudit, plpgsql, plpgsql_check, pg_cron, pg_net, pgsodium, timescaledb, auto_explain, pg_tle, plan_filter'	# (change requires restart)
+shared_preload_libraries = 'pg_stat_statements, pg_stat_monitor, pgaudit, plpgsql, plpgsql_check, pg_cron, pg_net, pgsodium, timescaledb, auto_explain, pg_tle, plan_filter, safeupdate'	# (change requires restart)
 jit_provider = 'llvmjit'		# JIT library to use
 
 # - Other Defaults -
@@ -774,3 +774,4 @@ include = '/etc/postgresql-custom/read-replica.conf'
 #------------------------------------------------------------------------------
 
 # Add settings for extensions here
+safeupdate.enabled = off

--- a/ansible/files/postgresql_config/supautils.conf.j2
+++ b/ansible/files/postgresql_config/supautils.conf.j2
@@ -7,6 +7,6 @@ supautils.privileged_extensions = 'address_standardizer, address_standardizer_da
 supautils.privileged_extensions_custom_scripts_path = '/etc/postgresql-custom/extension-custom-scripts'
 supautils.privileged_extensions_superuser = 'supabase_admin'
 supautils.privileged_role = 'postgres'
-supautils.privileged_role_allowed_configs = 'auto_explain.log_min_duration, auto_explain.log_nested_statements, log_min_messages, pgaudit.log, pgaudit.log_catalog, pgaudit.log_client, pgaudit.log_level, pgaudit.log_relation, pgaudit.log_rows, pgaudit.log_statement, pgaudit.log_statement_once, pgaudit.role, pgrst.*, plan_filter.*, session_replication_role, track_io_timing'
+supautils.privileged_role_allowed_configs = 'auto_explain.log_min_duration, auto_explain.log_nested_statements, log_min_messages, pgaudit.log, pgaudit.log_catalog, pgaudit.log_client, pgaudit.log_level, pgaudit.log_relation, pgaudit.log_rows, pgaudit.log_statement, pgaudit.log_statement_once, pgaudit.role, pgrst.*, plan_filter.*, safeupdate.enabled, session_replication_role, track_io_timing'
 supautils.reserved_memberships = 'pg_read_server_files, pg_write_server_files, pg_execute_server_program, authenticator'
 supautils.reserved_roles = 'supabase_admin, supabase_auth_admin, supabase_storage_admin, supabase_read_only_user, supabase_replication_admin, dashboard_user, pgbouncer, service_role*, authenticator*, authenticated*, anon*'

--- a/ansible/tasks/postgres-extensions/04-pg_cron.yml
+++ b/ansible/tasks/postgres-extensions/04-pg_cron.yml
@@ -24,13 +24,6 @@
     target: install
   become: yes
 
-- name: pg_cron - set cron.database_name
-  become: yes
-  lineinfile:
-    path: /etc/postgresql/postgresql.conf
-    state: present
-    line: cron.database_name = 'postgres'
-    
 - name: pg_cron - cleanup
   file:
     state: absent

--- a/ansible/tasks/postgres-extensions/21-auto_explain.yml
+++ b/ansible/tasks/postgres-extensions/21-auto_explain.yml
@@ -1,7 +1,0 @@
-
-- name: auto_explain - set auto_explain.log_min_duration
-  become: yes
-  lineinfile:
-    path: /etc/postgresql/postgresql.conf
-    state: present
-    line: auto_explain.log_min_duration = 10s

--- a/ansible/tasks/setup-docker.yml
+++ b/ansible/tasks/setup-docker.yml
@@ -10,13 +10,6 @@
     apt-get update
     apt-get install -y --no-install-recommends /tmp/extensions/*.deb
 
-- name: pg_cron - set cron.database_name
-  become: yes
-  lineinfile:
-    path: /etc/postgresql/postgresql.conf
-    state: present
-    line: cron.database_name = 'postgres'
-
 - name: pgsodium - determine postgres bin directory
   shell: pg_config --bindir
   register: pg_bindir_output
@@ -30,13 +23,6 @@
     state: present
     # script is expected to be placed by finalization tasks for different target platforms
     line: pgsodium.getkey_script= '{{ pg_bindir }}/pgsodium_getkey.sh'
-
-- name: auto_explain - set auto_explain.log_min_duration
-  become: yes
-  lineinfile:
-    path: /etc/postgresql/postgresql.conf
-    state: present
-    line: auto_explain.log_min_duration = 10s
 
 # supautils
 - name: supautils - add supautils to session_preload_libraries

--- a/ansible/tasks/setup-extensions.yml
+++ b/ansible/tasks/setup-extensions.yml
@@ -65,9 +65,6 @@
 - name: Install pg_stat_monitor
   import_tasks: tasks/postgres-extensions/20-pg_stat_monitor.yml
 
-- name: Install auto_explain
-  import_tasks: tasks/postgres-extensions/21-auto_explain.yml
-
 - name: Install vault
   import_tasks: tasks/postgres-extensions/23-vault.yml
 

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.1.71"
+postgres-version = "15.1.1.72"

--- a/docker/orioledb/Dockerfile
+++ b/docker/orioledb/Dockerfile
@@ -616,10 +616,6 @@ RUN --mount=type=cache,target=/ccache,from=public.ecr.aws/supabase/postgres:ccac
 RUN checkinstall -D --install=no --fstrans=no --backup=no --pakdir=/tmp --nodoc
 
 ####################
-# 21-auto_explain.yml
-####################
-
-####################
 # 22-pg_jsonschema.yml
 ####################
 FROM rust-toolchain as pg_jsonschema-source
@@ -1033,10 +1029,8 @@ RUN sed -i \
     -e "s|#max_wal_size = 1GB|max_wal_size = 8GB|g" \
     -e "s|#include = '/etc/postgresql-custom/supautils.conf'|include = '/etc/postgresql-custom/supautils.conf'|g" \
     -e "s|#include = '/etc/postgresql-custom/wal-g.conf'|include = '/etc/postgresql-custom/wal-g.conf'|g" /etc/postgresql/postgresql.conf && \
-    echo "cron.database_name = 'postgres'" >> /etc/postgresql/postgresql.conf && \
     echo "pljava.libjvm_location = '/usr/lib/jvm/java-11-openjdk-${TARGETARCH}/lib/server/libjvm.so'" >> /etc/postgresql/postgresql.conf && \
     echo "pgsodium.getkey_script= '/usr/lib/postgresql/${postgresql_major}/bin/pgsodium_getkey.sh'" >> /etc/postgresql/postgresql.conf && \
-    echo 'auto_explain.log_min_duration = 10s' >> /etc/postgresql/postgresql.conf && \
     echo "orioledb.main_buffers = 1GB" >> /etc/postgresql/postgresql.conf && \
     echo "orioledb.undo_buffers = 256MB" >> /etc/postgresql/postgresql.conf && \
     useradd --create-home --shell /bin/bash wal-g -G postgres && \


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

pg_safeupdate can't be used with the `postgres` role since setting `[shared/session]_preload_libraries` requires superuser.

## What is the new behavior?

Allow using pg_safeupdate with the `postgres` role by setting `safeupdate.enabled = on`.