### PR TITLE
feat: randomize ami name on testinfra for 15.6

### DIFF
--- a/.github/workflows/testinfra-nix.yml
+++ b/.github/workflows/testinfra-nix.yml
@@ -55,10 +55,12 @@ jobs:
 
       - name: Run tests
         timeout-minutes: 10
+        env:
+          AMI_NAME: ${{ steps.random.outputs.random_string }}
         run: |
           # TODO: use poetry for pkg mgmt
           pip3 install boto3 boto3-stubs[essential] docker ec2instanceconnectcli pytest pytest-testinfra[paramiko,docker] requests
-          pytest -vv -s testinfra/test_ami_nix.py --ami-name "${{ steps.random.outputs.random_string }}"
+          pytest -vv -s testinfra/test_ami_nix.py 
       
       - name: Cleanup resources on build cancellation
         if: ${{ cancelled() }}

--- a/.github/workflows/testinfra-nix.yml
+++ b/.github/workflows/testinfra-nix.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Run tests
         timeout-minutes: 10
         env:
-          AMI_NAME: ${{ steps.random.outputs.random_string }}
+          AMI_NAME: "supabase-postgres-${{ steps.random.outputs.random_string }}"
         run: |
           # TODO: use poetry for pkg mgmt
           pip3 install boto3 boto3-stubs[essential] docker ec2instanceconnectcli pytest pytest-testinfra[paramiko,docker] requests

--- a/.github/workflows/testinfra-nix.yml
+++ b/.github/workflows/testinfra-nix.yml
@@ -42,19 +42,23 @@ jobs:
           packer init amazon-arm64-nix.pkr.hcl
           GIT_SHA=${{github.sha}}
           packer build -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${GITHUB_RUN_ID}" -var-file="development-arm.vars.pkr.hcl" -var-file="common-nix.vars.pkr.hcl" -var "ansible_arguments=" -var "postgres-version=ci-ami-test" -var "region=ap-southeast-1" -var 'ami_regions=["ap-southeast-1"]' -var "force-deregister=true" amazon-arm64-nix.pkr.hcl
+      
+      - name: Generate random string
+        id: random
+        run: echo "random_string=$(openssl rand -hex 8)" >> $GITHUB_OUTPUT
 
       - name: Build AMI stage 2
         run: |
           packer init stage2-nix-psql.pkr.hcl
           GIT_SHA=${{github.sha}}
-          packer build -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${GITHUB_RUN_ID}" -var-file="development-arm.vars.pkr.hcl" -var-file="common-nix.vars.pkr.hcl"  -var "postgres-version=ci-ami-test" -var "region=ap-southeast-1" -var 'ami_regions=["ap-southeast-1"]' -var "force-deregister=true" -var "git_sha=${GITHUB_SHA}"  stage2-nix-psql.pkr.hcl 
+          packer build -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${GITHUB_RUN_ID}" -var-file="development-arm.vars.pkr.hcl" -var-file="common-nix.vars.pkr.hcl"  -var "postgres-version=${{ steps.random.outputs.random_string }}" -var "region=ap-southeast-1" -var 'ami_regions=["ap-southeast-1"]' -var "force-deregister=true" -var "git_sha=${GITHUB_SHA}"  stage2-nix-psql.pkr.hcl 
 
       - name: Run tests
         timeout-minutes: 10
         run: |
           # TODO: use poetry for pkg mgmt
           pip3 install boto3 boto3-stubs[essential] docker ec2instanceconnectcli pytest pytest-testinfra[paramiko,docker] requests
-          pytest -vv -s testinfra/test_ami_nix.py
+          pytest -vv -s testinfra/test_ami_nix.py --ami-name "${{ steps.random.outputs.random_string }}"
       
       - name: Cleanup resources on build cancellation
         if: ${{ cancelled() }}
@@ -71,7 +75,7 @@ jobs:
         run: |
           # Define AMI name patterns
           STAGE1_AMI_NAME="supabase-postgres-ci-ami-test-stage-1"
