### PR TITLE
fix: build wrappers on aarch64-darwin

### DIFF
--- a/nix/ext/wrappers/default.nix
+++ b/nix/ext/wrappers/default.nix
@@ -6,6 +6,7 @@
 , postgresql
 , buildPgrxExtension_0_11_3
 , cargo
+, darwin
 }:
 
 buildPgrxExtension_0_11_3 rec {
@@ -22,7 +23,11 @@ buildPgrxExtension_0_11_3 rec {
 
   nativeBuildInputs = [ pkg-config cargo ];
 
-  buildInputs = [ openssl ];
+  buildInputs = [ openssl ] ++ lib.optionals (stdenv.isDarwin)  [ 
+    darwin.apple_sdk.frameworks.CoreFoundation 
+    darwin.apple_sdk.frameworks.Security 
+    darwin.apple_sdk.frameworks.SystemConfiguration 
+  ];
 
   # Needed to get openssl-sys to use pkg-config.
   OPENSSL_NO_VENDOR = 1;


### PR DESCRIPTION
## What kind of change does this PR introduce?

supabase-wrappers builds on nix aarch64-darwin with this PR, maintaining all other supported systems too