### PR TITLE
Sam/plv8 darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -417,15 +417,12 @@
               fi
             done
             createdb -p 5432 -h localhost testing
-            if ! psql -p 5432 -h localhost -d testing -v ON_ERROR_STOP=1 -Xaf ${./nix/tests/prime.sql} > $TMPDIR/psql_output.log 2>&1; then
-              echo "Error executing SQL file. Error output:"
-              cat $TMPDIR/psql_output.log
-              echo "PostgreSQL log content:"
+            if ! psql -p 5432 -h localhost -d testing -v ON_ERROR_STOP=1 -Xaf ${./nix/tests/prime.sql}; then
+              echo "Error executing SQL file. PostgreSQL log content:"
               cat $TMPDIR/logfile/postgresql.log
               pg_ctl -D "$PGDATA" stop
               exit 1
             fi
-
             pg_prove -p 5432 -h localhost -d testing ${sqlTests}/*.sql
 
             mkdir -p $out/regression_output

--- a/flake.nix
+++ b/flake.nix
@@ -417,7 +417,14 @@
               fi
             done
             createdb -p 5432 -h localhost testing
-            psql -p 5432 -h localhost -d testing -Xaf ${./nix/tests/prime.sql}
+            if ! psql -p 5432 -h localhost -d testing -v ON_ERROR_STOP=1 -Xaf ${./nix/tests/prime.sql} > $TMPDIR/psql_output.log 2>&1; then
+              echo "Error executing SQL file. Error output:"
+              cat $TMPDIR/psql_output.log
+              echo "PostgreSQL log content:"
+              cat $TMPDIR/logfile/postgresql.log
+              pg_ctl -D "$PGDATA" stop
+              exit 1
+            fi
 
             pg_prove -p 5432 -h localhost -d testing ${sqlTests}/*.sql
 

--- a/nix/tests/prime.sql
+++ b/nix/tests/prime.sql
@@ -68,8 +68,8 @@ ERROR:  could not load library "/nix/store/..../lib/plv8-3.1.5.so
 symbol not found in flat namespace
 */
 create extension plv8;
--- create extension plcoffee;
--- create extension plls;
+create extension plcoffee;
+create extension plls;
 
 create extension postgis;
 create extension postgis_raster;

--- a/nix/tests/prime.sql
+++ b/nix/tests/prime.sql
@@ -67,7 +67,7 @@ TODO: PLs can not be enabled on M1 Macs locally
 ERROR:  could not load library "/nix/store/..../lib/plv8-3.1.5.so
 symbol not found in flat namespace
 */
--- create extension plv8;
+create extension plv8;
 -- create extension plcoffee;
 -- create extension plls;
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

We had some issues with building and enabling these extensions on `aarch64-darwin`

```
plv8
plcoffee
plls
```

This PR creates a build for darwin and non darwin platforms. It has been tested and verified on `x86_64-linix` , `aarch64-linux` and `aarch64-darwin`

The `nix flake check -L ` test is confirmed to pass on all 3 platforms, and the `pg_regress` section of the `nix flake check` test has been updated to re-introduce the 3 above extensions and those are re-added back into the `prime.sql` file.

This PR closes #1094 