### PR TITLE
fix: buildFeature missing at least auth0_fdw

### DIFF
--- a/nix/ext/wrappers/default.nix
+++ b/nix/ext/wrappers/default.nix
@@ -54,6 +54,7 @@ buildPgrxExtension_0_11_3 rec {
     "s3_fdw"
     "airtable_fdw"
     "logflare_fdw"
+    "auth0_fdw"
   ];
 
   # FIXME (aseipp): disable the tests since they try to install .control


### PR DESCRIPTION
## What kind of change does this PR introduce?

the nix package was missing at least `auth0_fdw` in the `buildfeatures` call 