### PR TITLE
fix: remove `safeupdate` from `shared_preload_libraries`

### DIFF
--- a/ansible/files/postgresql_config/postgresql.conf.j2
+++ b/ansible/files/postgresql_config/postgresql.conf.j2
@@ -688,7 +688,7 @@ default_text_search_config = 'pg_catalog.english'
 #local_preload_libraries = ''
 #session_preload_libraries = ''
 
-shared_preload_libraries = 'pg_stat_statements, pg_stat_monitor, pgaudit, plpgsql, plpgsql_check, pg_cron, pg_net, pgsodium, timescaledb, auto_explain, pg_tle, plan_filter, safeupdate'	# (change requires restart)
+shared_preload_libraries = 'pg_stat_statements, pg_stat_monitor, pgaudit, plpgsql, plpgsql_check, pg_cron, pg_net, pgsodium, timescaledb, auto_explain, pg_tle, plan_filter'	# (change requires restart)
 jit_provider = 'llvmjit'		# JIT library to use
 
 # - Other Defaults -
@@ -776,4 +776,3 @@ include = '/etc/postgresql-custom/read-replica.conf'
 # Add settings for extensions here
 auto_explain.log_min_duration = 10s
 cron.database_name = 'postgres'
-safeupdate.enabled = off

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.1.77"
+postgres-version = "15.1.1.78"


### PR DESCRIPTION
* `safeupdate.enabled = off` doesn't really work to disable the extension's behaviour by default
* Breaks timescaledb for projects
* Context: https://supabase.slack.com/archives/C01D6TWFFFW/p1721056260658829