### PR TITLE
fix: sql migration files for pg_jsonschema

### DIFF
--- a/nix/ext/pg_jsonschema.nix
+++ b/nix/ext/pg_jsonschema.nix
@@ -14,6 +14,9 @@ buildPgrxExtension_0_11_3 rec {
 
   nativeBuildInputs = [ cargo ];
   buildInputs = [ postgresql ];
+  # update the following array when the pg_jsonschema version is updated
+  # required to ensure that extensions update scripts from previous versions are generated
+
   previousVersions = ["0.3.0" "0.2.0" "0.1.4" "0.1.4" "0.1.2" "0.1.1" "0.1.0"];
   CARGO="${cargo}/bin/cargo";
   env = lib.optionalAttrs stdenv.isDarwin {

--- a/nix/ext/pg_jsonschema.nix
+++ b/nix/ext/pg_jsonschema.nix
@@ -14,7 +14,7 @@ buildPgrxExtension_0_11_3 rec {
 
   nativeBuildInputs = [ cargo ];
   buildInputs = [ postgresql ];
-  
+  previousVersions = ["0.3.0" "0.2.0" "0.1.4" "0.1.4" "0.1.2" "0.1.1" "0.1.0"];
   CARGO="${cargo}/bin/cargo";
   env = lib.optionalAttrs stdenv.isDarwin {
     POSTGRES_LIB = "${postgresql}/lib";
@@ -25,6 +25,31 @@ buildPgrxExtension_0_11_3 rec {
   # FIXME (aseipp): testsuite tries to write files into /nix/store; we'll have
   # to fix this a bit later.
   doCheck = false;
+
+  preBuild = ''
+    echo "Processing git tags..."
+    echo '${builtins.concatStringsSep "," previousVersions}' | sed 's/,/\n/g' > git_tags.txt
+  '';
+
+  postInstall = ''
+    echo "Creating SQL files for previous versions..."
+    current_version="${version}"
+    sql_file="$out/share/postgresql/extension/pg_jsonschema--$current_version.sql"
+    
+    if [ -f "$sql_file" ]; then
+      while read -r previous_version; do
+        if [ "$(printf '%s\n' "$previous_version" "$current_version" | sort -V | head -n1)" = "$previous_version" ] && [ "$previous_version" != "$current_version" ]; then
+          new_file="$out/share/postgresql/extension/pg_jsonschema--$previous_version--$current_version.sql"
+          echo "Creating $new_file"
+          cp "$sql_file" "$new_file"
+        fi
+      done < git_tags.txt
+    else
+      echo "Warning: $sql_file not found"
+    fi
+    rm git_tags.txt
+  '';
+
 
   meta = with lib; {
     description = "JSON Schema Validation for PostgreSQL";


### PR DESCRIPTION
## What kind of change does this PR introduce?

The nix package needs to take on the responsibility of generating sql migration files so that updates will continue to work

