### PR TITLE
Sam/pg 15 8

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -40,6 +40,7 @@ jobs:
           role-to-assume: ${{ secrets.DEV_AWS_ROLE }}
           aws-region: "us-east-1"
           output-credentials: true
+          role-duration-seconds: 7200
       - name: write secret key
         # use python so we don't interpolate the secret into the workflow logs, in case of bugs
         run: |

--- a/flake.lock
+++ b/flake.lock
@@ -107,11 +107,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1712666087,
-        "narHash": "sha256-WwjUkWsjlU8iUImbivlYxNyMB1L5YVqE8QotQdL9jWc=",
+        "lastModified": 1725910328,
+        "narHash": "sha256-n9pCtzGZ0httmTwMuEbi5E78UQ4ZbQMr1pzi5N0LAG8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a76c4553d7e741e17f289224eda135423de0491d",
+        "rev": "5775c2583f1801df7b790bf7f7d710a19bac66f4",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,12 @@
         #This variable works the same as 'oriole_pkgs' but builds using the upstream
         #nixpkgs builds of postgresql 15 and 16 + the overlays listed below
         pkgs = import nixpkgs {
-          config = { allowUnfree = true; };
+          config = { 
+            allowUnfree = true;
+            permittedInsecurePackages = [
+              "v8-9.7.106.18"
+            ]; 
+          };
           inherit system;
           overlays = [
             # NOTE (aseipp): add any needed overlays here. in theory we could
@@ -293,6 +298,7 @@
           sfcgal = sfcgal;
           pg_regress = pg_regress;
           pg_prove = pkgs.perlPackages.TAPParserSourceHandlerpgTAP;
+          postgresql_15 = postgresql_15;
           # Start a version of the server.
           start-server =
             let
@@ -512,6 +518,7 @@
           inherit (pkgs)
             # NOTE: comes from our cargo-pgrx-0-11-3.nix overlay
             cargo-pgrx_0_11_3;
+
 
         };
 

--- a/nix/ext/pg_graphql.nix
+++ b/nix/ext/pg_graphql.nix
@@ -19,6 +19,7 @@ buildPgrxExtension_0_11_3 rec {
   env = lib.optionalAttrs stdenv.isDarwin {
     POSTGRES_LIB = "${postgresql}/lib";
     RUSTFLAGS = "-C link-arg=-undefined -C link-arg=dynamic_lookup";
+    PGPORT = "5434";
   };
   cargoHash = "sha256-WkHufMw8OvinMRYd06ZJACnVvY9OLi069nCgq3LSmMY=";
 

--- a/nix/ext/pg_jsonschema.nix
+++ b/nix/ext/pg_jsonschema.nix
@@ -22,6 +22,7 @@ buildPgrxExtension_0_11_3 rec {
   env = lib.optionalAttrs stdenv.isDarwin {
     POSTGRES_LIB = "${postgresql}/lib";
     RUSTFLAGS = "-C link-arg=-undefined -C link-arg=dynamic_lookup";
+    PGPORT = "5433";
   };
   cargoHash = "sha256-VcS+efMDppofuFW2zNrhhsbC28By3lYekDFquHPta2g=";
 

--- a/nix/ext/pg_regress.nix
+++ b/nix/ext/pg_regress.nix
@@ -5,7 +5,7 @@
 
 stdenv.mkDerivation {
   pname = "pg_regress";
-  version = postgresql.version;
+  version = "0.0.1";
 
   phases = [ "installPhase" ];
 

--- a/nix/ext/pg_regress.nix
+++ b/nix/ext/pg_regress.nix
@@ -5,7 +5,7 @@
 
 stdenv.mkDerivation {
   pname = "pg_regress";
-  version = "0.0.1";
+  version = postgresql.version;
 
   phases = [ "installPhase" ];
 

--- a/nix/ext/plv8.nix
+++ b/nix/ext/plv8.nix
@@ -37,9 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    (v8.overrideAttrs (oldAttrs: {
-      version = "9.7.106.18";  
-    }))
+    v8
     postgresql
   ] ++ lib.optionals stdenv.isDarwin [
     darwin.apple_sdk.frameworks.CoreFoundation

--- a/nix/libxml2.nix
+++ b/nix/libxml2.nix
@@ -18,7 +18,7 @@
 , gnome
 , testers
 , enableHttp ? false
-, python ? null  # Add this line to accept 'python' as an argument
+, python ? null  # accept 'python' as an argument
 }:
 
 let

--- a/nix/libxml2.nix
+++ b/nix/libxml2.nix
@@ -1,0 +1,123 @@
+{ stdenv
+, lib
+, fetchurl
+, pkg-config
+, autoreconfHook
+, libintl
+, python3
+, gettext
+, ncurses
+, findXMLCatalogs
+, libiconv
+, pythonSupport ? enableShared &&
+    (stdenv.hostPlatform == stdenv.buildPlatform || stdenv.hostPlatform.isCygwin || stdenv.hostPlatform.isLinux || stdenv.hostPlatform.isWasi)
+, icuSupport ? false
+, icu
+, enableShared ? !stdenv.hostPlatform.isMinGW && !stdenv.hostPlatform.isStatic
+, enableStatic ? !enableShared
+, gnome
+, testers
+, enableHttp ? false
+, python ? null  # Add this line to accept 'python' as an argument
+}:
+
+let
+  # If 'python' is provided, use it; otherwise use 'python3'
+  pythonEnv = python3;
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libxml2";
+  version = "2.13.3";
+
+  outputs = [ "bin" "dev" "out" "devdoc" ]
+    ++ lib.optional pythonSupport "py"
+    ++ lib.optional (enableStatic && enableShared) "static";
+  outputMan = "bin";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/libxml2/${lib.versions.majorMinor finalAttrs.version}/libxml2-${finalAttrs.version}.tar.xz";
+    hash = "sha256-CAXXwYDPCcqtcWZsekWKdPBBVhpTKQJFTaUEfYOUgTg=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    autoreconfHook
+  ];
+
+  buildInputs = lib.optionals pythonSupport [
+    pythonEnv
+    ncurses
+  ];
+
+  propagatedBuildInputs = [
+    findXMLCatalogs
+  ] ++ lib.optionals stdenv.isDarwin [
+    libiconv
+  ] ++ lib.optionals icuSupport [
+    icu
+  ];
+
+  configureFlags = [
+    "--exec-prefix=${placeholder "dev"}"
+    (lib.enableFeature enableStatic "static")
+    (lib.enableFeature enableShared "shared")
+    (lib.withFeature icuSupport "icu")
+    (lib.withFeature pythonSupport "python")
+    (lib.optionalString pythonSupport "PYTHON=${pythonEnv.pythonOnBuildForHost.interpreter}")
+  ] ++ lib.optional enableHttp "--with-http";
+
+  installFlags = lib.optionals pythonSupport [
+    "pythondir=\"${placeholder "py"}/${pythonEnv.sitePackages}\""
+    "pyexecdir=\"${placeholder "py"}/${pythonEnv.sitePackages}\""
+  ];
+
+  enableParallelBuilding = true;
+
+  doCheck =
+    (stdenv.hostPlatform == stdenv.buildPlatform) &&
+    stdenv.hostPlatform.libc != "musl";
+  preCheck = lib.optional stdenv.isDarwin ''
+    export DYLD_LIBRARY_PATH="$PWD/.libs:$DYLD_LIBRARY_PATH"
+  '';
+
+  preConfigure = lib.optionalString (lib.versionAtLeast stdenv.hostPlatform.darwinMinVersion "11") ''
+    MACOSX_DEPLOYMENT_TARGET=10.16
+  '';
+
+  preInstall = lib.optionalString pythonSupport ''
+    substituteInPlace python/libxml2mod.la --replace-fail "$dev/${pythonEnv.sitePackages}" "$py/${pythonEnv.sitePackages}"
+  '';
+
+  postFixup = ''
+    moveToOutput bin/xml2-config "$dev"
+    moveToOutput lib/xml2Conf.sh "$dev"
+  '' + lib.optionalString (enableStatic && enableShared) ''
+    moveToOutput lib/libxml2.a "$static"
+  '';
+
+  passthru = {
+    inherit pythonSupport;
+
+    updateScript = gnome.updateScript {
+      packageName = "libxml2";
+      versionPolicy = "none";
+    };
+    tests = {
+      pkg-config = testers.hasPkgConfigModules {
+        package = finalAttrs.finalPackage;
+      };
+    };
+  };
+
+  meta = with lib; {
+    homepage = "https://gitlab.gnome.org/GNOME/libxml2";
+    description = "XML parsing library for C";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ jtojnar ];
+    pkgConfigModules = [ "libxml-2.0" ];
+  };
+})

