### PR TITLE
chore: create an isolated output for postgres, to expose debug symbols

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -273,6 +273,7 @@
           sfcgal = sfcgal;
           pg_regress = pg_regress;
           pg_prove = pkgs.perlPackages.TAPParserSourceHandlerpgTAP;
+          postgresql_15 = pkgs.postgresql_15;
           # Start a version of the server.
           start-server =
             let

--- a/flake.nix
+++ b/flake.nix
@@ -274,6 +274,29 @@
           pg_regress = pg_regress;
           pg_prove = pkgs.perlPackages.TAPParserSourceHandlerpgTAP;
           postgresql_15 = pkgs.postgresql_15;
+
+          postgresql_15_src = pkgs.stdenv.mkDerivation {
+            pname = "postgresql-15-src";
+            version = pkgs.postgresql_15.version;
+
+            src = pkgs.postgresql_15.src;
+
+            nativeBuildInputs = [ pkgs.bzip2 ];
+
+            phases = [ "unpackPhase" "installPhase" ];
+
+            installPhase = ''
+              mkdir -p $out
+              cp -r . $out
+            '';
+
+            meta = with pkgs.lib; {
+              description = "PostgreSQL 15 source files";
+              homepage = "https://www.postgresql.org/";
+              license = licenses.postgresql;
+              platforms = platforms.all;
+            };
+          };
           # Start a version of the server.
           start-server =
             let


### PR DESCRIPTION
This is a small PR to expose only the underlying postgresql_15 package. It turns out that postgresql in nixpkgs are already built with debug symbols enabled, but in a separate directory which is considered the best practice.

To access these symbols you can run

```bash
nix build .#postgresql_15.debug && nix derivation show .#postgresql_15.debug | jq -r '.[].env.debug'
/nix/store/pxx1mdvxdq932km87a8d8q4nqvadpspy-postgresql-15.6-debug
```

Then use `/nix/store/<yourpath>-postgresql-15.6-debug`  in your debugger and these will be the corresponding debug symbols for the current version of postgresql_15 

this same method will work going forward with our own packaging of postgresql as well. 