### PR TITLE
fix: write sql migration files for wrappers

### DIFF
--- a/.github/workflows/ami-release-nix.yml
+++ b/.github/workflows/ami-release-nix.yml
@@ -49,13 +49,13 @@ jobs:
         run: |
           packer init amazon-arm64-nix.pkr.hcl
           GIT_SHA=${{github.sha}}
-          packer build -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${GITHUB_RUN_ID}" -var-file="development-arm.vars.pkr.hcl" -var-file="common-nix.vars.pkr.hcl" -var "ansible_arguments="  amazon-arm64-nix.pkr.hcl
+          packer build -var "git_sha=${GIT_SHA}" -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${GITHUB_RUN_ID}" -var-file="development-arm.vars.pkr.hcl" -var-file="common-nix.vars.pkr.hcl" -var "ansible_arguments="  amazon-arm64-nix.pkr.hcl
 
       - name: Build AMI stage 2
         run: |
           packer init stage2-nix-psql.pkr.hcl
           GIT_SHA=${{github.sha}}
-          packer build -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${GITHUB_RUN_ID}" -var-file="development-arm.vars.pkr.hcl" -var-file="common-nix.vars.pkr.hcl" stage2-nix-psql.pkr.hcl
+          packer build -var "git_sha=${GIT_SHA}" -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${GITHUB_RUN_ID}" -var-file="development-arm.vars.pkr.hcl" -var-file="common-nix.vars.pkr.hcl" stage2-nix-psql.pkr.hcl
 
       - name: Grab release version
         id: process_release_version

--- a/.github/workflows/ami-release-nix.yml
+++ b/.github/workflows/ami-release-nix.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           packer init amazon-arm64-nix.pkr.hcl
           GIT_SHA=${{github.sha}}
-          packer build -var "git_sha=${GIT_SHA}" -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${GITHUB_RUN_ID}" -var-file="development-arm.vars.pkr.hcl" -var-file="common-nix.vars.pkr.hcl" -var "ansible_arguments="  amazon-arm64-nix.pkr.hcl
+          packer build -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${GITHUB_RUN_ID}" -var-file="development-arm.vars.pkr.hcl" -var-file="common-nix.vars.pkr.hcl" -var "ansible_arguments="  amazon-arm64-nix.pkr.hcl
 
       - name: Build AMI stage 2
         run: |

--- a/common-nix.vars.pkr.hcl
+++ b/common-nix.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.6.1.111"
+postgres-version = "15.6.1.111-rc2"

--- a/common-nix.vars.pkr.hcl
+++ b/common-nix.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.6.1.110"
+postgres-version = "15.6.1.111-rc1"

--- a/common-nix.vars.pkr.hcl
+++ b/common-nix.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.6.1.111-rc1"
+postgres-version = "15.6.1.111"

--- a/common-nix.vars.pkr.hcl
+++ b/common-nix.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.6.1.111-rc2"
+postgres-version = "15.6.1.111-rc3"

--- a/common-nix.vars.pkr.hcl
+++ b/common-nix.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.6.1.111-rc3"
+postgres-version = "15.6.1.111"

--- a/nix/ext/wrappers/default.nix
+++ b/nix/ext/wrappers/default.nix
@@ -7,43 +7,41 @@
 , buildPgrxExtension_0_11_3
 , cargo
 , darwin
+, jq
 }:
 
