### PR TITLE
fix: ensure that we pull apt updates before building

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,7 +41,7 @@ ENV DEB_CFLAGS_APPEND="-g3"
 ARG DEB_BUILD_PROFILES="pkg.postgresql.nozstd"
 ENV DEB_BUILD_PROFILES="${DEB_BUILD_PROFILES}"
 
-RUN apt-get build-dep -y postgresql-common pgdg-keyring && \
+RUN apt-get -o Acquire::GzipIndexes=false update && apt-get build-dep -y postgresql-common pgdg-keyring && \
     apt-get source --compile postgresql-common pgdg-keyring && \
     dpkg-scanpackages . > Packages && \
     apt-get -o Acquire::GzipIndexes=false update


### PR DESCRIPTION
I'm not quite certain why the current apt commands are structured the way they are, pulling the package lists _after_ operations that use the package list.

The proposed change should unblock the build, but we should clean this up during the week once folks that contributed the original code are available.
