### PR TITLE
chore: remove placeholder file before root resize

### DIFF
--- a/ansible/files/admin_api_scripts/grow_fs.sh
+++ b/ansible/files/admin_api_scripts/grow_fs.sh
@@ -9,9 +9,13 @@ if [ -b /dev/nvme1n1 ] ; then
         resize2fs /dev/nvme1n1
 
     elif [[ "${VOLUME_TYPE}" == "root" ]] ; then
+        PLACEHOLDER_FL=/home/ubuntu/50M_PLACEHOLDER
+        rm -f "${PLACEHOLDER_FL}" || true
         growpart /dev/nvme0n1 2
         resize2fs /dev/nvme0n1p2
-
+        if [[ ! -f "${PLACEHOLDER_FL}" ]] ; then
+            fallocate -l50M "${PLACEHOLDER_FL}"
+        fi
     else
         echo "Invalid disk specified: ${VOLUME_TYPE}"
         exit 1


### PR DESCRIPTION
On the rare occasion when the root vol is completely full, a resize
could fail. This change attempts to work around that by removing the
placeholder file prior to the resize, and re-creating it afterwards.