+let
+  gitTags = builtins.fromJSON (builtins.readFile (builtins.fetchurl {
+    url = "https://api.github.com/repos/supabase/wrappers/tags";
+    sha256 = "0am40yspir70wp8pik1c7qmfvbby3nyxza115pi9klp6fyv2s93j"; # Replace with actual hash
+  }));
+in
 buildPgrxExtension_0_11_3 rec {
   pname = "supabase-wrappers";
   version = "0.4.1";
   inherit postgresql;
-
   src = fetchFromGitHub {
     owner = "supabase";
     repo = "wrappers";
     rev = "v${version}";
     hash = "sha256-AU9Y43qEMcIBVBThu+Aor1HCtfFIg+CdkzK9IxVdkzM=";
   };
-
-  nativeBuildInputs = [ pkg-config cargo ];
-
-  buildInputs = [ openssl ] ++ lib.optionals (stdenv.isDarwin)  [ 
+  nativeBuildInputs = [ pkg-config cargo jq ];
+  buildInputs = [ openssl ] ++ lib.optionals (stdenv.isDarwin) [ 
     darwin.apple_sdk.frameworks.CoreFoundation 
     darwin.apple_sdk.frameworks.Security 
     darwin.apple_sdk.frameworks.SystemConfiguration 
   ];
-
-  # Needed to get openssl-sys to use pkg-config.
   OPENSSL_NO_VENDOR = 1;
   
   CARGO="${cargo}/bin/cargo";
-
   cargoLock = {
-    #TODO when we move to newer versions this lockfile will need to be sourced
-    # from ${src}/Cargo.lock
     lockFile = "${src}/Cargo.lock";
     outputHashes = {
       "clickhouse-rs-1.0.0-alpha.1" = "sha256-0zmoUo/GLyCKDLkpBsnLAyGs1xz6cubJhn+eVqMEMaw=";
     };
   };
   postPatch = "cp ${cargoLock.lockFile} Cargo.lock";
-
   buildAndTestSubdir = "wrappers";
   buildFeatures = [
     "helloworld_fdw"
@@ -60,11 +58,32 @@ buildPgrxExtension_0_11_3 rec {
     "cognito_fdw"
     "wasm_fdw"
   ];
-
-  # FIXME (aseipp): disable the tests since they try to install .control
-  # files into the wrong spot, aside from that the one main test seems
-  # to work, though
   doCheck = false;
+
+  preBuild = ''
+    echo "Processing git tags..."
+    echo '${builtins.toJSON gitTags}' | ${jq}/bin/jq -r '.[].name' | sort -rV > git_tags.txt
+  '';
+
+  postInstall = ''
+    echo "Creating SQL files for previous versions..."
+    current_version="${version}"
+    sql_file="$out/share/postgresql/extension/wrappers--$current_version.sql"
+    
+    if [ -f "$sql_file" ]; then
+      while read -r tag; do
+        tag_version=$(echo "$tag" | sed 's/^v//')
+        if [ "$(printf '%s\n' "$tag_version" "$current_version" | sort -V | head -n1)" = "$tag_version" ] && [ "$tag_version" != "$current_version" ]; then
+          new_file="$out/share/postgresql/extension/wrappers--$tag_version--$current_version.sql"
+          echo "Creating $new_file"
+          cp "$sql_file" "$new_file"
+        fi
+      done < git_tags.txt
+    else
+      echo "Warning: $sql_file not found"
+    fi
+    rm git_tags.txt
+  '';
 
   meta = with lib; {
     description = "Various Foreign Data Wrappers (FDWs) for PostreSQL";


### PR DESCRIPTION

## What kind of change does this PR introduce?

we need to produce a series of migration files on pkg build, although they are all a copy of the latest

The goal is to emulate what happened in the release gh action for https://github.com/supabase/wrappers 


We need to fetch the release tags from github (in this case in a preBuild phase before we start building) write to file, and use the file to copy the latest wrappers--$current_version.sql to a wrappers--$prev_version-$current_version.sql and writing that into the nix store.

The outcome should be that all of those identical files end up at 

```
/nix/store/postressqlbundle-hash/share/postgresql/extension/

rwxrwxrwx  4 root root   100 Dec 31  1969 vector.control -> /nix/store/3zk1d03nrg9d01hpb7x5jdcs3w5d15yg-pgvector-0.7.4/share/postgresql/extension/vector.control
lrwxrwxrwx  4 root root    96 Dec 31  1969 vector.sql -> /nix/store/3zk1d03nrg9d01hpb7x5jdcs3w5d15yg-pgvector-0.7.4/share/postgresql/extension/vector.sql
lrwxrwxrwx  4 root root   121 Dec 31  1969 wrappers--0.1.0--0.4.1.sql -> /nix/store/px3wvdr1wjy642spm653x713zfydmqyn-supabase-wrappers-0.4.1/share/postgresql/extension/wrappers--0.1.0--0.4.1.sql
lrwxrwxrwx  4 root root   122 Dec 31  1969 wrappers--0.1.10--0.4.1.sql -> /nix/store/px3wvdr1wjy642spm653x713zfydmqyn-supabase-wrappers-0.4.1/share/postgresql/extension/wrappers--0.1.10--0.4.1.sql
lrwxrwxrwx  4 root root   121 Dec 31  1969 wrappers--0.1.1--0.4.1.sql -> /nix/store/px3wvdr1wjy642spm653x713zfydmqyn-supabase-wrappers-0.4.1/share/postgresql/extension/wrappers--0.1.1--0.4.1.sql
lrwxrwxrwx  4 root root   122 Dec 31  1969 wrappers--0.1.11--0.4.1.sql -> /nix/store/px3wvdr1wjy642spm653x713zfydmqyn-supabase-wrappers-0.4.1/share/postgresql/extension/wrappers--0.1.11--0.4.1.sql
lrwxrwxrwx  4 root root   122 Dec 31  1969 wrappers--0.1.12--0.4.1.sql -> /nix/store/px3wvdr1wjy642spm653x713zfydmqyn-supabase-wrappers-0.4.1/share/postgresql/extension/wrappers--0.1.12--0.4.1.sql
lrwxrwxrwx  4 root root   122 Dec 31  1969 wrappers--0.1.14--0.4.1.sql -> /nix/store/px3wvdr1wjy642spm653x713zfydmqyn-supabase-wrappers-0.4.1/share/postgresql/extension/wrappers--0.1.14--0.4.1.sql
lrwxrwxrwx  4 root root   122 Dec 31  1969 wrappers--0.1.15--0.4.1.sql -> /nix/store/px3wvdr1wjy642spm653x713zfydmqyn-supabase-wrappers-0.4.1/share/postgresql/extension/wrappers--0.1.15--0.4.1.sql
lrwxrwxrwx  4 root root   122 Dec 31  1969 wrappers--0.1.16--0.4.1.sql -> /nix/store/px3wvdr1wjy642spm653x713zfydmqyn-supabase-wrappers-0.4.1/share/postgresql/extension/wrappers--0.1.16--0.4.1.sql
lrwxrwxrwx  4 root root   122 Dec 31  1969 wrappers--0.1.17--0.4.1.sql -> /nix/store/px3wvdr1wjy642spm653x713zfydmqyn-supabase-wrappers-0.4.1/share/postgresql/extension/wrappers--0.1.17--0.4.1.sql
lrwxrwxrwx  4 root root   122 Dec 31  1969 wrappers--0.1.18--0.4.1.sql -> /nix/store/px3wvdr1wjy642spm653x713zfydmqyn-supabase-wrappers-0.4.1/share/postgresql/extension/wrappers--0.1.18--0.4.1.sql
lrwxrwxrwx  4 root root   122 Dec 31  1969 wrappers--0.1.19--0.4.1.sql -> /nix/store/px3wvdr1wjy642spm653x713zfydmqyn-supabase-wrappers-0.4.1/share/postgresql/extension/wrappers--0.1.19--0.4.1.sql
lrwxrwxrwx  4 root root   121 Dec 31  1969 wrappers--0.1.4--0.4.1.sql -> /nix/store/px3wvdr1wjy642spm653x713zfydmqyn-supabase-wrappers-0.4.1/share/postgresql/extension/wrappers--0.1.4--0.4.1.sql
lrwxrwxrwx  4 root root   121 Dec 31  1969 wrappers--0.1.5--0.4.1.sql -> /nix/store/px3wvdr1wjy642spm653x713zfydmqyn-supabase-wrappers-0.4.1/share/postgresql/extension/wrappers--0.1.5--0.4.1.sql
lrwxrwxrwx  4 root root   121 Dec 31  1969 wrappers--0.1.6--0.4.1.sql -> /nix/store/px3wvdr1wjy642spm653x713zfydmqyn-supabase-wrappers-0.4.1/share/postgresql/extension/wrappers--0.1.6--0.4.1.sql
lrwxrwxrwx  4 root root   121 Dec 31  1969 wrappers--0.1.7--0.4.1.sql -> /nix/store/px3wvdr1wjy642spm653x713zfydmqyn-supabase-wrappers-0.4.1/share/postgresql/extension/wrappers--0.1.7--0.4.1.sql
lrwxrwxrwx  4 root root   121 Dec 31  1969 wrappers--0.1.8--0.4.1.sql -> /nix/store/px3wvdr1wjy642spm653x713zfydmqyn-supabase-wrappers-0.4.1/share/postgresql/extension/wrappers--0.1.8--0.4.1.sql
lrwxrwxrwx  4 root root   121 Dec 31  1969 wrappers--0.1.9--0.4.1.sql -> /nix/store/px3wvdr1wjy642spm653x713zfydmqyn-supabase-wrappers-0.4.1/share/postgresql/extension/wrappers--0.1.9--0.4.1.sql
lrwxrwxrwx  4 root root   121 Dec 31  1969 wrappers--0.2.0--0.4.1.sql -> /nix/store/px3wvdr1wjy642spm653x713zfydmqyn-supabase-wrappers-0.4.1/share/postgresql/extension/wrappers--0.2.0--0.4.1.sql
lrwxrwxrwx  4 root root   121 Dec 31  1969 wrappers--0.3.0--0.4.1.sql -> /nix/store/px3wvdr1wjy642spm653x713zfydmqyn-supabase-wrappers-0.4.1/share/postgresql/extension/wrappers--0.3.0--0.4.1.sql
lrwxrwxrwx  4 root root   121 Dec 31  1969 wrappers--0.3.1--0.4.1.sql -> /nix/store/px3wvdr1wjy642spm653x713zfydmqyn-supabase-wrappers-0.4.1/share/postgresql/extension/wrappers--0.3.1--0.4.1.sql
lrwxrwxrwx  4 root root   121 Dec 31  1969 wrappers--0.4.0--0.4.1.sql -> /nix/store/px3wvdr1wjy642spm653x713zfydmqyn-supabase-wrappers-0.4.1/share/postgresql/extension/wrappers--0.4.0--0.4.1.sql
lrwxrwxrwx  4 root root   114 Dec 31  1969 wrappers--0.4.1.sql -> /nix/store/px3wvdr1wjy642spm653x713zfydmqyn-supabase-wrappers-0.4.1/share/postgresql/extension/wrappers--0.4.1.sql
lrwxrwxrwx  4 root root   111 Dec 31  1969 wrappers.control -> /nix/store/px3wvdr1wjy642spm653x713zfydmqyn-supabase-wrappers-0.4.1/share/postgresql/extension/wrappers.control
```

for example. This PR has tested and verified this is working 

