### PR TITLE
feat: patch supautils sha

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -85,7 +85,7 @@ wal2json_release: "2_5"
 wal2json_release_checksum: sha256:b516653575541cf221b99cf3f8be9b6821f6dbcfc125675c85f35090f824f00e
 
 supautils_release: "2.2.1"
-supautils_release_checksum: sha256:1a2d2b8fe604d38921ed9cf3a0d56dd142a274035d0dca17ad21cdc81ddd9569
+supautils_release_checksum: sha256:f1f33371390322ac830645b8b0b8e249cb8ca10b19fdeae917f383014ed01b5d
 
 pljava_release: master
 pljava_release_checksum: sha256:e99b1c52f7b57f64c8986fe6ea4a6cc09d78e779c1643db060d0ac66c93be8b6


### PR DESCRIPTION
Currently it seems like the [SHA256sum is inaccurate](https://github.com/supabase/postgres/actions/runs/9789146863/job/27028480566#step:6:1191) which is leading to a build error