### PR TITLE
feat: add origin protection header

### DIFF
--- a/ansible/files/envoy_config/lds.yaml
+++ b/ansible/files/envoy_config/lds.yaml
@@ -37,6 +37,28 @@ resources:
                     rules:
                       action: DENY
                       policies:
+                        origin_protection_key_missing:
+                          permissions:
+                            - any: true
+                          principals:
+                            - not_id:
+                                or_ids:
+                                  ids:
+                                    - header:
+                                        name: x-sb-origin-protection-key
+                                        present_match: true
+                        origin_protection_key_not_valid:
+                          permissions:
+                            - any: true
+                          principals:
+                            - not_id:
+                                or_ids:
+                                  ids:
+                                    # when rolling over the key add a new entry here, deploy, then remove the old key and deploy again
+                                    - header:
+                                        name: x-sb-origin-protection-key
+                                        string_match:
+                                          exact: origin_protection_key
                         api_key_missing:
                           permissions:
                             - any: true
@@ -194,6 +216,7 @@ resources:
                               present_match: true
                         request_headers_to_remove:
                           - apikey
+                          - x-sb-origin-protection-key
                         route:
                           cluster: postgrest
                           prefix_rewrite: /
@@ -207,6 +230,7 @@ resources:
                           prefix: /rest/v1/
                         request_headers_to_remove:
                           - apikey
+                          - x-sb-origin-protection-key
                         route:
                           cluster: postgrest
                           prefix_rewrite: /
@@ -218,6 +242,7 @@ resources:
                               present_match: true
                         request_headers_to_remove:
                           - apikey
+                          - x-sb-origin-protection-key
                         route:
                           cluster: postgrest_admin
                           prefix_rewrite: /
@@ -230,11 +255,14 @@ resources:
                           prefix: /rest-admin/v1/
                         request_headers_to_remove:
                           - apikey
+                          - x-sb-origin-protection-key
                         route:
                           cluster: postgrest_admin
                           prefix_rewrite: /
                       - match:
                           path: /graphql/v1
+                        request_headers_to_remove:
+                          - x-sb-origin-protection-key
                         request_headers_to_add:
                           header:
                             key: Content-Profile
@@ -254,6 +282,8 @@ resources:
                         route:
                           cluster: admin_api
                           prefix_rewrite: /privileged/
+                        request_headers_to_remove:
+                          - x-sb-origin-protection-key
                         typed_per_filter_config:
                           envoy.filters.http.rbac:
                             '@type': >-
@@ -277,6 +307,8 @@ resources:
                         route:
                           cluster: admin_api
                           prefix_rewrite: /supabase-internal/metrics
+                        request_headers_to_remove:
+                          - x-sb-origin-protection-key
                         typed_per_filter_config:
                           envoy.filters.http.rbac:
                             '@type': >-

--- a/ansible/files/envoy_config/remove_apikey_query_parameter.lua
+++ b/ansible/files/envoy_config/remove_apikey_query_parameter.lua
@@ -5,4 +5,9 @@ function envoy_on_request(request_handle)
   request_handle
     :headers()
     :replace(":path", path:gsub("([&?])apikey=[^&]+&?", "%1"):gsub("&$", ""))
+
+  -- Removes the x-sb-origin-protection-key as it can be inspected via PostgREST pre-request hook, etc.
+  request_handle
+    :headers()
+    :replace("x-sb-origin-protection-key", "")
 end

--- a/docker/all-in-one/init/configure-envoy.sh
+++ b/docker/all-in-one/init/configure-envoy.sh
@@ -42,6 +42,7 @@ sed -i -e "s|anon_key|${ANON_KEY}|g" \
   -e "s|service_key|${SERVICE_ROLE_KEY}|g" \
   -e "s|supabase_admin_key|${ADMIN_API_KEY}|g" \
   -e "s|c2VydmljZV9yb2xlOnNlcnZpY2Vfa2V5|$(echo -n "service_role:${SERVICE_ROLE_KEY}" | base64 --wrap 0)|g" \
+  -e "s|origin_protection_key|${ORIGIN_PROTECTION_KEY}|g" \
   "${ENVOY_LDS_CONF}"
 
 # Update Envoy ports


### PR DESCRIPTION
Adds new Envoy config for authorizing requests with the `x-sb-origin-protection-key` header. Requests with a missing or invalid value will be rejected, and the value is stripped before being passed on to the downstream listeners to prevent it from being revealed in PostgREST pre-request functions.