### PR TITLE
feat: new flake app runs migrations before starting

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -433,7 +433,9 @@
           start-client-and-migrate =  
             let
               migrationsDir = ./migrations/db;
-              postgresqlSchemaSql = ./migrations/schema.sql;
+              postgresqlSchemaSql = ./nix/tools/postgresql_schema.sql;
+              pgbouncerAuthSchemaSql = ./ansible/files/pgbouncer_config/pgbouncer_auth_schema.sql;
+              statExtensionSql = ./ansible/files/stat_extension.sql;
             in
             pkgs.runCommand "start-postgres-client-migrate" { } ''
               mkdir -p $out/bin
@@ -442,7 +444,9 @@
                 --subst-var-by 'PGSQL_SUPERUSER' '${pgsqlSuperuser}' \
                 --subst-var-by 'PSQL15_BINDIR' '${basePackages.psql_15.bin}' \
                 --subst-var-by 'MIGRATIONS_DIR' '${migrationsDir}' \
-                --subst-var-by 'POSTGRESQL_SCHEMA_SQL' '${postgresqlSchemaSql}'
+                --subst-var-by 'POSTGRESQL_SCHEMA_SQL' '${postgresqlSchemaSql}' \
+                --subst-var-by 'PGBOUNCER_AUTH_SCHEMA_SQL' '${pgbouncerAuthSchemaSql}' \
+                --subst-var-by 'STAT_EXTENSION_SQL' '${statExtensionSql}'
               chmod +x $out/bin/start-postgres-client-migrate
             '';
 

--- a/nix/tests/util/pgsodium_getkey.sh
+++ b/nix/tests/util/pgsodium_getkey.sh
@@ -1,4 +1,10 @@
-# NOTE (aseipp): just use some random key for testing, no need to query
-# /dev/urandom. also helps ferrit out other random flukes, perhaps?
+#!/bin/bash
 
-echo -n 8359dafbba5c05568799c1c24eb6c2fbff497654bc6aa5e9a791c666768875a1
+set -euo pipefail
+
+KEY_FILE="${1:-/tmp/pgsodium.key}"
+
+if [[ ! -f "${KEY_FILE}" ]]; then
+    head -c 32 /dev/urandom | od -A n -t x1 | tr -d ' \n' > "${KEY_FILE}"
+fi
+cat $KEY_FILE

--- a/nix/tools/postgresql_schema.sql
+++ b/nix/tools/postgresql_schema.sql
@@ -1,0 +1,11 @@
+ALTER DATABASE postgres SET "app.settings.jwt_secret" TO  'my_jwt_secret_which_is_not_so_secret';
+ALTER DATABASE postgres SET "app.settings.jwt_exp" TO 3600;
+ALTER USER supabase_admin WITH PASSWORD 'postgres';
+ALTER USER postgres WITH PASSWORD 'postgres';
+ALTER USER authenticator WITH PASSWORD 'postgres';
+ALTER USER pgbouncer WITH PASSWORD 'postgres';
+ALTER USER supabase_auth_admin WITH PASSWORD 'postgres';
+ALTER USER supabase_storage_admin WITH PASSWORD 'postgres';
+ALTER USER supabase_replication_admin WITH PASSWORD 'postgres';
+ALTER ROLE supabase_read_only_user WITH PASSWORD 'postgres';
+ALTER ROLE supabase_admin SET search_path TO "$user",public,auth,extensions;

