### PR TITLE
chore: mirror postgrest image on version bump

### DIFF
--- a/.github/workflows/mirror-postgrest.yml
+++ b/.github/workflows/mirror-postgrest.yml
@@ -1,0 +1,33 @@
+name: Mirror PostgREST
+
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - ".github/workflows/mirror-postgrest.yml"
+      - "common.vars*"
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      postgrest_release: ${{ steps.args.outputs.result }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: args
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq '.postgrest_release' 'ansible/vars.yml'
+
+  mirror:
+    needs:
+      - version
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    uses: supabase/cli/.github/workflows/mirror-image.yml@main
+    with:
+      image: postgrest/postgrest:v${{ needs.version.outputs.postgrest_release }}
+    secrets: inherit


### PR DESCRIPTION
## What kind of change does this PR introduce?

ci

## What is the current behavior?

PostgREST repo does not belong to supabase org, so it cannot publish to our ECR and GHCR mirrors.

## What is the new behavior?

Trigger mirror job whenever the PostgREST version is updated on postgres repo. This removes the need for manual mirror from cli repo. https://github.com/supabase/cli/issues/2526

## Additional context

Tested https://github.com/supabase/postgres/actions/runs/10041937498