### PR TITLE
fix: add `HOME` env var to Supervisord managed postgres

### DIFF
--- a/docker/all-in-one/etc/supervisor/base-services/postgresql.conf
+++ b/docker/all-in-one/etc/supervisor/base-services/postgresql.conf
@@ -7,7 +7,7 @@ autostart=true
 startretries=1000
 priority=1
 # Inherit env vars from https://github.com/supabase/postgres/blob/develop/Dockerfile#L800
-environment=POSTGRES_PASSWORD="%(ENV_POSTGRES_PASSWORD)s",POSTGRES_HOST="%(ENV_POSTGRES_HOST)s"
+environment=POSTGRES_PASSWORD="%(ENV_POSTGRES_PASSWORD)s",POSTGRES_HOST="%(ENV_POSTGRES_HOST)s",HOME="/var/lib/postgresql"
 stdout_logfile=/var/log/postgresql/init.log
 redirect_stderr=true
 stdout_logfile_maxbytes=10MB


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add `HOME` env var definition to Supervisord managed postgres process.

## What is the current behavior?

Currently the `HOME` env var isn't defined for Supervisord managed postgres, so it defaults to `/root`. This caused permission denied issue when Wrappers is trying to save downloaded wasm file to `$HOME/.cache` folder.

## What is the new behavior?

Define `HOME` env var to `/var/lib/postgresql` for Supervisord managed postgres process.

## Additional context

N/A