--- a/nix/tools/run-client-migrate.sh.in
+++ b/nix/tools/run-client-migrate.sh.in
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+
+[ ! -z "$DEBUG" ] && set -x
+
+# first argument should be '15' or '16' for the version
+if [ "$1" == "15" ]; then
+    echo "Starting client for PSQL 15"
+    PSQL15=@PSQL15_BINDIR@
+    BINDIR="$PSQL15"
+elif [ "$1" == "16" ]; then
+    echo "Starting client for PSQL 16"
+    PSQL16=@PSQL16_BINDIR@
+    BINDIR="$PSQL16"
+elif [ "$1" == "orioledb-16" ]; then
+    echo "Starting client for PSQL ORIOLEDB 16"
+    PSQLORIOLEDB16=@PSQLORIOLEDB16_BINDIR@
+    BINDIR="$PSQLORIOLEDB16"
+else
+    echo "Please provide a valid Postgres version (15, 16, or orioledb-16)"
+    exit 1
+fi
+#vars for migration.sh
+export PATH=$BINDIR/bin:$PATH
+export POSTGRES_DB=postgres
+export POSTGRES_HOST=localhost
+export POSTGRES_PORT=@PGSQL_DEFAULT_PORT@
+PORTNO="${2:-@PGSQL_DEFAULT_PORT@}"
+PGSQL_SUPERUSER=@PGSQL_SUPERUSER@
+MIGRATIONS_DIR=@MIGRATIONS_DIR@
+POSTGRESQL_SCHEMA_SQL=@POSTGRESQL_SCHEMA_SQL@
+for sql in "$MIGRATIONS_DIR"/init-scripts/*.sql; do
+    echo "$0: running $sql"
+    psql -v ON_ERROR_STOP=1 --no-password --no-psqlrc -U postgres -p "$PORTNO" -h localhost -f  "$sql" postgres
+done
+psql -v ON_ERROR_STOP=1 --no-password --no-psqlrc -U postgres -p "$PORTNO" -h localhost -f -c "ALTER USER supabase_admin WITH PASSWORD '$PGPASSWORD'" postgres
+# run migrations as super user - postgres user demoted in post-setup
+for sql in "$MIGRATIONS_DIR"/migrations/*.sql; do
+    echo "$0: running $sql"
+    psql -v ON_ERROR_STOP=1 --no-password --no-psqlrc -U supabase_admin -p "$PORTNO" -h localhost -f "$sql" postgres
+done
+psql -v ON_ERROR_STOP=1 --no-password --no-psqlrc -U supabase_admin -p "$PORTNO" -h localhost -f "$POSTGRESQL_SCHEMA_SQL" postgres
+# TODO Do we need to reset stats when running migrations locally?
+#psql -v ON_ERROR_STOP=1 --no-password --no-psqlrc -U supabase_admin -p "$PORTNO" -h localhost -c 'SELECT extensions.pg_stat_statements_reset(); SELECT pg_stat_reset();' postgres || true
+
+exec psql -U "$PGSQL_SUPERUSER" -p "$PORTNO" -h localhost postgres

--- a/nix/tools/run-client-migrate.sh.in
+++ b/nix/tools/run-client-migrate.sh.in
@@ -29,11 +29,15 @@ PORTNO="${2:-@PGSQL_DEFAULT_PORT@}"
 PGSQL_SUPERUSER=@PGSQL_SUPERUSER@
 MIGRATIONS_DIR=@MIGRATIONS_DIR@
 POSTGRESQL_SCHEMA_SQL=@POSTGRESQL_SCHEMA_SQL@
+PGBOUNCER_AUTH_SCHEMA_SQL=@PGBOUNCER_AUTH_SCHEMA_SQL@
+STAT_EXTENSION_SQL=@STAT_EXTENSION_SQL@
+psql -v ON_ERROR_STOP=1 --no-password --no-psqlrc -U "$PGSQL_SUPERUSER" -p "$PORTNO" -h localhost -d postgres -f "$PGBOUNCER_AUTH_SCHEMA_SQL"
+psql -v ON_ERROR_STOP=1 --no-password --no-psqlrc -U "$PGSQL_SUPERUSER" -p "$PORTNO" -h localhost -d postgres -f "$STAT_EXTENSION_SQL"
 for sql in "$MIGRATIONS_DIR"/init-scripts/*.sql; do
     echo "$0: running $sql"
     psql -v ON_ERROR_STOP=1 --no-password --no-psqlrc -U postgres -p "$PORTNO" -h localhost -f  "$sql" postgres
 done
-psql -v ON_ERROR_STOP=1 --no-password --no-psqlrc -U postgres -p "$PORTNO" -h localhost -f -c "ALTER USER supabase_admin WITH PASSWORD '$PGPASSWORD'" postgres
+psql -v ON_ERROR_STOP=1 --no-password --no-psqlrc -U postgres -p "$PORTNO" -h localhost -c "ALTER USER supabase_admin WITH PASSWORD '$PGPASSWORD'"
 # run migrations as super user - postgres user demoted in post-setup
 for sql in "$MIGRATIONS_DIR"/migrations/*.sql; do
     echo "$0: running $sql"


### PR DESCRIPTION
## What kind of change does this PR introduce?

To support work that @soedirgo is doing now, and anyone in the future, this PR is expanding the tools provided by "nix flake apps" to create an alternate `nix run .#start-client-and-migrate 15` command that will start the client based on the postgres that is built by nix in the same repo, but also will run migrations that live in the same repo/revision

To use this you will open 2 terminals, and run

1. `nix run .#start-server 15` (starts the pg 15.6 server built into this project)
2. `nix run .#start-client-and-migrate 15` (starts psql 15.6 client, but first runs migrations following the same instructions found in the migrations.sh script and using the same files)
