### PR TITLE
fix: locale gen and ami deregister on any testinfra run

### DIFF
--- a/.github/workflows/testinfra-nix.yml
+++ b/.github/workflows/testinfra-nix.yml
@@ -65,3 +65,24 @@ jobs:
         if: ${{ always() }}
         run: |
           aws ec2 --region ap-southeast-1 describe-instances --filters "Name=tag:testinfra-run-id,Values=${GITHUB_RUN_ID}" --query "Reservations[].Instances[].InstanceId" --output text | xargs -n 1 -I {} aws ec2 terminate-instances --region ap-southeast-1 --instance-ids {} || true
+
+      - name: Cleanup AMIs
+        if: always()
+        run: |
+          # Define AMI name patterns
+          STAGE1_AMI_NAME="supabase-postgres-ci-ami-test-stage-1"
+          STAGE2_AMI_NAME="supabase-postgres-ci-ami-test-nix"
+          
+          # Function to deregister AMIs by name pattern
+          deregister_ami_by_name() {
+            local ami_name_pattern=$1
+            local ami_ids=$(aws ec2 describe-images --region ap-southeast-1 --owners self --filters "Name=name,Values=${ami_name_pattern}" --query 'Images[*].ImageId' --output text)
+            for ami_id in $ami_ids; do
+              echo "Deregistering AMI: $ami_id"
+              aws ec2 deregister-image --region ap-southeast-1 --image-id $ami_id
+            done
+          }
+          
+          # Deregister AMIs
+          deregister_ami_by_name "$STAGE1_AMI_NAME"
+          deregister_ami_by_name "$STAGE2_AMI_NAME"

--- a/ansible/tasks/setup-postgres.yml
+++ b/ansible/tasks/setup-postgres.yml
@@ -40,7 +40,7 @@
   when: debpkg_mode
 
 - name: locale-gen
-  command: sudo locale-gen en_US.UTF-8
+  command: sudo locale-gen en_US.UTF-8 C.UTF-8
   when: stage2_nix
 
 - name: update-locale

--- a/ansible/tasks/setup-postgres.yml
+++ b/ansible/tasks/setup-postgres.yml
@@ -39,8 +39,20 @@
     state: absent
   when: debpkg_mode
 
+- name: install locales
+  apt:
+    name: locales
+    state: present
+  become: yes
+  when: stage2_nix
+
+- name: configure locales
+  command: echo "C.UTF-8 UTF-8" > /etc/locale.gen && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
+  become: yes
+  when: stage2_nix
+
 - name: locale-gen
-  command: sudo locale-gen en_US.UTF-8 C.UTF-8
+  command: sudo locale-gen
   when: stage2_nix
 
 - name: update-locale


### PR DESCRIPTION
## What kind of change does this PR introduce?

needed to set another locale C.UTF-8 in the AMI

Also needed to try to handle cases where AMI testinfra randomly cancels, to make sure that workflow can be run again and not fail due to existence of registered AMI with same name (created function to deregister on cleanup no matter what)