### PR TITLE
Upgrade wal-g from v2 to v3.0.3 for oriole support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -860,7 +860,7 @@ ARG wal_g_release
 # ADD "https://github.com/wal-g/wal-g/releases/download/v${wal_g_release}/wal-g-pg-ubuntu-20.04-${TARGETARCH}.tar.gz" /tmp/wal-g.tar.gz
 RUN arch=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "$TARGETARCH") && \
     apt-get update && apt-get install -y --no-install-recommends curl && \
-    curl -kL "https://github.com/wal-g/wal-g/releases/download/v${wal_g_release}/wal-g-pg-ubuntu-20.04-${arch}.tar.gz" -o /tmp/wal-g.tar.gz && \
+    curl -kL "https://github.com/wal-g/wal-g/releases/download/v${wal_g_release}/wal-g-pg-ubuntu20.04-${arch}.tar.gz" -o /tmp/wal-g.tar.gz && \
     tar -xvf /tmp/wal-g.tar.gz -C /tmp && \
     rm -rf /tmp/wal-g.tar.gz && \
     mv /tmp/wal-g-pg-ubuntu*20.04-$arch /tmp/wal-g

--- a/Dockerfile-156
+++ b/Dockerfile-156
@@ -124,7 +124,7 @@ ARG wal_g_release
 # ADD "https://github.com/wal-g/wal-g/releases/download/v${wal_g_release}/wal-g-pg-ubuntu-20.04-${TARGETARCH}.tar.gz" /tmp/wal-g.tar.gz
 RUN arch=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "$TARGETARCH") && \
     apt-get update && apt-get install -y --no-install-recommends curl && \
-    curl -kL "https://github.com/wal-g/wal-g/releases/download/v${wal_g_release}/wal-g-pg-ubuntu-20.04-aarch64.tar.gz" -o /tmp/wal-g.tar.gz && \
+    curl -kL "https://github.com/wal-g/wal-g/releases/download/v${wal_g_release}/wal-g-pg-ubuntu20.04-aarch64.tar.gz" -o /tmp/wal-g.tar.gz && \
     tar -xvf /tmp/wal-g.tar.gz -C /tmp && \
     rm -rf /tmp/wal-g.tar.gz && \
     mv /tmp/wal-g-pg-ubuntu*20.04-aarch64 /tmp/wal-g

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -40,7 +40,7 @@ kong_deb_checksum: sha1:2086f6ccf8454fe64435252fea4d29d736d7ec61
 nginx_release: 1.22.0
 nginx_release_checksum: sha1:419efb77b80f165666e2ee406ad8ae9b845aba93
 
-wal_g_release: "2.0.1"
+wal_g_release: "3.0.3"
 
 sfcgal_release: "1.3.10"
 sfcgal_release_checksum: sha256:4e39b3b2adada6254a7bdba6d297bb28e1a9835a9f879b74f37e2dab70203232

--- a/docker/orioledb/Dockerfile
+++ b/docker/orioledb/Dockerfile
@@ -952,7 +952,7 @@ ARG wal_g_release
 # ADD "https://github.com/wal-g/wal-g/releases/download/v${wal_g_release}/wal-g-pg-ubuntu-20.04-${TARGETARCH}.tar.gz" /tmp/wal-g.tar.gz
 RUN arch=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "$TARGETARCH") && \
     apt-get update && apt-get install -y --no-install-recommends curl && \
-    curl -kL "https://github.com/wal-g/wal-g/releases/download/v${wal_g_release}/wal-g-pg-ubuntu-20.04-${arch}.tar.gz" -o /tmp/wal-g.tar.gz && \
+    curl -kL "https://github.com/wal-g/wal-g/releases/download/v${wal_g_release}/wal-g-pg-ubuntu20.04-${arch}.tar.gz" -o /tmp/wal-g.tar.gz && \
     tar -xvf /tmp/wal-g.tar.gz -C /tmp && \
     rm -rf /tmp/wal-g.tar.gz && \
     mv /tmp/wal-g-pg-ubuntu*20.04-$arch /tmp/wal-g


### PR DESCRIPTION
Upgrades wal-g from v2 to v3.0.3 for oriole support

resolves #1082 

Tasks:
- [ ] verify backup flows continue to work