### PR TITLE
feat: make pg_regress available in /bin outputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -61,6 +61,7 @@
         };
 
         sfcgal = pkgs.callPackage ./nix/ext/sfcgal/sfcgal.nix { };
+        pg_regress = pkgs.callPackage ./nix/ext/pg_regress.nix { };
 
         # Our list of PostgreSQL extensions which come from upstream Nixpkgs.
         # These are maintained upstream and can easily be used here just by
@@ -269,6 +270,7 @@
           #psql_16 = makePostgres "16";
           #psql_orioledb_16 = makeOrioleDbPostgres "16_23" postgresql_orioledb_16;
           sfcgal = sfcgal;
+          pg_regress = pg_regress;
           pg_prove = pkgs.perlPackages.TAPParserSourceHandlerpgTAP;
           # Start a version of the server.
           start-server =

--- a/nix/ext/pg_regress.nix
+++ b/nix/ext/pg_regress.nix
@@ -1,0 +1,24 @@
+{ lib
+, stdenv
+, postgresql
+}:
+
+stdenv.mkDerivation {
+  pname = "pg_regress";
+  version = postgresql.version;
+
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ${postgresql}/lib/pgxs/src/test/regress/pg_regress $out/bin/
+  '';
+
+  meta = with lib; {
+    description = "Regression testing tool for PostgreSQL";
+    homepage = "https://www.postgresql.org/";
+    maintainers = with maintainers; [ samrose ];
+    platforms = postgresql.meta.platforms;
+    license = licenses.postgresql;
+  };
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR introduces `pg_regress` tool as an executable binary inherited from the version of postgres we're supporting in the bundle.