--- a/nix/postgresql/15.nix
+++ b/nix/postgresql/15.nix
@@ -1,0 +1,4 @@
+import ./generic.nix {
+  version = "15.8";
+  hash = "sha256-RANRX5pp7rPv68mPMLjGlhIr/fiV6Ss7I/W452nty2o=";
+}

--- a/nix/postgresql/16.nix
+++ b/nix/postgresql/16.nix
@@ -1,0 +1,4 @@
+import ./generic.nix {
+  version = "16.4";
+  hash = "sha256-lxdm1kWqc+k7nvTjvkQgG09FtUdwlbBJElQD+fM4bW8=";
+}

--- a/nix/postgresql/default.nix
+++ b/nix/postgresql/default.nix
@@ -1,0 +1,21 @@
+self:
+let
+  #adapted from the postgresql nixpkgs package
+  versions = {
+    postgresql_15 = ./15.nix;
+    postgresql_16 = ./16.nix;
+  };
+
+  mkAttributes = jitSupport:
+    self.lib.mapAttrs' (version: path:
+      let
+        attrName = if jitSupport then "${version}_jit" else version;
+      in
+      self.lib.nameValuePair attrName (import path {
+        inherit jitSupport self;
+      })
+    ) versions;
+
+in
+# variations without and with JIT
+(mkAttributes false) // (mkAttributes true)

