### PR TITLE
fix: run timescaledb_pre/post_restore()

### DIFF
--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/common.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/common.sh
@@ -94,6 +94,14 @@ create role supabase_tmp superuser;
 set session authorization supabase_tmp;
 
 do $$
+begin
+  if exists (select from pg_extension where extname = 'timescaledb') then
+    execute(format('select %I.timescaledb_pre_restore()', (select pronamespace::regnamespace from pg_proc where proname = 'timescaledb_pre_restore')));
+  end if;
+end
+$$;
+
+do $$
 declare
   postgres_rolpassword text := (select rolpassword from pg_authid where rolname = 'postgres');
   supabase_admin_rolpassword text := (select rolpassword from pg_authid where rolname = 'supabase_admin');
@@ -490,6 +498,14 @@ begin
       execute(format('grant %s on table %s to %I %s', rec.privilege_type, (obj->>'oid')::oid::regclass, rec.grantee::regrole, case when rec.is_grantable then 'with grant option' else '' end));
     end loop;
   end loop;
+end
+$$;
+
+do $$
+begin
+  if exists (select from pg_extension where extname = 'timescaledb') then
+    execute(format('select %I.timescaledb_post_restore()', (select pronamespace::regnamespace from pg_proc where proname = 'timescaledb_post_restore')));
+  end if;
 end
 $$;
 


### PR DESCRIPTION
To avoid this issue:
```
8.2. Swap postgres & supabase_admin roles as we're upgrading a project with postgres as bootstrap user
SET
BEGIN
CREATE ROLE
SET
ERROR:  operation not supported on chunk tables
CONTEXT:  SQL statement "alter table _timescaledb_internal._hyper_6_248_chunk owner to postgres;"
PL/pgSQL function inline_code_block line 376 at EXECUTE
ERROR:  current transaction is aborted, commands ignored until end of transaction block
ERROR:  current transaction is aborted, commands ignored until end of transaction block
ROLLBACK
Wrappers extension not enabled. Skipping.
9. Creating new data directory, initializing database
The files belonging to this database system will be owned by user "postgres".
This user must also own the server process.
```