### PR TITLE
Adding Garnix Cache

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,11 @@
 {
   description = "Prototype tooling for deploying PostgreSQL";
 
+  nixConfig = {
+    extra-substituters = ["https://cache.garnix.io"];
+    extra-trusted-public-keys = ["cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="];
+  };
+
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";

--- a/nix/docs/docker.md
+++ b/nix/docs/docker.md
@@ -10,5 +10,5 @@ corresponds to a Git commit in the repository &mdash; for example commit
 in this repository has a tag in the container registry which can be used to pull
 exactly that version.
 
-This just starts the server. Client container images are not provided; you can
+This only starts the server. Client container images are not provided; you can
 use `nix run` for that, as outlined [here](./start-client-server.md).

--- a/nix/docs/docker.md
+++ b/nix/docs/docker.md
@@ -10,5 +10,5 @@ corresponds to a Git commit in the repository &mdash; for example commit
 in this repository has a tag in the container registry which can be used to pull
 exactly that version.
 
-This only starts the server. Client container images are not provided; you can
+This just starts the server. Client container images are not provided; you can
 use `nix run` for that, as outlined [here](./start-client-server.md).


### PR DESCRIPTION
Adding the Garnix cache to the `flake.nix` to enable faster CI build times, if a users opts to use Garnix, as described in [this issue](https://github.com/supabase/postgres/issues/1078)