### PR TITLE
chore: introduce a darwin builder just for the nix build

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -66,7 +66,7 @@ jobs:
         if: matrix.runner == 'macos-latest'
         run: |
           # Replace this with your actual build script
-          cp ./workspace/docker/nix/build_nix.sh ./build_nix.sh
+          cp ./docker/nix/build_nix.sh ./build_nix.sh
           sed -i 's/cd workspace//g' ./build_nix.sh
           ./build_nix.sh
         env:

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -22,6 +22,8 @@ jobs:
             arch: amd64
           - runner: arm-runner
             arch: arm64
+          - runner: macos-latest
+            arch: arm64
     runs-on: ${{ matrix.runner }}
 
     steps:
@@ -45,17 +47,32 @@ jobs:
         env:
           NIX_SIGN_SECRET_KEY: ${{ secrets.NIX_SIGN_SECRET_KEY }}
       - name: Log in to Docker Hub
+        if: matrix.runner != 'macos-latest'
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build psql bundle with nix
+        if: matrix.runner != 'macos-latest'
         run: docker build -t base_nix -f docker/nix/Dockerfile .
       - name: Run build psql bundle
+        if: matrix.runner != 'macos-latest'
         run:  |
           docker run -e AWS_ACCESS_KEY_ID=${{ env.AWS_ACCESS_KEY_ID }} \
                     -e AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }} \
                     -e AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }} \
                     base_nix bash -c "./workspace/docker/nix/build_nix.sh"
+      - name: Build psql bundle on macos
+        if: matrix.runner == 'macos-latest'
+        run: |
+          # Replace this with your actual build script
+          cp ./workspace/docker/nix/build_nix.sh ./build_nix.sh
+          sed -i 's/cd workspace//g' ./build_nix.sh
+          ./build_nix.sh
+        env:
+          AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
+
     name: build psql bundle on ${{ matrix.arch }}
     

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -67,6 +67,7 @@ jobs:
         run: |
           cp ./docker/nix/build_nix.sh ./build_nix.sh
           sed -i '' 's/cd workspace//g' ./build_nix.sh
+          sed -i '' '1s|^#!/bin/env bash|#!/usr/bin/env bash|' ./build_nix.sh
           chmod +x ./build_nix.sh
           ./build_nix.sh
         env:

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -68,6 +68,7 @@ jobs:
           curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --no-confirm \
           --extra-conf "substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com" \
           --extra-conf "trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=% cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
           cp ./docker/nix/build_nix.sh ./build_nix.sh
           sed -i '' 's/cd workspace//g' ./build_nix.sh
           sed -i '' '1s|^#!/bin/env bash|#!/usr/bin/env bash|' ./build_nix.sh

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -70,7 +70,6 @@ jobs:
           --extra-conf "trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=% cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
           . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
           cp ./docker/nix/build_nix.sh ./build_nix.sh
-          sed -i '' 's/cd workspace//g' ./build_nix.sh
           sed -i '' '1s|^#!/bin/env bash|#!/usr/bin/env bash|' ./build_nix.sh
           chmod +x ./build_nix.sh
           ./build_nix.sh

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -67,6 +67,7 @@ jobs:
         run: |
           cp ./docker/nix/build_nix.sh ./build_nix.sh
           sed -i '' 's/cd workspace//g' ./build_nix.sh
+          chmod +x ./build_nix.sh
           ./build_nix.sh
         env:
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -65,9 +65,8 @@ jobs:
       - name: Build psql bundle on macos
         if: matrix.runner == 'macos-latest'
         run: |
-          # Replace this with your actual build script
           cp ./docker/nix/build_nix.sh ./build_nix.sh
-          sed -i 's/cd workspace//g' ./build_nix.sh
+          sed -i '' 's/cd workspace//g' ./build_nix.sh
           ./build_nix.sh
         env:
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Build psql bundle on macos
         if: matrix.runner == 'macos-latest'
         run: |
+          curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --no-confirm \
+          --extra-conf "substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com" \
+          --extra-conf "trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=% cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
           cp ./docker/nix/build_nix.sh ./build_nix.sh
           sed -i '' 's/cd workspace//g' ./build_nix.sh
           sed -i '' '1s|^#!/bin/env bash|#!/usr/bin/env bash|' ./build_nix.sh

--- a/docker/nix/build_nix.sh
+++ b/docker/nix/build_nix.sh
@@ -2,7 +2,9 @@
 set -eou pipefail
 
 nix --version
-cd /workspace
+if [ -d "/workspace" ]; then
+    cd /workspace
+fi
 nix build .#psql_15/bin -o psql_15
 nix flake check -L 
 nix copy --to s3://nix-postgres-artifacts?secret-key=nix-secret-key ./psql_15

--- a/nix/ext/wrappers/default.nix
+++ b/nix/ext/wrappers/default.nix
@@ -30,7 +30,8 @@ buildPgrxExtension_0_11_3 rec {
     darwin.apple_sdk.frameworks.SystemConfiguration 
   ];
   OPENSSL_NO_VENDOR = 1;
-  
+  #need to set this to 2 to avoid cpu starvation
+  CARGO_BUILD_JOBS = "2";
   CARGO="${cargo}/bin/cargo";
   cargoLock = {
     lockFile = "${src}/Cargo.lock";


### PR DESCRIPTION
## What kind of change does this PR introduce?

In the nix CI build, this PR is introducing an ephemeral darwin arm64 build that runs in the matrix.

This darwin build does not use docker, and instead runs direct on the machine, since the runner machine  itself is ephemeral. Nothing has been changed about the aarch64-linux and x86_64-linux runners or builds.