### PR TITLE
chore: bump nix ami version

### DIFF
--- a/common-nix.vars.pkr.hcl
+++ b/common-nix.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.6.1.96-nix-staged"
+postgres-version = "15.6.1.97-nix-staged"


### PR DESCRIPTION
## What kind of change does this PR introduce?

A bump of nix ami version to trigger release so that we can stage the AMI