### PR TITLE
fix: fixes pg_graphql build on aarch64-darwin

### DIFF
--- a/nix/ext/pg_graphql.nix
+++ b/nix/ext/pg_graphql.nix
@@ -13,9 +13,13 @@ buildPgrxExtension_0_11_3 rec {
   };
 
   nativeBuildInputs = [ cargo ];
+  buildInputs = [ postgresql ];
   
   CARGO="${cargo}/bin/cargo";
-  
+  env = lib.optionalAttrs stdenv.isDarwin {
+    POSTGRES_LIB = "${postgresql}/lib";
+    RUSTFLAGS = "-C link-arg=-undefined -C link-arg=dynamic_lookup";
+  };
   cargoHash = "sha256-yc0lO4BZdbArBujRynl/ItkLLAiVZ2Wf3S7voQ2x6xM=";
 
   # FIXME (aseipp): disable the tests since they try to install .control


### PR DESCRIPTION
## What kind of change does this PR introduce?

This will fix the nix build on `aarch64-darwin` while maintaining builds on existing support architectures

Note: this won't work until the supported system is added to `flake.nix` which will not happen until `plv8` is also fixed on darwin