### PR TITLE
Sam/pgroonga deps

### DIFF
--- a/ansible/tasks/stage2-setup-postgres.yml
+++ b/ansible/tasks/stage2-setup-postgres.yml
@@ -13,7 +13,13 @@
 - name: Install pg_prove from nix binary cache
   become: yes
   shell: |
-    sudo -u postgres bash -c ". /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh && nix profile install github:supabase/postgres/sam/2-stage-ami-nix#pg_prove"
+    sudo -u postgres bash -c ". /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh && nix profile install github:supabase/postgres/{{ git_commit_sha }}#pg_prove"
+  when: stage2_nix
+
+- name: Install supabase-groonga from nix binary cache
+  become: yes
+  shell: |
+    sudo -u postgres bash -c ". /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh && nix profile install github:supabase/postgres/{{ git_commit_sha }}#supabase-groonga"
   when: stage2_nix
 
 - name: Set ownership and permissions for /etc/ssl/private
@@ -220,3 +226,9 @@
     # script is expected to be placed by finalization tasks for different target platforms
     line: pgsodium.getkey_script= '{{ pg_bindir }}/pgsodium_getkey.sh'
   when: stage2_nix
+
+- name: Append GRN_PLUGINS_DIR to /etc/environment.d/postgresql.env
+  ansible.builtin.lineinfile:
+    path: /etc/environment.d/postgresql.env
+    line: 'GRN_PLUGINS_DIR=/var/lib/postgresql/.nix-profile/lib/groonga/plugins'
+  become: yes

--- a/ansible/tasks/stage2-setup-postgres.yml
+++ b/ansible/tasks/stage2-setup-postgres.yml
@@ -19,7 +19,7 @@
 - name: Install supabase-groonga from nix binary cache
   become: yes
   shell: |
-    sudo -u postgres bash -c ". /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh && nix profile install github:supabase/postgres/{{ git_commit_sha }}#supabase-groonga"
+    sudo -u postgres bash -c ". /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh && nix profile install github:supabase/postgres/sam/pgroonga-deps#supabase-groonga"
   when: stage2_nix
 
 - name: Set ownership and permissions for /etc/ssl/private

--- a/flake.nix
+++ b/flake.nix
@@ -77,7 +77,7 @@
         postgresql = pkgs.postgresql.postgresql_15;
         sfcgal = pkgs.callPackage ./nix/ext/sfcgal/sfcgal.nix { };
         pg_regress = pkgs.callPackage ./nix/ext/pg_regress.nix { inherit postgresql; };
-
+        supabase-groonga = pkgs.callPackage ./nix/supabase-groonga.nix { };
         # Our list of PostgreSQL extensions which come from upstream Nixpkgs.
         # These are maintained upstream and can easily be used here just by
         # listing their name. Anytime the version of nixpkgs is upgraded, these
@@ -284,6 +284,7 @@
         # name in 'nix flake show' in order to make sure exactly what name you
         # want.
         basePackages = {
+          supabase-groonga = supabase-groonga;
           # PostgreSQL versions.
           psql_15 = makePostgres "15";
           #psql_16 = makePostgres "16";
@@ -377,8 +378,9 @@
                 --subst-var-by 'PG_HBA' "$out/etc/postgresql/pg_hba.conf" \
                 --subst-var-by 'PG_IDENT' "$out/etc/postgresql/pg_ident.conf" \
                 --subst-var-by 'LOCALES' '${localeArchive}' \
-                --subst-var-by 'EXTENSION_CUSTOM_SCRIPTS_DIR' "$out/extension-custom-scripts"
-                
+                --subst-var-by 'EXTENSION_CUSTOM_SCRIPTS_DIR' "$out/extension-custom-scripts" \
+                --subst-var-by 'MECAB_LIB' '${basePackages.psql_15.exts.pgroonga}/lib/groonga/plugins/tokenizers/tokenizer_mecab.so'
+
               chmod +x $out/bin/start-postgres-server
             '';
 

--- a/flake.nix
+++ b/flake.nix
@@ -78,6 +78,7 @@
         sfcgal = pkgs.callPackage ./nix/ext/sfcgal/sfcgal.nix { };
         pg_regress = pkgs.callPackage ./nix/ext/pg_regress.nix { inherit postgresql; };
         supabase-groonga = pkgs.callPackage ./nix/supabase-groonga.nix { };
+        mecab-naist-jdic = pkgs.callPackage ./nix/ext/mecab-naist-jdic/default.nix { };
         # Our list of PostgreSQL extensions which come from upstream Nixpkgs.
         # These are maintained upstream and can easily be used here just by
         # listing their name. Anytime the version of nixpkgs is upgraded, these
@@ -316,6 +317,7 @@
               platforms = platforms.all;
             };
           };
+          mecab_naist_jdic = mecab-naist-jdic;
           # Start a version of the server.
           start-server =
             let

--- a/flake.nix
+++ b/flake.nix
@@ -318,6 +318,7 @@
             };
           };
           mecab_naist_jdic = mecab-naist-jdic;
+          supabase_groonga = supabase-groonga;
           # Start a version of the server.
           start-server =
             let
@@ -381,7 +382,8 @@
                 --subst-var-by 'PG_IDENT' "$out/etc/postgresql/pg_ident.conf" \
                 --subst-var-by 'LOCALES' '${localeArchive}' \
                 --subst-var-by 'EXTENSION_CUSTOM_SCRIPTS_DIR' "$out/extension-custom-scripts" \
-                --subst-var-by 'MECAB_LIB' '${basePackages.psql_15.exts.pgroonga}/lib/groonga/plugins/tokenizers/tokenizer_mecab.so'
+                --subst-var-by 'MECAB_LIB' '${basePackages.psql_15.exts.pgroonga}/lib/groonga/plugins/tokenizers/tokenizer_mecab.so' \
+                --subst-var-by 'GROONGA_DIR' '${supabase-groonga}' 
 
               chmod +x $out/bin/start-postgres-server
             '';
@@ -452,10 +454,11 @@
           let
             sqlTests = ./nix/tests/smoke;
             pg_prove = pkgs.perlPackages.TAPParserSourceHandlerpgTAP;
+            supabase-groonga = pkgs.callPackage ./nix/supabase-groonga.nix { };
           in
           pkgs.runCommand "postgres-${pgpkg.version}-check-harness"
             {
-              nativeBuildInputs = with pkgs; [ coreutils bash pgpkg pg_prove pg_regress procps ];
+              nativeBuildInputs = with pkgs; [ coreutils bash pgpkg pg_prove pg_regress procps supabase-groonga ];
             } ''
             TMPDIR=$(mktemp -d)
             if [ $? -ne 0 ]; then
@@ -473,7 +476,7 @@
             mkdir -p $TMPDIR/logfile
             # Generate a random key and store it in an environment variable
             export PGSODIUM_KEY=$(head -c 32 /dev/urandom | od -A n -t x1 | tr -d ' \n')
-
+            export GRN_PLUGINS_DIR=${supabase-groonga}/lib/groonga/plugins
             # Create a simple script to echo the key
             echo '#!/bin/sh' > $TMPDIR/getkey.sh
             echo 'echo $PGSODIUM_KEY' >> $TMPDIR/getkey.sh

--- a/nix/do-not-use-vendored-libraries.patch
+++ b/nix/do-not-use-vendored-libraries.patch
@@ -1,0 +1,15 @@
+Do not use vendored libraries
+
+--- a/vendor/CMakeLists.txt
++++ b/vendor/CMakeLists.txt
+@@ -14,10 +14,7 @@
+ # License along with this library; if not, write to the Free Software
+ # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ 
+ add_subdirectory(onigmo)
+-add_subdirectory(mruby)
+-add_subdirectory(mecab)
+-add_subdirectory(message_pack)
+ if(GRN_WITH_MRUBY)
+   add_subdirectory(groonga-log)
+ endif()

--- a/nix/ext/mecab-naist-jdic/default.nix
+++ b/nix/ext/mecab-naist-jdic/default.nix
@@ -1,0 +1,41 @@
+{ lib, stdenv, fetchurl, mecab }:
+
+stdenv.mkDerivation rec {
+  pname = "mecab-naist-jdic";
+  version = "0.6.3b-20111013";
+  
+  src = fetchurl {
+    url = "https://github.com/supabase/mecab-naist-jdic/raw/main/mecab-naist-jdic-${version}.tar.gz";
+    sha256 = "sha256-yzdwDcmne5U/K/OxW0nP7NZ4SFMKLPirywm1lMpWKMw=";
+  };
+  
+  buildInputs = [ mecab ];
+  
+  configureFlags = [
+    "--with-charset=utf8"
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    make
+    ${mecab}/libexec/mecab/mecab-dict-index -d . -o . -f UTF-8 -t utf-8
+    runHook postBuild
+  '';
+  
+  installPhase = ''
+    runHook preInstall
+    
+    mkdir -p $out/lib/mecab/dic/naist-jdic
+    cp *.dic *.bin *.def $out/lib/mecab/dic/naist-jdic/
+    
+    runHook postInstall
+  '';
+  
+  meta = with lib; {
+    description = "Naist Japanese Dictionary for MeCab";
+    homepage = "https://taku910.github.io/mecab/";
+    license = licenses.gpl2;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ samrose ];
+  };
+}

