### PR TITLE
Adds a Wasm wrapper test script for pg_dumpall and pg_upgrade testing

### DIFF
--- a/nix/tests/migrations/wasm_wrapper.sql
+++ b/nix/tests/migrations/wasm_wrapper.sql
@@ -1,0 +1,33 @@
+create extension if not exists wrappers with schema extensions;
+
+create foreign data wrapper wasm_wrapper
+  handler wasm_fdw_handler
+  validator wasm_fdw_validator;
+
+create server example_server
+  foreign data wrapper wasm_wrapper
+  options (
+    -- change below fdw_package_* options accordingly, find examples in the README.txt in your releases
+    fdw_package_url 'https://github.com/supabase-community/wasm-fdw-example/releases/download/v0.1.0/wasm_fdw_example.wasm',
+    fdw_package_name 'my-company:example-fdw',
+    fdw_package_version '0.1.0',
+    fdw_package_checksum '67bbe7bfaebac6e8b844813121099558ffe5b9d8ac6fca8fe49c20181f50eba8',
+    api_url 'https://api.github.com'
+  );
+
+create schema github;
+
+create foreign table github.events (
+  id text,
+  type text,
+  actor jsonb,
+  repo jsonb,
+  payload jsonb,
+  public boolean,
+  created_at timestamp
+)
+  server example_server
+  options (
+    object 'events',
+    rowid_column 'id'
+  );


### PR DESCRIPTION
Creates a test script that can be used for evaluating if a pause/restore will work.

We should be able to execute it using
```
OLD_GIT_VERSION=47d598f6be65cd5b920ae807cf98c401ed5ae045
NEW_GIT_VERSION=47d598f6be65cd5b920ae807cf98c401ed5ae045

nix run github:supabase/nix-postgres#migration-test \
  $(nix build "github:supabase/nix-postgres/$OLD_GIT_VERSION#psql_15/bin") \
  $(nix build "github:supabase/nix-postgres/$NEW_GIT_VERSION#psql_15/bin") \
  pg_dumpall
```

but it is currently not functional. Opening as a draft so we can evaluate how to fix it

The error is
```
error: flake 'github:supabase/nix-postgres' does not provide attribute 'apps.aarch64-darwin.migration-test', 'packages.aarch64-darwin.migration-test', 'legacyPackages.aarch64-darwin.migration-test' or 'migration-test'
```