### PR TITLE
chore: no longer need extension on filename

### DIFF
--- a/stage2-nix-psql.pkr.hcl
+++ b/stage2-nix-psql.pkr.hcl
@@ -56,7 +56,7 @@ packer {
 }
 
 source "amazon-ebs" "ubuntu" {
-  ami_name      = "${var.ami_name}-${var.postgres-version}-nix"
+  ami_name      = "${var.ami_name}-${var.postgres-version}"
   instance_type = "c6g.4xlarge"
   region        = "${var.region}"
   source_ami_filter {


### PR DESCRIPTION
We now infer that 15.6 solely nix built

## What kind of change does this PR introduce?

For consistency in our tooling, we wanted to lose the `-nix` extension on the AMI name, and we'll just know that 15.6 and above are built with nix going forward. 