### PR TITLE
Upgrade pg_tle to 1.4.0

### DIFF
--- a/nix/ext/pg_tle.nix
+++ b/nix/ext/pg_tle.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "pg_tle";
-  version = "1.3.2";
+  version = "1.4.0";
 
   nativeBuildInputs = [ flex ];
   buildInputs = [ openssl postgresql libkrb5 ];
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     owner = "aws";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-g2up0hJ9y0yz6aKTRwNyJatnApMYz9hIp4lxT0I9bNs=";
+    hash = "sha256-crxj5R9jblIv0h8lpqddAoYe2UqgUlnvbOajKTzVces=";
   };
 
   


### PR DESCRIPTION
Upgrades pg_tle to 1.4.0 from 1.3.2

- existing pg_tle test continues to pass
- public interface changes are backwards compatible