-          STAGE2_AMI_NAME="supabase-postgres-ci-ami-test-nix"
+          STAGE2_AMI_NAME="${{ steps.random.outputs.random_string }}"
           
           # Function to deregister AMIs by name pattern
           deregister_ami_by_name() {

--- a/.github/workflows/testinfra-nix.yml
+++ b/.github/workflows/testinfra-nix.yml
@@ -37,16 +37,16 @@ jobs:
         with:
           endpoint: builders
 
+      - name: Generate random string
+        id: random
+        run: echo "random_string=$(openssl rand -hex 8)" >> $GITHUB_OUTPUT
+  
       - name: Build AMI stage 1
         run: |
           packer init amazon-arm64-nix.pkr.hcl
           GIT_SHA=${{github.sha}}
-          packer build -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${GITHUB_RUN_ID}" -var-file="development-arm.vars.pkr.hcl" -var-file="common-nix.vars.pkr.hcl" -var "ansible_arguments=" -var "postgres-version=ci-ami-test" -var "region=ap-southeast-1" -var 'ami_regions=["ap-southeast-1"]' -var "force-deregister=true" amazon-arm64-nix.pkr.hcl
+          packer build -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${GITHUB_RUN_ID}" -var-file="development-arm.vars.pkr.hcl" -var-file="common-nix.vars.pkr.hcl" -var "ansible_arguments=" -var "postgres-version=${{ steps.random.outputs.random_string }}" -var "region=ap-southeast-1" -var 'ami_regions=["ap-southeast-1"]' -var "force-deregister=true" amazon-arm64-nix.pkr.hcl
       
-      - name: Generate random string
-        id: random
-        run: echo "random_string=$(openssl rand -hex 8)" >> $GITHUB_OUTPUT
-
       - name: Build AMI stage 2
         run: |
           packer init stage2-nix-psql.pkr.hcl

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -192,7 +192,7 @@
     - name: Install osquery from nixpkgs binary cache
       become: yes
       shell: |
-        sudo -u ubuntu bash -c ". /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh && nix profile install nixpkgs#osquery"
+        sudo -u ubuntu bash -c ". /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh && nix profile install github:nixos/nixpkgs/f98ec4f73c762223d62bee706726138cb6ea27cc#osquery"
       when: stage2_nix
 
     - name: Run osquery permission checks

--- a/testinfra/test_ami_nix.py
+++ b/testinfra/test_ami_nix.py
@@ -6,6 +6,7 @@ import os
 import pytest
 import requests
 import socket
+import sys
 import testinfra
 from ec2instanceconnectcli.EC2InstanceConnectLogger import EC2InstanceConnectLogger
 from ec2instanceconnectcli.EC2InstanceConnectKey import EC2InstanceConnectKey
@@ -159,15 +160,19 @@ formatter = logging.Formatter(
 handler.setFormatter(formatter)
 logger.addHandler(handler)
 logger.setLevel(logging.DEBUG)
-
+def get_ami_name():
+    if len(sys.argv) > 1:
+        return sys.argv[1]
+    else:
+        raise ValueError("AMI name must be provided as a command-line argument")
 # scope='session' uses the same container for all the tests;
 # scope='function' uses a new container per test function.
 @pytest.fixture(scope="session")
-def host():
+def host(ami_name):
     ec2 = boto3.resource("ec2", region_name="ap-southeast-1")
     images = list(
         ec2.images.filter(
-            Filters=[{"Name": "name", "Values": ["supabase-postgres-ci-ami-test-nix"]}]
+            Filters=[{"Name": "name", "Values": [ami_name]}]
         )
     )
     assert len(images) == 1


### PR DESCRIPTION
## What kind of change does this PR introduce?

On the testinfra that runs for 15.6 build, gh actions was having trouble deregistering AMI if a build had failed under certain conditions.

This PR introduces a random name for the final ami that gh actions had trouble deregistering, which will prevent the test from failing due to a duplicate ami with the same name. The random name is also passed to the infra pytest run during the build as well, and the deregister action at the end on failure, complete, or cancel. 