--- a/nix/ext/pgroonga.nix
+++ b/nix/ext/pgroonga.nix
@@ -40,9 +40,6 @@ stdenv.mkDerivation rec {
     install -D pgroonga_database.control -t $out/share/postgresql/extension
     install -D data/pgroonga_database-*.sql -t $out/share/postgresql/extension
 
-    makeWrapper ${postgresql}/bin/postgres $out/bin/pgroonga-postgres \
-      --set LD_LIBRARY_PATH "${lib.makeLibraryPath buildInputs}:${supabase-groonga}/lib:$out/lib"
-
     echo "Debug: Groonga plugins directory contents:"
     ls -l ${supabase-groonga}/lib/groonga/plugins/tokenizers/
   '';

--- a/nix/ext/pgroonga.nix
+++ b/nix/ext/pgroonga.nix
@@ -1,119 +1,3 @@
-# { lib, stdenv, fetchurl, pkg-config, postgresql, msgpack-c, callPackage
-# , makeWrapper, mecab }:
-
-# let
-#   supabase-groonga = callPackage ../supabase-groonga.nix { };
-#   mecab-naist-jdic = callPackage ./mecab-naist-jdic { };
-# in stdenv.mkDerivation rec {
-#   pname = "pgroonga";
-#   version = "3.0.7";
-#   src = fetchurl {
-#     url =
-#       "https://packages.groonga.org/source/${pname}/${pname}-${version}.tar.gz";
-#     sha256 = "sha256-iF/zh4zDDpAw5fxW1WG8i2bfPt4VYsnYArwOoE/lwgM=";
-#   };
-#   nativeBuildInputs = [ pkg-config makeWrapper ];
-#   buildInputs = [ postgresql msgpack-c supabase-groonga mecab mecab-naist-jdic ];
-  
-#   makeFlags = [
-#     "USE_PGXS=1"
-#     "HAVE_MSGPACK=1"
-#     "MSGPACK_PACKAGE_NAME=msgpack-c"
-#     "HAVE_MECAB=1"
-#     "POSTGRES_INCLUDEDIR=${postgresql}/include"
-#     "POSTGRES_LIBDIR=${postgresql.lib}/lib"
-#     "PG_CONFIG=${postgresql}/bin/pg_config"
-#     "MECAB_CONFIG=${mecab}/bin/mecab-config"
-#     "MECAB_LIBRARIES=-L${mecab}/lib -lmecab"
-#     "GROONGA_INCLUDES=-I${supabase-groonga}/include"
-#     "GROONGA_LIBS=-L${supabase-groonga}/lib -lgroonga"
-#     "GROONGA_PLUGIN_LIBS=-L${supabase-groonga}/lib/groonga/plugins"
-#   ];
-  
-#   configureFlags = [
-#     "--with-mecab=${mecab}"
-#     "--enable-mecab"
-#     "--with-mecab-config=${mecab}/bin/mecab-config"
-#     "--with-mecab-dict=${mecab-naist-jdic}/lib/mecab/dic/naist-jdic"
-#     "--with-groonga=${supabase-groonga}"
-#     "--with-groonga-plugin-dir=${supabase-groonga}/lib/groonga/plugins"
-#   ];
-
-#   preConfigure = ''
-#     export MECAB_DICDIR=${mecab-naist-jdic}/lib/mecab/dic/naist-jdic
-#     export GROONGA_INCLUDE_PATH=${supabase-groonga}/include
-#     export GROONGA_LIB_PATH=${supabase-groonga}/lib
-#     export MECAB_INCLUDE_PATH=${mecab}/include
-#     export MECAB_LIB_PATH=${mecab}/lib
-#     export PKG_CONFIG_PATH="${supabase-groonga}/lib/pkgconfig:$PKG_CONFIG_PATH"
-#     export GRN_PLUGINS_PATH=${supabase-groonga}/lib/groonga/plugins
-    
-#     # Ensure MeCab is enabled
-#     sed -i 's|#define HAVE_MECAB 0|#define HAVE_MECAB 1|' src/pgroonga.h
-#   '';
-
-#   installPhase = ''
-#     runHook preInstall
-#     make $makeFlags install DESTDIR=$out
-#     install -D pgroonga${postgresql.dlSuffix} -t $out/lib/
-#     install -D pgroonga.control -t $out/share/postgresql/extension
-#     install -D data/pgroonga-*.sql -t $out/share/postgresql/extension
-#     install -D pgroonga_database${postgresql.dlSuffix} -t $out/lib/
-#     install -D pgroonga_database.control -t $out/share/postgresql/extension
-#     install -D data/pgroonga_database-*.sql -t $out/share/postgresql/extension
-
-#     for component in pgroonga_check pgroonga_wal_applier pgroonga_crash_safer pgroonga_standby_maintainer; do
-#       if [ -f "$component${postgresql.dlSuffix}" ]; then
-#         install -D "$component${postgresql.dlSuffix}" -t $out/lib/
-#       fi
-#     done
-
-#     # Ensure Groonga plugins are accessible
-#     mkdir -p $out/lib/groonga/plugins
-#     cp -r ${supabase-groonga}/lib/groonga/plugins/* $out/lib/groonga/plugins/
-
-#     # Create a wrapper script for pgroonga
-#     mkdir -p $out/bin
-#     makeWrapper ${postgresql}/bin/postgres $out/bin/pgroonga-postgres \
-#       --set GRN_PLUGINS_PATH ${supabase-groonga}/lib/groonga/plugins \
-#       --set LD_LIBRARY_PATH ${lib.makeLibraryPath buildInputs}:${supabase-groonga}/lib:$out/lib:$out/lib/groonga/plugins
-
-#     # Create SQL scripts to apply the necessary settings
-#     cat << EOF > $out/share/postgresql/extension/pgroonga_set_paths.sql
-#     DO \$\$
-#     BEGIN
-#       SET pgroonga.log_path TO current_setting('data_directory') || '/groonga.log';
-#       SET pgroonga.libgroonga_path TO '${supabase-groonga}/lib/libgroonga${stdenv.hostPlatform.extensions.sharedLibrary}';
-#       SET pgroonga.groonga_plugin_path TO '${supabase-groonga}/lib/groonga/plugins';
-#     END \$\$;
-# EOF
-#     chmod +x $out/share/postgresql/extension/pgroonga_set_paths.sql
-
-#     runHook postInstall
-#   '';
-
-#   postFixup = ''
-#     for f in $out/lib/*.so; do
-#       patchelf --set-rpath "${lib.makeLibraryPath buildInputs}:${supabase-groonga}/lib:$out/lib:$out/lib/groonga/plugins" $f
-#     done
-#   '';
-
-#   meta = with lib; {
-#     description = "A PostgreSQL extension to use Groonga as the index";
-#     longDescription = ''
-#       PGroonga is a PostgreSQL extension to use Groonga as the index.
-#       PostgreSQL supports full text search against languages that use only alphabet and digit.
-#       It means that PostgreSQL doesn't support full text search against Japanese, Chinese and so on.
-#       You can use super fast full text search feature against all languages by installing PGroonga into your PostgreSQL.
-#     '';
-#     homepage = "https://pgroonga.github.io/";
-#     changelog = "https://github.com/pgroonga/pgroonga/releases/tag/${version}";
-#     license = licenses.postgresql;
-#     platforms = postgresql.meta.platforms;
-#     maintainers = with maintainers; [ samrose ];
-#   };
-# }
-
 { lib, stdenv, fetchurl, pkg-config, postgresql, msgpack-c, callPackage, mecab, makeWrapper }:
 let
   supabase-groonga = callPackage ../supabase-groonga.nix { };
@@ -156,11 +40,15 @@ stdenv.mkDerivation rec {
     install -D pgroonga_database.control -t $out/share/postgresql/extension
     install -D data/pgroonga_database-*.sql -t $out/share/postgresql/extension
 
+    # Modify the main PGroonga SQL file to include MeCab plugin registration
+    for sql_file in $out/share/postgresql/extension/pgroonga-*.sql; do
+      echo "SELECT pgroonga_command('plugin_register ${supabase-groonga}/lib/groonga/plugins/tokenizers/mecab.so');" >> $sql_file
+    done
+
     cat << EOF > $out/share/postgresql/extension/pgroonga_set_paths.sql
     DO \$\$
     BEGIN
       SET pgroonga.log_path TO current_setting('data_directory') || '/groonga.log';
-      PERFORM pgroonga_command('plugin_register ${supabase-groonga}/lib/groonga/plugins/tokenizers/mecab.so');
     END \$\$;
 EOF
     chmod +x $out/share/postgresql/extension/pgroonga_set_paths.sql

--- a/nix/ext/pgroonga.nix
+++ b/nix/ext/pgroonga.nix
@@ -1,5 +1,6 @@
-# { lib, stdenv, fetchurl, pkg-config, postgresql, msgpack-c, mecab, callPackage
-# , patchelf }:
+# { lib, stdenv, fetchurl, pkg-config, postgresql, msgpack-c, callPackage
+# , makeWrapper, mecab }:
+
 # let
 #   supabase-groonga = callPackage ../supabase-groonga.nix { };
 #   mecab-naist-jdic = callPackage ./mecab-naist-jdic { };
@@ -11,85 +12,90 @@
 #       "https://packages.groonga.org/source/${pname}/${pname}-${version}.tar.gz";
 #     sha256 = "sha256-iF/zh4zDDpAw5fxW1WG8i2bfPt4VYsnYArwOoE/lwgM=";
 #   };
-#   nativeBuildInputs = [ pkg-config patchelf ];
-#   buildInputs =
-#     [ postgresql msgpack-c supabase-groonga mecab mecab-naist-jdic ];
-
+#   nativeBuildInputs = [ pkg-config makeWrapper ];
+#   buildInputs = [ postgresql msgpack-c supabase-groonga mecab mecab-naist-jdic ];
+  
+#   makeFlags = [
+#     "USE_PGXS=1"
+#     "HAVE_MSGPACK=1"
+#     "MSGPACK_PACKAGE_NAME=msgpack-c"
+#     "HAVE_MECAB=1"
+#     "POSTGRES_INCLUDEDIR=${postgresql}/include"
+#     "POSTGRES_LIBDIR=${postgresql.lib}/lib"
+#     "PG_CONFIG=${postgresql}/bin/pg_config"
+#     "MECAB_CONFIG=${mecab}/bin/mecab-config"
+#     "MECAB_LIBRARIES=-L${mecab}/lib -lmecab"
+#     "GROONGA_INCLUDES=-I${supabase-groonga}/include"
+#     "GROONGA_LIBS=-L${supabase-groonga}/lib -lgroonga"
+#     "GROONGA_PLUGIN_LIBS=-L${supabase-groonga}/lib/groonga/plugins"
+#   ];
+  
 #   configureFlags = [
 #     "--with-mecab=${mecab}"
 #     "--enable-mecab"
-#     "--enable-groonga-tokenizer-mecab"
+#     "--with-mecab-config=${mecab}/bin/mecab-config"
 #     "--with-mecab-dict=${mecab-naist-jdic}/lib/mecab/dic/naist-jdic"
 #     "--with-groonga=${supabase-groonga}"
-#     "--with-groonga-token-mecab-dir=${supabase-groonga}/lib/groonga/plugins/tokenizers"
-#     "--with-groonga-tokenizer-mecab=${supabase-groonga}/lib/groonga/plugins/tokenizers/mecab.so"
 #     "--with-groonga-plugin-dir=${supabase-groonga}/lib/groonga/plugins"
-#     "--with-pgconfigdir=${postgresql}/bin"
-#     "--with-mecab-config=${mecab}/bin/mecab-config"
 #   ];
 
-#   makeFlags =
-#     [ "HAVE_MSGPACK=1" "MSGPACK_PACKAGE_NAME=msgpack-c" "HAVE_MECAB=1" ];
-
-#   buildPhase = ''
-#     runHook preBuild
-#     make
-#     echo "Checking for MeCab-related files:"
-#     find . -name "*mecab*"
-#     runHook postBuild
+#   preConfigure = ''
+#     export MECAB_DICDIR=${mecab-naist-jdic}/lib/mecab/dic/naist-jdic
+#     export GROONGA_INCLUDE_PATH=${supabase-groonga}/include
+#     export GROONGA_LIB_PATH=${supabase-groonga}/lib
+#     export MECAB_INCLUDE_PATH=${mecab}/include
+#     export MECAB_LIB_PATH=${mecab}/lib
+#     export PKG_CONFIG_PATH="${supabase-groonga}/lib/pkgconfig:$PKG_CONFIG_PATH"
+#     export GRN_PLUGINS_PATH=${supabase-groonga}/lib/groonga/plugins
+    
+#     # Ensure MeCab is enabled
+#     sed -i 's|#define HAVE_MECAB 0|#define HAVE_MECAB 1|' src/pgroonga.h
 #   '';
 
 #   installPhase = ''
 #     runHook preInstall
-
+#     make $makeFlags install DESTDIR=$out
 #     install -D pgroonga${postgresql.dlSuffix} -t $out/lib/
-#     install -D pgroonga.control -t $out/share/postgresql/extension/
-#     install -D data/pgroonga-*.sql -t $out/share/postgresql/extension/
+#     install -D pgroonga.control -t $out/share/postgresql/extension
+#     install -D data/pgroonga-*.sql -t $out/share/postgresql/extension
 #     install -D pgroonga_database${postgresql.dlSuffix} -t $out/lib/
-#     install -D pgroonga_database.control -t $out/share/postgresql/extension/
-#     install -D data/pgroonga_database-*.sql -t $out/share/postgresql/extension/
+#     install -D pgroonga_database.control -t $out/share/postgresql/extension
+#     install -D data/pgroonga_database-*.sql -t $out/share/postgresql/extension
 
-#     # Ensure MeCab tokenizer is available
-#     if [ -f ${supabase-groonga}/lib/groonga/plugins/tokenizers/mecab.so ]; then
-#       mkdir -p $out/lib/postgresql/plugins/
-#       cp ${supabase-groonga}/lib/groonga/plugins/tokenizers/mecab.so $out/lib/postgresql/plugins/
-#     else
-#       echo "MeCab tokenizer plugin not found in Groonga installation"
-#       exit 1
-#     fi
+#     for component in pgroonga_check pgroonga_wal_applier pgroonga_crash_safer pgroonga_standby_maintainer; do
+#       if [ -f "$component${postgresql.dlSuffix}" ]; then
+#         install -D "$component${postgresql.dlSuffix}" -t $out/lib/
+#       fi
+#     done
+
+#     # Ensure Groonga plugins are accessible
+#     mkdir -p $out/lib/groonga/plugins
+#     cp -r ${supabase-groonga}/lib/groonga/plugins/* $out/lib/groonga/plugins/
+
+#     # Create a wrapper script for pgroonga
+#     mkdir -p $out/bin
+#     makeWrapper ${postgresql}/bin/postgres $out/bin/pgroonga-postgres \
+#       --set GRN_PLUGINS_PATH ${supabase-groonga}/lib/groonga/plugins \
+#       --set LD_LIBRARY_PATH ${lib.makeLibraryPath buildInputs}:${supabase-groonga}/lib:$out/lib:$out/lib/groonga/plugins
+
+#     # Create SQL scripts to apply the necessary settings
+#     cat << EOF > $out/share/postgresql/extension/pgroonga_set_paths.sql
+#     DO \$\$
+#     BEGIN
+#       SET pgroonga.log_path TO current_setting('data_directory') || '/groonga.log';
+#       SET pgroonga.libgroonga_path TO '${supabase-groonga}/lib/libgroonga${stdenv.hostPlatform.extensions.sharedLibrary}';
+#       SET pgroonga.groonga_plugin_path TO '${supabase-groonga}/lib/groonga/plugins';
+#     END \$\$;
+# EOF
+#     chmod +x $out/share/postgresql/extension/pgroonga_set_paths.sql
 
 #     runHook postInstall
 #   '';
 
-#   postInstall = ''
-#     echo "Checking installed files:"
-#     find $out -type f
-
-#     echo "Checking for MeCab-related files in the output:"
-#     find $out -name "*mecab*"
-#   '';
-
 #   postFixup = ''
-#     patchelf --set-rpath "${
-#       lib.makeLibraryPath [
-#         mecab
-#         mecab-naist-jdic
-#         supabase-groonga
-#         postgresql
-#         stdenv.cc.cc.lib
-#         msgpack-c
-#       ]
-#     }" $out/lib/pgroonga${postgresql.dlSuffix}
-#     patchelf --set-rpath "${
-#       lib.makeLibraryPath [
-#         mecab
-#         mecab-naist-jdic
-#         supabase-groonga
-#         postgresql
-#         stdenv.cc.cc.lib
-#         msgpack-c
-#       ]
-#     }" $out/lib/pgroonga_database${postgresql.dlSuffix}
+#     for f in $out/lib/*.so; do
+#       patchelf --set-rpath "${lib.makeLibraryPath buildInputs}:${supabase-groonga}/lib:$out/lib:$out/lib/groonga/plugins" $f
+#     done
 #   '';
 
 #   meta = with lib; {
@@ -108,176 +114,67 @@
 #   };
 # }
 
-# { lib, stdenv, fetchurl, pkg-config, postgresql, cmake, msgpack-c, mecab, callPackage }:
-# let
-#   supabase-groonga = callPackage ../supabase-groonga.nix { };
-#   mecab-naist-jdic = callPackage ./mecab-naist-jdic { };
-# in
-# stdenv.mkDerivation rec {
-#   pname = "pgroonga";
-#   version = "3.0.7";
-
-#   src = fetchurl {
-#     url = "https://packages.groonga.org/source/${pname}/${pname}-${version}.tar.gz";
-#     sha256 = "sha256-iF/zh4zDDpAw5fxW1WG8i2bfPt4VYsnYArwOoE/lwgM=";
-#   };
-
-#   nativeBuildInputs = [ cmake pkg-config ];
-#   buildInputs = [ postgresql msgpack-c supabase-groonga mecab mecab-naist-jdic ];
-
-#   makeFlags = [
-#     "HAVE_MSGPACK=1"
-#     "MSGPACK_PACKAGE_NAME=msgpack-c"
-#   ];
-
-#   installPhase = ''
-#     install -D pgroonga${postgresql.dlSuffix} -t $out/lib/
-#     install -D pgroonga.control -t $out/share/postgresql/extension
-#     install -D data/pgroonga-*.sql -t $out/share/postgresql/extension
-
-#     install -D pgroonga_database${postgresql.dlSuffix} -t $out/lib/
-#     install -D pgroonga_database.control -t $out/share/postgresql/extension
-#     install -D data/pgroonga_database-*.sql -t $out/share/postgresql/extension
-#   '';
-
-#   meta = with lib; {
-#     description = "A PostgreSQL extension to use Groonga as the index";
-#     longDescription = ''
-#       PGroonga is a PostgreSQL extension to use Groonga as the index.
-#       PostgreSQL supports full text search against languages that use only alphabet and digit.
-#       It means that PostgreSQL doesn't support full text search against Japanese, Chinese and so on.
-#       You can use super fast full text search feature against all languages by installing PGroonga into your PostgreSQL.
-#     '';
-#     homepage = "https://pgroonga.github.io/";
-#     changelog = "https://github.com/pgroonga/pgroonga/releases/tag/${version}";
-#     license = licenses.postgresql;
-#     platforms = postgresql.meta.platforms;
-#     maintainers = with maintainers; [ samrose ];
-#   };
-# }
-
-# { lib, stdenv, fetchurl, pkg-config, postgresql, msgpack-c, callPackage, cmake, mecab }:
-# let
-#   supabase-groonga = callPackage ../supabase-groonga.nix { };
-#   mecab-naist-jdic = callPackage ./mecab-naist-jdic { };
-# in
-# stdenv.mkDerivation rec {
-#   pname = "pgroonga";
-#   version = "3.0.7";
-#   src = fetchurl {
-#     url = "https://packages.groonga.org/source/${pname}/${pname}-${version}.tar.gz";
-#     sha256 = "sha256-iF/zh4zDDpAw5fxW1WG8i2bfPt4VYsnYArwOoE/lwgM=";
-#   };
-#   patches = [ ./use-system-groonga.patch ];
-#   nativeBuildInputs = [ pkg-config cmake ];
-#   buildInputs = [ postgresql msgpack-c supabase-groonga mecab mecab-naist-jdic ];
-#   cmakeFlags = [
-#     "-DCMAKE_PREFIX_PATH=${supabase-groonga}"
-#     "-DMECAB_CONFIG=${mecab}/bin/mecab-config"
-#     "-DMECAB_DICT_INDEX=${mecab}/libexec/mecab/mecab-dict-index"
-#     "-DMECAB_DIC_DIR=${mecab-naist-jdic}/lib/mecab/dic/naist-jdic"
-#     "-DCMAKE_BUILD_TYPE=Release"
-#     "-DBUILD_TESTING=OFF"
-#   ];
-#   preConfigure = ''
-#     export CFLAGS="-I${supabase-groonga}/include -I${postgresql}/include/server -I${supabase-groonga}/include/groonga"
-#     export CPPFLAGS="$CFLAGS"
-#     export LDFLAGS="-L${supabase-groonga}/lib -L${postgresql}/lib"
-
-#     # Remove the problematic /EHsc flag
-#     export CFLAGS="$(echo $CFLAGS | sed 's/-EHsc//g')"
-#     export CXXFLAGS="$(echo $CXXFLAGS | sed 's/-EHsc//g')"
-
-#     # Ensure CMake doesn't add it back
-#     substituteInPlace CMakeLists.txt --replace "-EHsc" ""
-#   '';
-
-#   installPhase = ''
-#     install -D pgroonga${postgresql.dlSuffix} -t $out/lib/
-#     install -D pgroonga.control -t $out/share/postgresql/extension
-#     install -D data/pgroonga-*.sql -t $out/share/postgresql/extension
-#     install -D pgroonga_database${postgresql.dlSuffix} -t $out/lib/
-#     install -D pgroonga_database.control -t $out/share/postgresql/extension
-#     install -D data/pgroonga_database-*.sql -t $out/share/postgresql/extension
-#   '';
-#   meta = with lib; {
-#     description = "A PostgreSQL extension to use Groonga as the index";
-#     longDescription = ''
-#       PGroonga is a PostgreSQL extension to use Groonga as the index.
-#       PostgreSQL supports full text search against languages that use only alphabet and digit.
-#       It means that PostgreSQL doesn't support full text search against Japanese, Chinese and so on.
-#       You can use super fast full text search feature against all languages by installing PGroonga into your PostgreSQL.
-#     '';
-#     homepage = "https://pgroonga.github.io/";
-#     changelog = "https://github.com/pgroonga/pgroonga/releases/tag/${version}";
-#     license = licenses.postgresql;
-#     platforms = postgresql.meta.platforms;
-#     maintainers = with maintainers; [ samrose ];
-#   };
-# }
-
-{ lib, stdenv, fetchurl, pkg-config, postgresql, msgpack-c, callPackage
-, makeWrapper, mecab }:
-
+{ lib, stdenv, fetchurl, pkg-config, postgresql, msgpack-c, callPackage, mecab, makeWrapper }:
 let
   supabase-groonga = callPackage ../supabase-groonga.nix { };
-  mecab-naist-jdic = callPackage ./mecab-naist-jdic { };
-in stdenv.mkDerivation rec {
+in
+stdenv.mkDerivation rec {
   pname = "pgroonga";
   version = "3.0.7";
   src = fetchurl {
-    url =
-      "https://packages.groonga.org/source/${pname}/${pname}-${version}.tar.gz";
+    url = "https://packages.groonga.org/source/${pname}/${pname}-${version}.tar.gz";
     sha256 = "sha256-iF/zh4zDDpAw5fxW1WG8i2bfPt4VYsnYArwOoE/lwgM=";
   };
   nativeBuildInputs = [ pkg-config makeWrapper ];
-  buildInputs = [ postgresql msgpack-c supabase-groonga mecab mecab-naist-jdic ];
+  buildInputs = [ postgresql msgpack-c supabase-groonga mecab ];
+  
+  configureFlags = [
+    "--with-mecab=${mecab}"
+    "--enable-mecab"
+    "--with-groonga=${supabase-groonga}"
+    "--with-groonga-plugin-dir=${supabase-groonga}/lib/groonga/plugins"
+  ];
+
   makeFlags = [
-    "USE_PGXS=1"
     "HAVE_MSGPACK=1"
     "MSGPACK_PACKAGE_NAME=msgpack-c"
     "HAVE_MECAB=1"
-    "POSTGRES_INCLUDEDIR=${postgresql}/include"
-    "POSTGRES_LIBDIR=${postgresql.lib}/lib"
-    "PG_CONFIG=${postgresql}/bin/pg_config"
-    "MECAB_CONFIG=${mecab}/bin/mecab-config"
   ];
-  
-  preConfigure = ''
-    export MECAB_DICDIR=${mecab-naist-jdic}/lib/mecab/dic/naist-jdic
-    export GROONGA_INCLUDE_PATH=${supabase-groonga}/include
-    export GROONGA_LIB_PATH=${supabase-groonga}/lib
-    export MECAB_INCLUDE_PATH=${mecab}/include
-    export MECAB_LIB_PATH=${mecab}/lib
-  '';
 
-  buildPhase = ''
-    runHook preBuild
-    make $makeFlags
-    runHook postBuild
+  preConfigure = ''
+    export GROONGA_LIBS="-L${supabase-groonga}/lib -lgroonga"
+    export GROONGA_CFLAGS="-I${supabase-groonga}/include"
+    export MECAB_CONFIG="${mecab}/bin/mecab-config"
   '';
 
   installPhase = ''
-    runHook preInstall
-    make $makeFlags install DESTDIR=$out
+    mkdir -p $out/lib $out/share/postgresql/extension $out/bin
     install -D pgroonga${postgresql.dlSuffix} -t $out/lib/
     install -D pgroonga.control -t $out/share/postgresql/extension
     install -D data/pgroonga-*.sql -t $out/share/postgresql/extension
     install -D pgroonga_database${postgresql.dlSuffix} -t $out/lib/
     install -D pgroonga_database.control -t $out/share/postgresql/extension
     install -D data/pgroonga_database-*.sql -t $out/share/postgresql/extension
-    
-    for component in pgroonga_check pgroonga_wal_applier pgroonga_crash_safer pgroonga_standby_maintainer; do
-      if [ -f "$component${postgresql.dlSuffix}" ]; then
-        install -D "$component${postgresql.dlSuffix}" -t $out/lib/
-      fi
-    done
-    runHook postInstall
+
+    cat << EOF > $out/share/postgresql/extension/pgroonga_set_paths.sql
+    DO \$\$
+    BEGIN
+      SET pgroonga.log_path TO current_setting('data_directory') || '/groonga.log';
+      PERFORM pgroonga_command('plugin_register ${supabase-groonga}/lib/groonga/plugins/tokenizers/mecab.so');
+    END \$\$;
+EOF
+    chmod +x $out/share/postgresql/extension/pgroonga_set_paths.sql
+
+    makeWrapper ${postgresql}/bin/postgres $out/bin/pgroonga-postgres \
+      --set LD_LIBRARY_PATH "${lib.makeLibraryPath buildInputs}:${supabase-groonga}/lib:$out/lib"
+
+    echo "Debug: Groonga plugins directory contents:"
+    ls -l ${supabase-groonga}/lib/groonga/plugins/tokenizers/
   '';
 
   postFixup = ''
     for f in $out/lib/*.so; do
-      patchelf --set-rpath "${lib.makeLibraryPath buildInputs}:$out/lib" $f
+      patchelf --set-rpath "${lib.makeLibraryPath buildInputs}:${supabase-groonga}/lib:$out/lib:${supabase-groonga}/lib/groonga/plugins/tokenizers" $f
     done
   '';
 

--- a/nix/ext/pgroonga.nix
+++ b/nix/ext/pgroonga.nix
@@ -60,12 +60,6 @@ EOF
     ls -l ${supabase-groonga}/lib/groonga/plugins/tokenizers/
   '';
 
-  postFixup = ''
-    for f in $out/lib/*.so; do
-      patchelf --set-rpath "${lib.makeLibraryPath buildInputs}:${supabase-groonga}/lib:$out/lib:${supabase-groonga}/lib/groonga/plugins/tokenizers" $f
-    done
-  '';
-
   meta = with lib; {
     description = "A PostgreSQL extension to use Groonga as the index";
     longDescription = ''

--- a/nix/ext/pgroonga.nix
+++ b/nix/ext/pgroonga.nix
@@ -1,54 +1,284 @@
-{ lib, stdenv, fetchurl, pkg-config, postgresql, msgpack-c, mecab, callPackage}:
-let 
+# { lib, stdenv, fetchurl, pkg-config, postgresql, msgpack-c, mecab, callPackage
+# , patchelf }:
+# let
+#   supabase-groonga = callPackage ../supabase-groonga.nix { };
+#   mecab-naist-jdic = callPackage ./mecab-naist-jdic { };
+# in stdenv.mkDerivation rec {
+#   pname = "pgroonga";
+#   version = "3.0.7";
+#   src = fetchurl {
+#     url =
+#       "https://packages.groonga.org/source/${pname}/${pname}-${version}.tar.gz";
+#     sha256 = "sha256-iF/zh4zDDpAw5fxW1WG8i2bfPt4VYsnYArwOoE/lwgM=";
+#   };
+#   nativeBuildInputs = [ pkg-config patchelf ];
+#   buildInputs =
+#     [ postgresql msgpack-c supabase-groonga mecab mecab-naist-jdic ];
+
+#   configureFlags = [
+#     "--with-mecab=${mecab}"
+#     "--enable-mecab"
+#     "--enable-groonga-tokenizer-mecab"
+#     "--with-mecab-dict=${mecab-naist-jdic}/lib/mecab/dic/naist-jdic"
+#     "--with-groonga=${supabase-groonga}"
+#     "--with-groonga-token-mecab-dir=${supabase-groonga}/lib/groonga/plugins/tokenizers"
+#     "--with-groonga-tokenizer-mecab=${supabase-groonga}/lib/groonga/plugins/tokenizers/mecab.so"
+#     "--with-groonga-plugin-dir=${supabase-groonga}/lib/groonga/plugins"
+#     "--with-pgconfigdir=${postgresql}/bin"
+#     "--with-mecab-config=${mecab}/bin/mecab-config"
+#   ];
+
+#   makeFlags =
+#     [ "HAVE_MSGPACK=1" "MSGPACK_PACKAGE_NAME=msgpack-c" "HAVE_MECAB=1" ];
+
+#   buildPhase = ''
+#     runHook preBuild
+#     make
+#     echo "Checking for MeCab-related files:"
+#     find . -name "*mecab*"
+#     runHook postBuild
+#   '';
+
+#   installPhase = ''
+#     runHook preInstall
+
+#     install -D pgroonga${postgresql.dlSuffix} -t $out/lib/
+#     install -D pgroonga.control -t $out/share/postgresql/extension/
+#     install -D data/pgroonga-*.sql -t $out/share/postgresql/extension/
+#     install -D pgroonga_database${postgresql.dlSuffix} -t $out/lib/
+#     install -D pgroonga_database.control -t $out/share/postgresql/extension/
+#     install -D data/pgroonga_database-*.sql -t $out/share/postgresql/extension/
+
+#     # Ensure MeCab tokenizer is available
+#     if [ -f ${supabase-groonga}/lib/groonga/plugins/tokenizers/mecab.so ]; then
+#       mkdir -p $out/lib/postgresql/plugins/
+#       cp ${supabase-groonga}/lib/groonga/plugins/tokenizers/mecab.so $out/lib/postgresql/plugins/
+#     else
+#       echo "MeCab tokenizer plugin not found in Groonga installation"
+#       exit 1
+#     fi
+
+#     runHook postInstall
+#   '';
+
+#   postInstall = ''
+#     echo "Checking installed files:"
+#     find $out -type f
+
+#     echo "Checking for MeCab-related files in the output:"
+#     find $out -name "*mecab*"
+#   '';
+
+#   postFixup = ''
+#     patchelf --set-rpath "${
+#       lib.makeLibraryPath [
+#         mecab
+#         mecab-naist-jdic
+#         supabase-groonga
+#         postgresql
+#         stdenv.cc.cc.lib
+#         msgpack-c
+#       ]
+#     }" $out/lib/pgroonga${postgresql.dlSuffix}
+#     patchelf --set-rpath "${
+#       lib.makeLibraryPath [
+#         mecab
+#         mecab-naist-jdic
+#         supabase-groonga
+#         postgresql
+#         stdenv.cc.cc.lib
+#         msgpack-c
+#       ]
+#     }" $out/lib/pgroonga_database${postgresql.dlSuffix}
+#   '';
+
+#   meta = with lib; {
+#     description = "A PostgreSQL extension to use Groonga as the index";
+#     longDescription = ''
+#       PGroonga is a PostgreSQL extension to use Groonga as the index.
+#       PostgreSQL supports full text search against languages that use only alphabet and digit.
+#       It means that PostgreSQL doesn't support full text search against Japanese, Chinese and so on.
+#       You can use super fast full text search feature against all languages by installing PGroonga into your PostgreSQL.
+#     '';
+#     homepage = "https://pgroonga.github.io/";
+#     changelog = "https://github.com/pgroonga/pgroonga/releases/tag/${version}";
+#     license = licenses.postgresql;
+#     platforms = postgresql.meta.platforms;
+#     maintainers = with maintainers; [ samrose ];
+#   };
+# }
+
+# { lib, stdenv, fetchurl, pkg-config, postgresql, cmake, msgpack-c, mecab, callPackage }:
+# let
+#   supabase-groonga = callPackage ../supabase-groonga.nix { };
+#   mecab-naist-jdic = callPackage ./mecab-naist-jdic { };
+# in
+# stdenv.mkDerivation rec {
+#   pname = "pgroonga";
+#   version = "3.0.7";
+
+#   src = fetchurl {
+#     url = "https://packages.groonga.org/source/${pname}/${pname}-${version}.tar.gz";
+#     sha256 = "sha256-iF/zh4zDDpAw5fxW1WG8i2bfPt4VYsnYArwOoE/lwgM=";
+#   };
+
+#   nativeBuildInputs = [ cmake pkg-config ];
+#   buildInputs = [ postgresql msgpack-c supabase-groonga mecab mecab-naist-jdic ];
+
+#   makeFlags = [
+#     "HAVE_MSGPACK=1"
+#     "MSGPACK_PACKAGE_NAME=msgpack-c"
+#   ];
+
+#   installPhase = ''
+#     install -D pgroonga${postgresql.dlSuffix} -t $out/lib/
+#     install -D pgroonga.control -t $out/share/postgresql/extension
+#     install -D data/pgroonga-*.sql -t $out/share/postgresql/extension
+
+#     install -D pgroonga_database${postgresql.dlSuffix} -t $out/lib/
+#     install -D pgroonga_database.control -t $out/share/postgresql/extension
+#     install -D data/pgroonga_database-*.sql -t $out/share/postgresql/extension
+#   '';
+
+#   meta = with lib; {
+#     description = "A PostgreSQL extension to use Groonga as the index";
+#     longDescription = ''
+#       PGroonga is a PostgreSQL extension to use Groonga as the index.
+#       PostgreSQL supports full text search against languages that use only alphabet and digit.
+#       It means that PostgreSQL doesn't support full text search against Japanese, Chinese and so on.
+#       You can use super fast full text search feature against all languages by installing PGroonga into your PostgreSQL.
+#     '';
+#     homepage = "https://pgroonga.github.io/";
+#     changelog = "https://github.com/pgroonga/pgroonga/releases/tag/${version}";
+#     license = licenses.postgresql;
+#     platforms = postgresql.meta.platforms;
+#     maintainers = with maintainers; [ samrose ];
+#   };
+# }
+
+# { lib, stdenv, fetchurl, pkg-config, postgresql, msgpack-c, callPackage, cmake, mecab }:
+# let
+#   supabase-groonga = callPackage ../supabase-groonga.nix { };
+#   mecab-naist-jdic = callPackage ./mecab-naist-jdic { };
+# in
+# stdenv.mkDerivation rec {
+#   pname = "pgroonga";
+#   version = "3.0.7";
+#   src = fetchurl {
+#     url = "https://packages.groonga.org/source/${pname}/${pname}-${version}.tar.gz";
+#     sha256 = "sha256-iF/zh4zDDpAw5fxW1WG8i2bfPt4VYsnYArwOoE/lwgM=";
+#   };
+#   patches = [ ./use-system-groonga.patch ];
+#   nativeBuildInputs = [ pkg-config cmake ];
+#   buildInputs = [ postgresql msgpack-c supabase-groonga mecab mecab-naist-jdic ];
+#   cmakeFlags = [
+#     "-DCMAKE_PREFIX_PATH=${supabase-groonga}"
+#     "-DMECAB_CONFIG=${mecab}/bin/mecab-config"
+#     "-DMECAB_DICT_INDEX=${mecab}/libexec/mecab/mecab-dict-index"
+#     "-DMECAB_DIC_DIR=${mecab-naist-jdic}/lib/mecab/dic/naist-jdic"
+#     "-DCMAKE_BUILD_TYPE=Release"
+#     "-DBUILD_TESTING=OFF"
+#   ];
+#   preConfigure = ''
+#     export CFLAGS="-I${supabase-groonga}/include -I${postgresql}/include/server -I${supabase-groonga}/include/groonga"
+#     export CPPFLAGS="$CFLAGS"
+#     export LDFLAGS="-L${supabase-groonga}/lib -L${postgresql}/lib"
+
+#     # Remove the problematic /EHsc flag
+#     export CFLAGS="$(echo $CFLAGS | sed 's/-EHsc//g')"
+#     export CXXFLAGS="$(echo $CXXFLAGS | sed 's/-EHsc//g')"
+
+#     # Ensure CMake doesn't add it back
+#     substituteInPlace CMakeLists.txt --replace "-EHsc" ""
+#   '';
+
+#   installPhase = ''
+#     install -D pgroonga${postgresql.dlSuffix} -t $out/lib/
+#     install -D pgroonga.control -t $out/share/postgresql/extension
+#     install -D data/pgroonga-*.sql -t $out/share/postgresql/extension
+#     install -D pgroonga_database${postgresql.dlSuffix} -t $out/lib/
+#     install -D pgroonga_database.control -t $out/share/postgresql/extension
+#     install -D data/pgroonga_database-*.sql -t $out/share/postgresql/extension
+#   '';
+#   meta = with lib; {
+#     description = "A PostgreSQL extension to use Groonga as the index";
+#     longDescription = ''
+#       PGroonga is a PostgreSQL extension to use Groonga as the index.
+#       PostgreSQL supports full text search against languages that use only alphabet and digit.
+#       It means that PostgreSQL doesn't support full text search against Japanese, Chinese and so on.
+#       You can use super fast full text search feature against all languages by installing PGroonga into your PostgreSQL.
+#     '';
+#     homepage = "https://pgroonga.github.io/";
+#     changelog = "https://github.com/pgroonga/pgroonga/releases/tag/${version}";
+#     license = licenses.postgresql;
+#     platforms = postgresql.meta.platforms;
+#     maintainers = with maintainers; [ samrose ];
+#   };
+# }
+
+{ lib, stdenv, fetchurl, pkg-config, postgresql, msgpack-c, callPackage
+, makeWrapper, mecab }:
+
+let
   supabase-groonga = callPackage ../supabase-groonga.nix { };
-in
-stdenv.mkDerivation rec {
+  mecab-naist-jdic = callPackage ./mecab-naist-jdic { };
+in stdenv.mkDerivation rec {
   pname = "pgroonga";
   version = "3.0.7";
-
   src = fetchurl {
-    url = "https://packages.groonga.org/source/${pname}/${pname}-${version}.tar.gz";
+    url =
+      "https://packages.groonga.org/source/${pname}/${pname}-${version}.tar.gz";
     sha256 = "sha256-iF/zh4zDDpAw5fxW1WG8i2bfPt4VYsnYArwOoE/lwgM=";
   };
-
-  nativeBuildInputs = [ pkg-config ];
-
-  buildInputs = [ postgresql msgpack-c supabase-groonga mecab ];
-
-  runtimeDependencies = [ mecab ];
-
-  preConfigure = ''
-    export MECAB_CONFIG=${mecab}/bin/mecab-config
-    export MECAB_DICDIR=${mecab}/lib/mecab/dic/ipadic
-    export GRN_PLUGINS_DIR=$out/lib/groonga/plugins
-    export GROONGA_TOKENIZER_MECAB_DIR=${supabase-groonga}/lib/groonga/plugins/tokenizers
-    export GROONGA_TOKENIZER_MECAB=$out/lib/groonga/plugins/tokenizer_mecab.so
-  '';
-
-  configureFlags = [
-    "--with-mecab=${mecab}"
-    "--enable-tokenizer-mecab"
-    "--with-groonga=${supabase-groonga}"
-    "--with-groonga-token-mecab-dir=${supabase-groonga}/lib/groonga/plugins/tokenizers"
-    "--with-groonga-tokenizer-mecab=${supabase-groonga}/lib/groonga/plugins/tokenizers/mecab.so"
-    "--with-groonga-plugin-dir=${supabase-groonga}/lib/groonga/plugins"
-  ];
-
+  nativeBuildInputs = [ pkg-config makeWrapper ];
+  buildInputs = [ postgresql msgpack-c supabase-groonga mecab mecab-naist-jdic ];
   makeFlags = [
+    "USE_PGXS=1"
     "HAVE_MSGPACK=1"
     "MSGPACK_PACKAGE_NAME=msgpack-c"
     "HAVE_MECAB=1"
+    "POSTGRES_INCLUDEDIR=${postgresql}/include"
+    "POSTGRES_LIBDIR=${postgresql.lib}/lib"
+    "PG_CONFIG=${postgresql}/bin/pg_config"
+    "MECAB_CONFIG=${mecab}/bin/mecab-config"
   ];
+  
+  preConfigure = ''
+    export MECAB_DICDIR=${mecab-naist-jdic}/lib/mecab/dic/naist-jdic
+    export GROONGA_INCLUDE_PATH=${supabase-groonga}/include
+    export GROONGA_LIB_PATH=${supabase-groonga}/lib
+    export MECAB_INCLUDE_PATH=${mecab}/include
+    export MECAB_LIB_PATH=${mecab}/lib
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    make $makeFlags
+    runHook postBuild
+  '';
 
   installPhase = ''
+    runHook preInstall
+    make $makeFlags install DESTDIR=$out
     install -D pgroonga${postgresql.dlSuffix} -t $out/lib/
     install -D pgroonga.control -t $out/share/postgresql/extension
     install -D data/pgroonga-*.sql -t $out/share/postgresql/extension
-
     install -D pgroonga_database${postgresql.dlSuffix} -t $out/lib/
     install -D pgroonga_database.control -t $out/share/postgresql/extension
     install -D data/pgroonga_database-*.sql -t $out/share/postgresql/extension
     
+    for component in pgroonga_check pgroonga_wal_applier pgroonga_crash_safer pgroonga_standby_maintainer; do
+      if [ -f "$component${postgresql.dlSuffix}" ]; then
+        install -D "$component${postgresql.dlSuffix}" -t $out/lib/
+      fi
+    done
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    for f in $out/lib/*.so; do
+      patchelf --set-rpath "${lib.makeLibraryPath buildInputs}:$out/lib" $f
+    done
   '';
 
   meta = with lib; {

--- a/nix/ext/pgroonga.nix
+++ b/nix/ext/pgroonga.nix
@@ -12,19 +12,25 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkg-config ];
+
   buildInputs = [ postgresql msgpack-c supabase-groonga mecab ];
+
+  runtimeDependencies = [ mecab ];
 
   preConfigure = ''
     export MECAB_CONFIG=${mecab}/bin/mecab-config
     export MECAB_DICDIR=${mecab}/lib/mecab/dic/ipadic
     export GRN_PLUGINS_DIR=$out/lib/groonga/plugins
     export GROONGA_TOKENIZER_MECAB_DIR=${supabase-groonga}/lib/groonga/plugins/tokenizers
+    export GROONGA_TOKENIZER_MECAB=$out/lib/groonga/plugins/tokenizer_mecab.so
   '';
 
   configureFlags = [
     "--with-mecab=${mecab}"
     "--enable-tokenizer-mecab"
-    "--with-groonga-tokenizer-mecab=$out/lib/groonga/plugins/tokenizer_mecab.so"
+    "--with-groonga=${supabase-groonga}"
+    "--with-groonga-token-mecab-dir=${supabase-groonga}/lib/groonga/plugins/tokenizers"
+    "--with-groonga-tokenizer-mecab=${supabase-groonga}/lib/groonga/plugins/tokenizers/mecab.so"
     "--with-groonga-plugin-dir=${supabase-groonga}/lib/groonga/plugins"
   ];
 
@@ -43,10 +49,6 @@ stdenv.mkDerivation rec {
     install -D pgroonga_database.control -t $out/share/postgresql/extension
     install -D data/pgroonga_database-*.sql -t $out/share/postgresql/extension
     
-    mkdir -p $out/lib/groonga/plugins
-  
-    # Create symbolic link for MeCab tokenizer
-    cp ${supabase-groonga}/lib/groonga/plugins/tokenizers/mecab.so $out/lib/groonga/plugins/tokenizer_mecab.so
   '';
 
   meta = with lib; {

--- a/nix/ext/use-system-groonga.patch
+++ b/nix/ext/use-system-groonga.patch
@@ -1,0 +1,21 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 33b34477..f4ffefe5 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -12,7 +12,6 @@ if(MSVC_VERSION LESS 1800)
+   message(FATAL_ERROR "PGroonga supports only MSVC 2013 or later")
+ endif()
+ 
+-add_subdirectory(vendor/groonga)
+ 
+ set(PGRN_POSTGRESQL_DIR "${CMAKE_INSTALL_PREFIX}"
+   CACHE PATH "PostgreSQL binary directory")
+@@ -52,8 +51,6 @@ string(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)" "\\3"
+ string(REGEX REPLACE ".*comment = '([^']+)'.*" "\\1"
+   PGRN_DESCRIPTION "${PGRN_CONTROL}")
+ 
+-file(READ "${CMAKE_CURRENT_SOURCE_DIR}/vendor/groonga/bundled_message_pack_version"
+-  PGRN_BUNDLED_MESSAGE_PACK_VERSION)
+ string(STRIP
+   "${PGRN_BUNDLED_MESSAGE_PACK_VERSION}"
+   PGRN_BUNDLED_MESSAGE_PACK_VERSION)

--- a/nix/fix-cmake-install-path.patch
+++ b/nix/fix-cmake-install-path.patch
@@ -1,0 +1,21 @@
+Fix CMake install path
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1141,11 +1141,11 @@
+ 
+ set(prefix "${CMAKE_INSTALL_PREFIX}")
+ set(exec_prefix "\${prefix}")
+-set(bindir "\${exec_prefix}/${CMAKE_INSTALL_BINDIR}")
+-set(sbindir "\${exec_prefix}/${CMAKE_INSTALL_SBINDIR}")
+-set(libdir "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
+-set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+-set(datarootdir "\${prefix}/${CMAKE_INSTALL_DATAROOTDIR}")
++set(bindir "${CMAKE_INSTALL_FULL_BINDIR}")
++set(sbindir "${CMAKE_INSTALL_FULL_SBINDIR}")
++set(libdir "${CMAKE_INSTALL_FULL_LIBDIR}")
++set(includedir "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
++set(datarootdir "${CMAKE_INSTALL_FULL_DATAROOTDIR}")
+ set(datadir "\${datarootdir}")
+ set(expanded_pluginsdir "${GRN_PLUGINS_DIR}")
+ set(GRN_EXPANDED_DEFAULT_DOCUMENT_ROOT "${GRN_DEFAULT_DOCUMENT_ROOT}")

--- a/nix/supabase-groonga.nix
+++ b/nix/supabase-groonga.nix
@@ -51,18 +51,7 @@ in stdenv.mkDerivation (finalAttrs: {
   '';
   env.NIX_CFLAGS_COMPILE =
     lib.optionalString zlibSupport "-I${zlib.dev}/include";
-  # passthru = {
-  #   tests = {
-  #     inherit (postgresqlPackages) pgroonga;
-  #     version = testers.testVersion {
-  #       package = finalAttrs.finalPackage;
-  #     };
-  #     pkg-config = testers.hasPkgConfigModules {
-  #       package = finalAttrs.finalPackage;
-  #       moduleNames = [ "supabase-groonga" ];
-  #     };
-  #   };
-  # };
+
   meta = with lib; {
     homepage = "https://groonga.org/";
     description = "Open-source fulltext search engine and column store";

--- a/nix/supabase-groonga.nix
+++ b/nix/supabase-groonga.nix
@@ -37,6 +37,15 @@ in stdenv.mkDerivation (finalAttrs: {
     echo "CMake cache contents related to MeCab:"
     grep -i mecab CMakeCache.txt
   '';
+
+  # installPhase = ''
+  #   mkdir -p $out/bin $out/lib/groonga/plugins
+  #   cp -r lib/groonga/plugins/* $out/lib/groonga/plugins
+  #   cp -r bin/* $out/bin
+  #   echo "Installed Groonga plugins:"
+  #   ls -l $out/lib/groonga/plugins
+  # '';
+
   postInstall = ''
     echo "Searching for MeCab-related files:"
     find $out -name "*mecab*"

--- a/nix/supabase-groonga.nix
+++ b/nix/supabase-groonga.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   preConfigure = ''
     export MECAB_DICDIR=${mecab}/lib/mecab/dic/ipadic
-    echo "MeCab dictionary directory: $MECAB_DICDIR"
+    echo "MeCab dictionary directory is: $MECAB_DICDIR"
   '';
   buildPhase = ''
     cmake --build . -- VERBOSE=1
@@ -68,23 +68,23 @@ stdenv.mkDerivation (finalAttrs: {
     
   '';
   env.NIX_CFLAGS_COMPILE = lib.optionalString zlibSupport "-I${zlib.dev}/include";
-  passthru = {
-    tests = {
-      inherit (postgresqlPackages) pgroonga;
-      version = testers.testVersion {
-        package = finalAttrs.finalPackage;
-      };
-      pkg-config = testers.hasPkgConfigModules {
-        package = finalAttrs.finalPackage;
-        moduleNames = [ "groonga" ];
-      };
-    };
-  };
+  # passthru = {
+  #   tests = {
+  #     inherit (postgresqlPackages) pgroonga;
+  #     version = testers.testVersion {
+  #       package = finalAttrs.finalPackage;
+  #     };
+  #     pkg-config = testers.hasPkgConfigModules {
+  #       package = finalAttrs.finalPackage;
+  #       moduleNames = [ "supabase-groonga" ];
+  #     };
+  #   };
+  # };
   meta = with lib; {
     homepage = "https://groonga.org/";
     description = "Open-source fulltext search engine and column store";
     license = licenses.lgpl21;
-    maintainers = [ maintainers.ericsagnes ];
+    maintainers = [ maintainers.samrose ];
     platforms = platforms.all;
     longDescription = ''
       Groonga is an open-source fulltext search engine and column store.

--- a/nix/supabase-groonga.nix
+++ b/nix/supabase-groonga.nix
@@ -1,0 +1,94 @@
+{ lib, stdenv, cmake, fetchurl, kytea, msgpack-c, mecab, pkg-config, rapidjson, testers, xxHash, zstd, postgresqlPackages, makeWrapper
+, suggestSupport ? false, zeromq, libevent, openssl
+, lz4Support  ? false, lz4
+, zlibSupport ? true, zlib
+, writeShellScriptBin
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "supabase-groonga";
+  version = "14.0.5";
+  src = fetchurl {
+    url = "https://packages.groonga.org/source/groonga/groonga-${finalAttrs.version}.tar.gz";
+    hash = "sha256-y4UGnv8kK0z+br8wXpPf57NMXkdEJHcLCuTvYiubnIc=";
+  };
+  patches = [
+    ./fix-cmake-install-path.patch
+    ./do-not-use-vendored-libraries.patch
+  ];
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    makeWrapper
+  ];
+  buildInputs = [
+    rapidjson
+    xxHash
+    zstd
+    mecab
+    kytea
+    msgpack-c
+  ] ++ lib.optionals lz4Support [
+    lz4
+  ] ++ lib.optional zlibSupport [
+    zlib
+  ] ++ lib.optionals suggestSupport [
+    zeromq
+    libevent
+  ];
+  cmakeFlags = [
+    "-DWITH_MECAB=ON"
+    "-DMECAB_DICDIR=${mecab}/lib/mecab/dic/ipadic"
+    "-DMECAB_CONFIG=${mecab}/bin/mecab-config"
+    "-DENABLE_MECAB_TOKENIZER=ON"
+    "-DMECAB_INCLUDE_DIR=${mecab}/include"
+    "-DMECAB_LIBRARY=${mecab}/lib/libmecab.so"
+    "-DGROONGA_ENABLE_TOKENIZER_MECAB=YES"
+    "-DGRN_WITH_MECAB=YES"
+  ];
+  preConfigure = ''
+    export MECAB_DICDIR=${mecab}/lib/mecab/dic/ipadic
+    echo "MeCab dictionary directory: $MECAB_DICDIR"
+  '';
+  buildPhase = ''
+    cmake --build . -- VERBOSE=1
+    grep -i mecab CMakeCache.txt || (echo "MeCab not detected in CMake cache" && exit 1)
+    echo "CMake cache contents related to MeCab:"
+    grep -i mecab CMakeCache.txt
+  '';
+  postInstall = ''
+    echo "Searching for MeCab-related files:"
+    find $out -name "*mecab*"
+    
+    echo "Checking Groonga plugins directory:"
+    ls -l $out/lib/groonga/plugins
+    
+    echo "Wrapping Groonga binary:"
+    wrapProgram $out/bin/groonga \
+      --set GRN_PLUGINS_DIR $out/lib/groonga/plugins 
+    
+  '';
+  env.NIX_CFLAGS_COMPILE = lib.optionalString zlibSupport "-I${zlib.dev}/include";
+  passthru = {
+    tests = {
+      inherit (postgresqlPackages) pgroonga;
+      version = testers.testVersion {
+        package = finalAttrs.finalPackage;
+      };
+      pkg-config = testers.hasPkgConfigModules {
+        package = finalAttrs.finalPackage;
+        moduleNames = [ "groonga" ];
+      };
+    };
+  };
+  meta = with lib; {
+    homepage = "https://groonga.org/";
+    description = "Open-source fulltext search engine and column store";
+    license = licenses.lgpl21;
+    maintainers = [ maintainers.ericsagnes ];
+    platforms = platforms.all;
+    longDescription = ''
+      Groonga is an open-source fulltext search engine and column store.
+      It lets you write high-performance applications that requires fulltext search.
+    '';
+  };
+})

--- a/nix/tests/expected/pgroonga.out
+++ b/nix/tests/expected/pgroonga.out
@@ -1,0 +1,76 @@
+create schema v;
+create table v.roon(
+  id serial primary key,
+  content text
+);
+with tokenizers as (
+  select
+    x
+  from
+    jsonb_array_elements(
+      (select pgroonga_command('tokenizer_list'))::jsonb
+    ) x(val)
+  limit
+    1
+  offset
+    1 -- first record is unrelated and not stable
+)
+select
+  t.x::jsonb ->> 'name'
+from
+  jsonb_array_elements((select * from tokenizers)) t(x)
+order by
+  t.x::jsonb ->> 'name';
+                  ?column?                   
+---------------------------------------------
+ TokenBigram
+ TokenBigramIgnoreBlank
+ TokenBigramIgnoreBlankSplitSymbol
+ TokenBigramIgnoreBlankSplitSymbolAlpha
+ TokenBigramIgnoreBlankSplitSymbolAlphaDigit
+ TokenBigramSplitSymbol
+ TokenBigramSplitSymbolAlpha
+ TokenBigramSplitSymbolAlphaDigit
+ TokenDelimit
+ TokenDelimitNull
+ TokenDocumentVectorBM25
+ TokenDocumentVectorTFIDF
+ TokenMecab
+ TokenNgram
+ TokenPattern
+ TokenRegexp
+ TokenTable
+ TokenTrigram
+ TokenUnigram
+(19 rows)
+
+insert into v.roon (content)
+values
+  ('Hello World'),
+  ('PostgreSQL with PGroonga is a thing'),
+  ('This is a full-text search test'),
+  ('PGroonga supports various languages');
+-- Create default index
+create index pgroonga_index on v.roon using pgroonga (content);
+-- Create mecab tokenizer index since we had a bug with this one once
+create index pgroonga_index_mecab on v.roon using pgroonga (content) with (tokenizer='TokenMecab');
+-- Run some queries to test the index
+select * from v.roon where content &@~ 'Hello';
+ id |   content   
+----+-------------
+  1 | Hello World
+(1 row)
+
+select * from v.roon where content &@~ 'powerful';
+ id | content 
+----+---------
+(0 rows)
+
+select * from v.roon where content &@~ 'supports';
+ id |               content               
+----+-------------------------------------
+  4 | PGroonga supports various languages
+(1 row)
+
+drop schema v cascade;
+NOTICE:  drop cascades to table v.roon

--- a/nix/tests/smoke/0005-test_pgroonga_mecab.sql
+++ b/nix/tests/smoke/0005-test_pgroonga_mecab.sql
@@ -1,0 +1,36 @@
+-- File: 0005-test_pgroonga_revised.sql
+
+begin;
+    -- Plan for 3 tests: extension, table, and index
+    select plan(3);
+    
+    -- Create the PGroonga extension
+    create extension if not exists pgroonga;
+    
+    -- -- Test 1: Check if PGroonga extension exists
+    select has_extension('pgroonga', 'The pgroonga extension should exist.');
+    
+    -- Create the table
+    create table notes(
+        id integer primary key,
+        content text
+    );
+    
+    -- Test 2: Check if the table was created
+    SELECT has_table('public', 'notes', 'The notes table should exist.');    
+    -- Create the PGroonga index
+    CREATE INDEX pgroonga_content_index
+            ON notes
+         USING pgroonga (content)
+          WITH (tokenizer='TokenMecab');
+    
+    -- -- Test 3: Check if the index was created
+    SELECT has_index('public', 'notes', 'pgroonga_content_index', 'The pgroonga_content_index should exist.');
+    
+    -- -- Cleanup (this won't affect the test results as they've already been checked)
+    DROP INDEX IF EXISTS pgroonga_content_index;
+    DROP TABLE IF EXISTS notes;
+    
+    -- Finish the test plan
+    select * from finish();
+rollback;

--- a/nix/tests/sql/pgroonga.sql
+++ b/nix/tests/sql/pgroonga.sql
@@ -1,0 +1,48 @@
+create schema v;
+
+create table v.roon(
+  id serial primary key,
+  content text
+);
+
+
+with tokenizers as (
+  select
+    x
+  from
+    jsonb_array_elements(
+      (select pgroonga_command('tokenizer_list'))::jsonb
+    ) x(val)
+  limit
+    1
+  offset
+    1 -- first record is unrelated and not stable
+)
+select
+  t.x::jsonb ->> 'name'
+from
+  jsonb_array_elements((select * from tokenizers)) t(x)
+order by
+  t.x::jsonb ->> 'name';
+
+
+insert into v.roon (content)
+values
+  ('Hello World'),
+  ('PostgreSQL with PGroonga is a thing'),
+  ('This is a full-text search test'),
+  ('PGroonga supports various languages');
+
+-- Create default index
+create index pgroonga_index on v.roon using pgroonga (content);
+
+-- Create mecab tokenizer index since we had a bug with this one once
+create index pgroonga_index_mecab on v.roon using pgroonga (content) with (tokenizer='TokenMecab');
+
+-- Run some queries to test the index
+select * from v.roon where content &@~ 'Hello';
+select * from v.roon where content &@~ 'powerful';
+select * from v.roon where content &@~ 'supports';
+
+
+drop schema v cascade;

--- a/nix/tools/run-server.sh.in
+++ b/nix/tools/run-server.sh.in
@@ -29,6 +29,7 @@ READREPL_CONFIG_FILE=@READREPL_CONF_FILE@
 PG_HBA_FILE=@PG_HBA@
 PG_IDENT_FILE=@PG_IDENT@
 EXTENSION_CUSTOM_SCRIPTS=@EXTENSION_CUSTOM_SCRIPTS_DIR@
+GROONGA=@GROONGA_DIR@
 DATDIR=$(mktemp -d)
 LOCALE_ARCHIVE=@LOCALES@
 export LOCALE_ARCHIVE
@@ -60,4 +61,5 @@ pgsodium.getkey_script = '$PGSODIUM_GETKEY_SCRIPT'" \
 -e "\$a\\
 session_preload_libraries = 'supautils'" \
 "$PSQL_CONF_FILE" > "$DATDIR/postgresql.conf"
+export GRN_PLUGINS_DIR=$GROONGA/lib/groonga/plugins
 postgres --config-file="$DATDIR/postgresql.conf" -p "$PORTNO" -D "$DATDIR" -k /tmp


### PR DESCRIPTION
## What kind of change does this PR introduce?

a comment on a PR https://github.com/supabase/postgres/pull/462#issuecomment-2270662752 reported that in our 15.6 release, `TokenMecab` was no longer working on the `pgroonga` extension.

This PR restores that Tokenizer capability to the proonga extension, and adds the following test below, which will run on every PR going forward. 


```sql
-- File: 0005-test_pgroonga_revised.sql

begin;
    -- Plan for 3 tests: extension, table, and index
    select plan(3);
    
    -- Create the PGroonga extension
    create extension if not exists pgroonga;
    
    -- -- Test 1: Check if PGroonga extension exists
    select has_extension('pgroonga', 'The pgroonga extension should exist.');
    
    -- Create the table
    create table notes(
        id integer primary key,
        content text
    );
    
    -- Test 2: Check if the table was created
    SELECT has_table('public', 'notes', 'The notes table should exist.');    
    -- Create the PGroonga index
    CREATE INDEX pgroonga_content_index
            ON notes
         USING pgroonga (content)
          WITH (tokenizer='TokenMecab');
    
    -- -- Test 3: Check if the index was created
    SELECT has_index('public', 'notes', 'pgroonga_content_index', 'The pgroonga_content_index should exist.');
    
    -- -- Cleanup (this won't affect the test results as they've already been checked)
    DROP INDEX IF EXISTS pgroonga_content_index;
    DROP TABLE IF EXISTS notes;
    
    -- Finish the test plan
    select * from finish();
rollback;
```