### PR TITLE
fix: when we dl supautils in oriole Dockerfile, we use tar instead of deb

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -86,6 +86,7 @@ wal2json_release_checksum: sha256:b516653575541cf221b99cf3f8be9b6821f6dbcfc12567
 
 supautils_release: "2.2.1"
 supautils_release_checksum: sha256:1a2d2b8fe604d38921ed9cf3a0d56dd142a274035d0dca17ad21cdc81ddd9569
+supautils_release_tar_checksum: sha256:f1f33371390322ac830645b8b0b8e249cb8ca10b19fdeae917f383014ed01b5d
 
 pljava_release: master
 pljava_release_checksum: sha256:e99b1c52f7b57f64c8986fe6ea4a6cc09d78e779c1643db060d0ac66c93be8b6

--- a/docker/orioledb/Dockerfile
+++ b/docker/orioledb/Dockerfile
@@ -927,8 +927,8 @@ RUN checkinstall -D --install=no --fstrans=no --backup=no --pakdir=/tmp --nodoc
 ####################
 FROM ccache as supautils-source
 ARG supautils_release
-ARG supautils_release_checksum
-ADD --checksum=${supautils_release_checksum} \
+ARG supautils_release_tar_checksum
+ADD --checksum=${supautils_release_tar_checksum} \
     "https://github.com/supabase/supautils/archive/refs/tags/v${supautils_release}.tar.gz" \
     /tmp/supautils.tar.gz
 RUN tar -xvf /tmp/supautils.tar.gz -C /tmp && \


### PR DESCRIPTION
## What kind of change does this PR introduce?

In our main Dockerfile we download a `.deb` for supautils release. But in orioledb Dockerfile, we download a `.tar.gz`

So this introduces a checksum into vars that supports to tar.gz download