--- a/nix/postgresql/generic.nix
+++ b/nix/postgresql/generic.nix
@@ -1,0 +1,309 @@
+let
+
+  generic =
+      # adapted from the nixpkgs postgresql package
+      # dependencies
+      { stdenv, lib, fetchurl, fetchpatch, makeWrapper
+      , glibc, zlib, readline, openssl, icu, lz4, zstd, systemd, libossp_uuid
+      , pkg-config, libxml2, tzdata, libkrb5, substituteAll, darwin
+      , linux-pam
+
+      # This is important to obtain a version of `libpq` that does not depend on systemd.
+      , systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd && !stdenv.hostPlatform.isStatic
+      , enableSystemd ? null
+      , gssSupport ? with stdenv.hostPlatform; !isWindows && !isStatic
+
+      # for postgresql.pkgs
+      , self, newScope, buildEnv
+
+      # source specification
+      , version, hash, muslPatches ? {}
+
+      # for tests
+      , testers
+
+      # JIT
+      , jitSupport
+      , nukeReferences, patchelf, llvmPackages
+
+      # PL/Python
+      , pythonSupport ? false
+      , python3
+
+      # detection of crypt fails when using llvm stdenv, so we add it manually
+      # for <13 (where it got removed: https://github.com/postgres/postgres/commit/c45643d618e35ec2fe91438df15abd4f3c0d85ca)
+      , libxcrypt
+    } @args:
+  let
+    atLeast = lib.versionAtLeast version;
+    olderThan = lib.versionOlder version;
+    lz4Enabled = atLeast "14";
+    zstdEnabled = atLeast "15";
+
+    systemdSupport' = if enableSystemd == null then systemdSupport else (lib.warn "postgresql: argument enableSystemd is deprecated, please use systemdSupport instead." enableSystemd);
+
+    pname = "postgresql";
+
+    stdenv' = if jitSupport then llvmPackages.stdenv else stdenv;
+  in stdenv'.mkDerivation (finalAttrs: {
+    inherit version;
+    pname = pname + lib.optionalString jitSupport "-jit";
+
+    src = fetchurl {
+      url = "mirror://postgresql/source/v${version}/${pname}-${version}.tar.bz2";
+      inherit hash;
+    };
+
+    hardeningEnable = lib.optionals (!stdenv'.cc.isClang) [ "pie" ];
+
+    outputs = [ "out" "lib" "doc" "man" ];
+    setOutputFlags = false; # $out retains configureFlags :-/
+
+    buildInputs = [
+      zlib
+      readline
+      openssl
+      (libxml2.override {enableHttp = true; python = python3;})
+      icu
+    ]
+      ++ lib.optionals (olderThan "13") [ libxcrypt ]
+      ++ lib.optionals jitSupport [ llvmPackages.llvm ]
+      ++ lib.optionals lz4Enabled [ lz4 ]
+      ++ lib.optionals zstdEnabled [ zstd ]
+      ++ lib.optionals systemdSupport' [ systemd ]
+      ++ lib.optionals pythonSupport [ python3 ]
+      ++ lib.optionals gssSupport [ libkrb5 ]
+      ++ lib.optionals stdenv'.isLinux [ linux-pam ]
+      ++ lib.optionals (!stdenv'.isDarwin) [ libossp_uuid ];
+
+    nativeBuildInputs = [
+      makeWrapper
+      pkg-config
+    ]
+      ++ lib.optionals jitSupport [ llvmPackages.llvm.dev nukeReferences patchelf ];
+
+    enableParallelBuilding = true;
+
+    separateDebugInfo = true;
+
+    buildFlags = [ "world" ];
+
+    # Makes cross-compiling work when xml2-config can't be executed on the host.
+    # Fixed upstream in https://github.com/postgres/postgres/commit/0bc8cebdb889368abdf224aeac8bc197fe4c9ae6
+    env.NIX_CFLAGS_COMPILE = lib.optionalString (olderThan "13") "-I${libxml2.dev}/include/libxml2";
+
+    configureFlags = [
+      "--with-openssl"
+      "--with-libxml"
+      "--with-icu"
+      "--sysconfdir=/etc"
+      "--libdir=$(lib)/lib"
+      "--with-system-tzdata=${tzdata}/share/zoneinfo"
+      "--enable-debug"
+      (lib.optionalString systemdSupport' "--with-systemd")
+      (if stdenv'.isDarwin then "--with-uuid=e2fs" else "--with-ossp-uuid")
+    ] ++ lib.optionals lz4Enabled [ "--with-lz4" ]
+      ++ lib.optionals zstdEnabled [ "--with-zstd" ]
+      ++ lib.optionals gssSupport [ "--with-gssapi" ]
+      ++ lib.optionals pythonSupport [ "--with-python" ]
+      ++ lib.optionals jitSupport [ "--with-llvm" ]
+      ++ lib.optionals stdenv'.isLinux [ "--with-pam" ];
+
+    patches = [
+      (if atLeast "16" then ./patches/relative-to-symlinks-16+.patch else ./patches/relative-to-symlinks.patch)
+      ./patches/less-is-more.patch
+      ./patches/paths-for-split-outputs.patch
+      ./patches/specify_pkglibdir_at_runtime.patch
+      ./patches/paths-with-postgresql-suffix.patch
+
+      (substituteAll {
+        src = ./patches/locale-binary-path.patch;
+        locale = "${if stdenv.isDarwin then darwin.adv_cmds else lib.getBin stdenv.cc.libc}/bin/locale";
+      })
+    ] ++ lib.optionals stdenv'.hostPlatform.isMusl (
+      # Using fetchurl instead of fetchpatch on purpose: https://github.com/NixOS/nixpkgs/issues/240141
+      map fetchurl (lib.attrValues muslPatches)
+    ) ++ lib.optionals stdenv'.isLinux  [
+      (if atLeast "13" then ./patches/socketdir-in-run-13+.patch else ./patches/socketdir-in-run.patch)
+    ];
+
+    installTargets = [ "install-world" ];
+
+    postPatch = ''
+      # Hardcode the path to pgxs so pg_config returns the path in $out
+      substituteInPlace "src/common/config_info.c" --subst-var out
+    '' + lib.optionalString jitSupport ''
+        # Force lookup of jit stuff in $out instead of $lib
+        substituteInPlace src/backend/jit/jit.c --replace pkglib_path \"$out/lib\"
+        substituteInPlace src/backend/jit/llvm/llvmjit.c --replace pkglib_path \"$out/lib\"
+        substituteInPlace src/backend/jit/llvm/llvmjit_inline.cpp --replace pkglib_path \"$out/lib\"
+    '';
+
+    postInstall =
+      ''
+        moveToOutput "lib/pgxs" "$out" # looks strange, but not deleting it
+        moveToOutput "lib/libpgcommon*.a" "$out"
+        moveToOutput "lib/libpgport*.a" "$out"
+        moveToOutput "lib/libecpg*" "$out"
+
+        # Prevent a retained dependency on gcc-wrapper.
+        substituteInPlace "$out/lib/pgxs/src/Makefile.global" --replace ${stdenv'.cc}/bin/ld ld
+
+        if [ -z "''${dontDisableStatic:-}" ]; then
+          # Remove static libraries in case dynamic are available.
+          for i in $out/lib/*.a $lib/lib/*.a; do
+            name="$(basename "$i")"
+            ext="${stdenv'.hostPlatform.extensions.sharedLibrary}"
+            if [ -e "$lib/lib/''${name%.a}$ext" ] || [ -e "''${i%.a}$ext" ]; then
+              rm "$i"
+            fi
+          done
+        fi
+      '' + lib.optionalString jitSupport ''
+        # Move the bitcode and libllvmjit.so library out of $lib; otherwise, every client that
+        # depends on libpq.so will also have libLLVM.so in its closure too, bloating it
+        moveToOutput "lib/bitcode" "$out"
+        moveToOutput "lib/llvmjit*" "$out"
+
+        # In the case of JIT support, prevent a retained dependency on clang-wrapper
+        substituteInPlace "$out/lib/pgxs/src/Makefile.global" --replace ${stdenv'.cc}/bin/clang clang
+        nuke-refs $out/lib/llvmjit_types.bc $(find $out/lib/bitcode -type f)
+
+        # Stop out depending on the default output of llvm
+        substituteInPlace $out/lib/pgxs/src/Makefile.global \
+          --replace ${llvmPackages.llvm.out}/bin "" \
+          --replace '$(LLVM_BINPATH)/' ""
+
+        # Stop out depending on the -dev output of llvm
+        substituteInPlace $out/lib/pgxs/src/Makefile.global \
+          --replace ${llvmPackages.llvm.dev}/bin/llvm-config llvm-config \
+          --replace -I${llvmPackages.llvm.dev}/include ""
+
+        ${lib.optionalString (!stdenv'.isDarwin) ''
+          # Stop lib depending on the -dev output of llvm
+          rpath=$(patchelf --print-rpath $out/lib/llvmjit.so)
+          nuke-refs -e $out $out/lib/llvmjit.so
+          # Restore the correct rpath
+          patchelf $out/lib/llvmjit.so --set-rpath "$rpath"
+        ''}
+      '';
+
+    postFixup = lib.optionalString (!stdenv'.isDarwin && stdenv'.hostPlatform.libc == "glibc")
+      ''
+        # initdb needs access to "locale" command from glibc.
+        wrapProgram $out/bin/initdb --prefix PATH ":" ${glibc.bin}/bin
+      '';
+
+    doCheck = !stdenv'.isDarwin;
+    # autodetection doesn't seem to able to find this, but it's there.
+    checkTarget = "check";
+
+    disallowedReferences = [ stdenv'.cc ];
+
+    passthru = let
+      this = self.callPackage generic args;
+      jitToggle = this.override {
+        jitSupport = !jitSupport;
+      };
+    in
+    {
+      psqlSchema = lib.versions.major version;
+
+      withJIT = if jitSupport then this else jitToggle;
+      withoutJIT = if jitSupport then jitToggle else this;
+
+      dlSuffix = if olderThan "16" then ".so" else stdenv.hostPlatform.extensions.sharedLibrary;
+
+      pkgs = let
+        scope = {
+          inherit jitSupport;
+          inherit (llvmPackages) llvm;
+          postgresql = this;
+          stdenv = stdenv';
+        };
+        newSelf = self // scope;
+        newSuper = { callPackage = newScope (scope // this.pkgs); };
+      in import ./ext newSelf newSuper;
+
+      withPackages = postgresqlWithPackages {
+                       inherit makeWrapper buildEnv;
+                       postgresql = this;
+                     }
+                     this.pkgs;
+
+      tests = {
+        postgresql-wal-receiver = import ../../../../nixos/tests/postgresql-wal-receiver.nix {
+          inherit (stdenv) system;
+          pkgs = self;
+          package = this;
+        };
+        pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+      } // lib.optionalAttrs jitSupport {
+        postgresql-jit = import ../../../../nixos/tests/postgresql-jit.nix {
+          inherit (stdenv) system;
+          pkgs = self;
+          package = this;
+        };
+      };
+    };
+
+    meta = with lib; {
+      homepage    = "https://www.postgresql.org";
+      description = "Powerful, open source object-relational database system";
+      license     = licenses.postgresql;
+      changelog   = "https://www.postgresql.org/docs/release/${finalAttrs.version}/";
+      maintainers = with maintainers; [ thoughtpolice danbst globin ivan ma27 wolfgangwalther ];
+      pkgConfigModules = [ "libecpg" "libecpg_compat" "libpgtypes" "libpq" ];
+      platforms   = platforms.unix;
+
+      # JIT support doesn't work with cross-compilation. It is attempted to build LLVM-bytecode
+      # (`%.bc` is the corresponding `make(1)`-rule) for each sub-directory in `backend/` for
+      # the JIT apparently, but with a $(CLANG) that can produce binaries for the build, not the
+      # host-platform.
+      #
+      # I managed to get a cross-build with JIT support working with
+      # `depsBuildBuild = [ llvmPackages.clang ] ++ buildInputs`, but considering that the
+      # resulting LLVM IR isn't platform-independent this doesn't give you much.
+      # In fact, I tried to test the result in a VM-test, but as soon as JIT was used to optimize
+      # a query, postgres would coredump with `Illegal instruction`.
+      broken = (jitSupport && stdenv.hostPlatform != stdenv.buildPlatform)
+        # Allmost all tests fail FATAL errors for v12 and v13
+        || (jitSupport && stdenv.hostPlatform.isMusl && olderThan "14");
+    };
+  });
+
+  postgresqlWithPackages = { postgresql, makeWrapper, buildEnv }: pkgs: f: buildEnv {
+    name = "postgresql-and-plugins-${postgresql.version}";
+    paths = f pkgs ++ [
+        postgresql
+        postgresql.lib
+        postgresql.man   # in case user installs this into environment
+    ];
+    nativeBuildInputs = [ makeWrapper ];
+
+
+    # We include /bin to ensure the $out/bin directory is created, which is
+    # needed because we'll be removing the files from that directory in postBuild
+    # below. See #22653
+    pathsToLink = ["/" "/bin"];
+
+    # Note: the duplication of executables is about 4MB size.
+    # So a nicer solution was patching postgresql to allow setting the
+    # libdir explicitly.
+    postBuild = ''
+      mkdir -p $out/bin
+      rm $out/bin/{pg_config,postgres,pg_ctl}
+      cp --target-directory=$out/bin ${postgresql}/bin/{postgres,pg_config,pg_ctl}
+      wrapProgram $out/bin/postgres --set NIX_PGLIBDIR $out/lib
+    '';
+
+    passthru.version = postgresql.version;
+    passthru.psqlSchema = postgresql.psqlSchema;
+  };
+
+in
+# passed by <major>.nix
+versionArgs:
+# passed by default.nix
+{ self, ... } @defaultArgs:
+self.callPackage generic (defaultArgs // versionArgs)

--- a/nix/postgresql/patches/less-is-more.patch
+++ b/nix/postgresql/patches/less-is-more.patch
@@ -1,0 +1,11 @@
+--- a/src/include/fe_utils/print.h
++++ b/src/include/fe_utils/print.h
+@@ -18,7 +18,7 @@
+ 
+ /* This is not a particularly great place for this ... */
+ #ifndef __CYGWIN__
+-#define DEFAULT_PAGER "more"
++#define DEFAULT_PAGER "less"
+ #else
+ #define DEFAULT_PAGER "less"
+ #endif

--- a/nix/postgresql/patches/locale-binary-path.patch
+++ b/nix/postgresql/patches/locale-binary-path.patch
@@ -1,0 +1,11 @@
+--- a/src/backend/commands/collationcmds.c
++++ b/src/backend/commands/collationcmds.c
+@@ -611,7 +611,7 @@ pg_import_system_collations(PG_FUNCTION_ARGS)
+ 		aliases = (CollAliasData *) palloc(maxaliases * sizeof(CollAliasData));
+ 		naliases = 0;
+ 
+-		locale_a_handle = OpenPipeStream("locale -a", "r");
++		locale_a_handle = OpenPipeStream("@locale@ -a", "r");
+ 		if (locale_a_handle == NULL)
+ 			ereport(ERROR,
+ 					(errcode_for_file_access(),

--- a/nix/postgresql/patches/paths-for-split-outputs.patch
+++ b/nix/postgresql/patches/paths-for-split-outputs.patch
@@ -1,0 +1,11 @@
+--- a/src/common/config_info.c
++++ b/src/common/config_info.c
+@@ -118,7 +118,7 @@
+ 	i++;
+
+ 	configdata[i].name = pstrdup("PGXS");
++	strlcpy(path, "@out@/lib", sizeof(path));
+-	get_pkglib_path(my_exec_path, path);
+ 	strlcat(path, "/pgxs/src/makefiles/pgxs.mk", sizeof(path));
+ 	cleanup_path(path);
+ 	configdata[i].setting = pstrdup(path);

--- a/nix/postgresql/patches/paths-with-postgresql-suffix.patch
+++ b/nix/postgresql/patches/paths-with-postgresql-suffix.patch
@@ -1,0 +1,41 @@
+Nix outputs put the `name' in each store path like
+/nix/store/...-<name>. This was confusing the Postgres make script
+because it thought its data directory already had postgresql in its
+directory. This lead to Postgres installing all of its fils in
+$out/share. To fix this, we just look for postgres or psql in the part
+after the / using make's notdir.
+
+---
+--- a/src/Makefile.global.in
++++ b/src/Makefile.global.in
+@@ -102,15 +102,15 @@ datarootdir := @datarootdir@
+ bindir := @bindir@
+ 
+ datadir := @datadir@
+-ifeq "$(findstring pgsql, $(datadir))" ""
+-ifeq "$(findstring postgres, $(datadir))" ""
++ifeq "$(findstring pgsql, $(notdir $(datadir)))" ""
++ifeq "$(findstring postgres, $(notdir $(datadir)))" ""
+ override datadir := $(datadir)/postgresql
+ endif
+ endif
+ 
+ sysconfdir := @sysconfdir@
+-ifeq "$(findstring pgsql, $(sysconfdir))" ""
+-ifeq "$(findstring postgres, $(sysconfdir))" ""
++ifeq "$(findstring pgsql, $(notdir $(sysconfdir)))" ""
++ifeq "$(findstring postgres, $(notdir $(sysconfdir)))" ""
+ override sysconfdir := $(sysconfdir)/postgresql
+ endif
+ endif
+@@ -136,8 +136,8 @@ endif
+ mandir := @mandir@
+ 
+ docdir := @docdir@
+-ifeq "$(findstring pgsql, $(docdir))" ""
+-ifeq "$(findstring postgres, $(docdir))" ""
++ifeq "$(findstring pgsql, $(notdir $(docdir)))" ""
++ifeq "$(findstring postgres, $(notdir $(docdir)))" ""
+ override docdir := $(docdir)/postgresql
+ endif
+ endif

--- a/nix/postgresql/patches/relative-to-symlinks-16+.patch
+++ b/nix/postgresql/patches/relative-to-symlinks-16+.patch
@@ -1,0 +1,13 @@
+On NixOS we *want* stuff relative to symlinks.
+---
+--- a/src/common/exec.c
++++ b/src/common/exec.c
+@@ -238,6 +238,8 @@
+ static int
+ normalize_exec_path(char *path)
+ {
++	return 0;
++
+ 	/*
+ 	 * We used to do a lot of work ourselves here, but now we just let
+ 	 * realpath(3) do all the heavy lifting.

--- a/nix/postgresql/patches/relative-to-symlinks.patch
+++ b/nix/postgresql/patches/relative-to-symlinks.patch
@@ -1,0 +1,13 @@
+On NixOS we *want* stuff relative to symlinks.
+---
+--- a/src/common/exec.c
++++ b/src/common/exec.c
+@@ -218,6 +218,8 @@
+ static int
+ resolve_symlinks(char *path)
+ {
++	return 0;
++
+ #ifdef HAVE_READLINK
+ 	struct stat buf;
+ 	char		orig_wd[MAXPGPATH],

--- a/nix/postgresql/patches/socketdir-in-run-13+.patch
+++ b/nix/postgresql/patches/socketdir-in-run-13+.patch
@@ -1,0 +1,11 @@
+--- a/src/include/pg_config_manual.h
++++ b/src/include/pg_config_manual.h
+@@ -201,7 +201,7 @@
+  * support them yet.
+  */
+ #ifndef WIN32
+-#define DEFAULT_PGSOCKET_DIR  "/tmp"
++#define DEFAULT_PGSOCKET_DIR  "/run/postgresql"
+ #else
+ #define DEFAULT_PGSOCKET_DIR ""
+ #endif

--- a/nix/postgresql/patches/socketdir-in-run.patch
+++ b/nix/postgresql/patches/socketdir-in-run.patch
@@ -1,0 +1,11 @@
+--- a/src/include/pg_config_manual.h
++++ b/src/include/pg_config_manual.h
+@@ -179,7 +179,7 @@
+  * here's where to twiddle it.  You can also override this at runtime
+  * with the postmaster's -k switch.
+  */
+-#define DEFAULT_PGSOCKET_DIR  "/tmp"
++#define DEFAULT_PGSOCKET_DIR  "/run/postgresql"
+ 
+ /*
+  * This is the default event source for Windows event log.

--- a/nix/postgresql/patches/specify_pkglibdir_at_runtime.patch
+++ b/nix/postgresql/patches/specify_pkglibdir_at_runtime.patch
@@ -1,0 +1,28 @@
+--- a/src/port/path.c
++++ b/src/port/path.c
+@@ -714,7 +714,11 @@
+ void
+ get_lib_path(const char *my_exec_path, char *ret_path)
+ {
+-	make_relative_path(ret_path, LIBDIR, PGBINDIR, my_exec_path);
++	char const * const nix_pglibdir = getenv("NIX_PGLIBDIR");
++	if(nix_pglibdir == NULL)
++		make_relative_path(ret_path, LIBDIR, PGBINDIR, my_exec_path);
++	else
++		make_relative_path(ret_path, nix_pglibdir, PGBINDIR, my_exec_path);
+ }
+ 
+ /*
+@@ -723,7 +727,11 @@
+ void
+ get_pkglib_path(const char *my_exec_path, char *ret_path)
+ {
+-	make_relative_path(ret_path, PKGLIBDIR, PGBINDIR, my_exec_path);
++	char const * const nix_pglibdir = getenv("NIX_PGLIBDIR");
++	if(nix_pglibdir == NULL)
++		make_relative_path(ret_path, PKGLIBDIR, PGBINDIR, my_exec_path);
++	else
++		make_relative_path(ret_path, nix_pglibdir, PGBINDIR, my_exec_path);
+ }
+ 
+ /*

--- a/nix/tests/prime.sql
+++ b/nix/tests/prime.sql
@@ -62,11 +62,6 @@ create extension pgrowlocks;
 create extension pgstattuple;
 create extension plpgsql_check;
 
-/*
-TODO: PLs can not be enabled on M1 Macs locally
-ERROR:  could not load library "/nix/store/..../lib/plv8-3.1.5.so
-symbol not found in flat namespace
-*/
 create extension plv8;
 create extension plcoffee;
 create extension plls;


### PR DESCRIPTION
## What kind of change does this PR introduce?

- bumping the git revision of nixpkgs to the latest rev or `nixpkgs-unstable`
- Bringing packaging of postgresql and a dependency into our codebase, so that we can control the build, dependencies, and minor version changes independent of what is happening in nixpkgs
- for running on darwin, needed some env vars for PGPORT during the build phase
- introducing postgresql_16, but not yet incorporating it into the installables available from the flake
- advanced postgresql minor version to "15.8" 