### PR TITLE
chore: bump gotrue version to v2.157.1

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -17,8 +17,8 @@ postgrest_release: "12.2.2"
 postgrest_arm_release_checksum: sha1:444a52ae11381f0b78bf8e847641c7e5f6929216
 postgrest_x86_release_checksum: sha1:db1b061c6b4ad34ef6f38d16c7d0557bf5b96daf
 
-gotrue_release: 2.156.0
-gotrue_release_checksum: sha1:2f04eb5d61395d0d1cb48b0a36cf56464d2e8995
+gotrue_release: 2.157.1
+gotrue_release_checksum: sha1:c8ff68fe39b864eaef62118102c2316ce3214ffc
 
 aws_cli_release: "2.2.7"
 

--- a/common-nix.vars.pkr.hcl
+++ b/common-nix.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.6.1.100"
+postgres-version = "15.6.1.101"

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.1.82"
+postgres-version = "15.1.1.83"


### PR DESCRIPTION
## What kind of change does this PR introduce?
* See [changelog](https://github.com/supabase/auth/compare/v2.156.0...v2.157.1) - this version of gotrue introduces the changes made to support asymmetric JWTs for projects 

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.