### PR TITLE
feat(pg_upgrade): use self-hosted nix installer if available; move files out of /tmp

### DIFF
--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/complete.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/complete.sh
@@ -170,13 +170,13 @@ function apply_auth_scheme_updates {
 
 function start_vacuum_analyze {
     echo "complete" > /tmp/pg-upgrade-status
-    if ! command -v nix &> /dev/null; then
-        su -c 'vacuumdb --all --analyze-in-stages' -s "$SHELL" postgres
-    else
+
+    # shellcheck disable=SC1091
+    if [ -f "/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh" ]; then
         # shellcheck disable=SC1091
-        source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-        vacuumdb --all --analyze-in-stages -U supabase_admin -h localhost -p 5432
+        source "/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh"
     fi
+    vacuumdb --all --analyze-in-stages -U supabase_admin -h localhost -p 5432
     echo "Upgrade job completed"
 }
 

--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/complete.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/complete.sh
@@ -173,7 +173,9 @@ function start_vacuum_analyze {
     if ! command -v nix &> /dev/null; then
         su -c 'vacuumdb --all --analyze-in-stages' -s "$SHELL" postgres
     else
-        su -c '. /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh && vacuumdb --all --analyze-in-stages' -s "$SHELL" postgres
+        # shellcheck disable=SC1091
+        source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+        vacuumdb --all --analyze-in-stages -U supabase_admin -h localhost -p 5432
     fi
     echo "Upgrade job completed"
 }

--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
@@ -120,8 +120,8 @@ cleanup() {
     fi
 
     echo "Re-enabling extensions"
-    if [ -f "$POST_UPGRADE_EXTENSION_SCRIPT" ]; then
-        run_sql -f "$POST_UPGRADE_EXTENSION_SCRIPT"
+    if [ -f $POST_UPGRADE_EXTENSION_SCRIPT ]; then
+        run_sql -f $POST_UPGRADE_EXTENSION_SCRIPT
     fi
 
     echo "Removing SUPERUSER grant from postgres"
@@ -142,15 +142,15 @@ cleanup() {
 }
 
 function handle_extensions {
-    rm -f "$POST_UPGRADE_EXTENSION_SCRIPT"
-    touch "$POST_UPGRADE_EXTENSION_SCRIPT"
+    rm -f $POST_UPGRADE_EXTENSION_SCRIPT
+    touch $POST_UPGRADE_EXTENSION_SCRIPT
 
     PASSWORD_ENCRYPTION_SETTING=$(run_sql -A -t -c "SHOW password_encryption;")
     if [ "$PASSWORD_ENCRYPTION_SETTING" = "md5" ]; then
-        echo "ALTER SYSTEM SET password_encryption = 'md5';" >> "$POST_UPGRADE_EXTENSION_SCRIPT"
+        echo "ALTER SYSTEM SET password_encryption = 'md5';" >> $POST_UPGRADE_EXTENSION_SCRIPT
     fi
 
-    cat << EOF >> "$POST_UPGRADE_EXTENSION_SCRIPT"
+    cat << EOF >> $POST_UPGRADE_EXTENSION_SCRIPT
 ALTER SYSTEM SET jit = off;
 SELECT pg_reload_conf();
 EOF
@@ -162,7 +162,7 @@ EOF
         if [ "$EXTENSION_ENABLED" = "t" ]; then
             echo "Disabling extension ${EXTENSION}"
             run_sql -c "DROP EXTENSION IF EXISTS ${EXTENSION} CASCADE;"
-            cat << EOF >> "$POST_UPGRADE_EXTENSION_SCRIPT"
+            cat << EOF >> $POST_UPGRADE_EXTENSION_SCRIPT
 DO \$\$
 BEGIN
     IF EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = '${EXTENSION}') THEN

--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
@@ -120,8 +120,8 @@ cleanup() {
     fi
 
     echo "Re-enabling extensions"
-    if [ -f $POST_UPGRADE_EXTENSION_SCRIPT ]; then
-        run_sql -f $POST_UPGRADE_EXTENSION_SCRIPT
+    if [ -f "$POST_UPGRADE_EXTENSION_SCRIPT" ]; then
+        run_sql -f "$POST_UPGRADE_EXTENSION_SCRIPT"
     fi
 
     echo "Removing SUPERUSER grant from postgres"
@@ -142,15 +142,15 @@ cleanup() {
 }
 
 function handle_extensions {
-    rm -f $POST_UPGRADE_EXTENSION_SCRIPT
-    touch $POST_UPGRADE_EXTENSION_SCRIPT
+    rm -f "$POST_UPGRADE_EXTENSION_SCRIPT"
+    touch "$POST_UPGRADE_EXTENSION_SCRIPT"
 
     PASSWORD_ENCRYPTION_SETTING=$(run_sql -A -t -c "SHOW password_encryption;")
     if [ "$PASSWORD_ENCRYPTION_SETTING" = "md5" ]; then
-        echo "ALTER SYSTEM SET password_encryption = 'md5';" >> $POST_UPGRADE_EXTENSION_SCRIPT
+        echo "ALTER SYSTEM SET password_encryption = 'md5';" >> "$POST_UPGRADE_EXTENSION_SCRIPT"
     fi
 
-    cat << EOF >> $POST_UPGRADE_EXTENSION_SCRIPT
+    cat << EOF >> "$POST_UPGRADE_EXTENSION_SCRIPT"
 ALTER SYSTEM SET jit = off;
 SELECT pg_reload_conf();
 EOF
@@ -162,7 +162,7 @@ EOF
         if [ "$EXTENSION_ENABLED" = "t" ]; then
             echo "Disabling extension ${EXTENSION}"
             run_sql -c "DROP EXTENSION IF EXISTS ${EXTENSION} CASCADE;"
-            cat << EOF >> $POST_UPGRADE_EXTENSION_SCRIPT
+            cat << EOF >> "$POST_UPGRADE_EXTENSION_SCRIPT"
 DO \$\$
 BEGIN
     IF EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = '${EXTENSION}') THEN

--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
@@ -49,6 +49,8 @@ PGBINOLD="/usr/lib/postgresql/bin"
 PGLIBOLD="/usr/lib/postgresql/lib"
 
 PG_UPGRADE_BIN_DIR="/tmp/pg_upgrade_bin/$PGVERSION"
+NIX_INSTALLER_PATH="/tmp/persistent/nix-installer"
+NIX_INSTALLER_PACKAGE_PATH="$NIX_INSTALLER_PATH.tar.gz"
 
 if [ -L "$PGBINOLD/pg_upgrade" ]; then
     BINARY_PATH=$(readlink -f "$PGBINOLD/pg_upgrade")
@@ -283,9 +285,18 @@ function initiate_upgrade {
                 if ! command -v nix > /dev/null; then
                     echo "1.1. Nix is not installed; installing."
 
-                    curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --no-confirm \
-                    --extra-conf "substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com" \
-                    --extra-conf "trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=% cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+                    if [ -f "$NIX_INSTALLER_PACKAGE_PATH" ]; then
+                        echo "1.1.1. Installing Nix using the provided installer"
+                        tar -xzf "$NIX_INSTALLER_PACKAGE_PATH" -C /tmp/persistent/
+                        chmod +x "$NIX_INSTALLER_PATH"
+                        "$NIX_INSTALLER_PATH" install --no-confirm
+                    else
+                        echo "1.1.1. Installing Nix using the official installer"
+
+                        curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --no-confirm \
+                        --extra-conf "substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com" \
+                        --extra-conf "trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=% cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+                    fi
                 else 
                     echo "1.1. Nix is installed; moving on."
                 fi


### PR DESCRIPTION
* Saves us from headaches due to external outages, or mismatched installer issues
* Fixes vacuumdb not being run as superuser post-bootstrap user switch