### PR TITLE
Sam/postgres 15 8

### DIFF
--- a/common-nix.vars.pkr.hcl
+++ b/common-nix.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.6.1.124"
+postgres-version = "15.8.1.000"

--- a/flake.lock
+++ b/flake.lock
@@ -107,11 +107,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1712666087,
-        "narHash": "sha256-WwjUkWsjlU8iUImbivlYxNyMB1L5YVqE8QotQdL9jWc=",
+        "lastModified": 1726142289,
+        "narHash": "sha256-Jks8O42La+nm5AMTSq/PvM5O+fUAhIy0Ce1QYqLkyZ4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a76c4553d7e741e17f289224eda135423de0491d",
+        "rev": "280db3decab4cbeb22a4599bd472229ab74d25e1",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -107,11 +107,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1726142289,
-        "narHash": "sha256-Jks8O42La+nm5AMTSq/PvM5O+fUAhIy0Ce1QYqLkyZ4=",
+        "lastModified": 1712666087,
+        "narHash": "sha256-WwjUkWsjlU8iUImbivlYxNyMB1L5YVqE8QotQdL9jWc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "280db3decab4cbeb22a4599bd472229ab74d25e1",
+        "rev": "a76c4553d7e741e17f289224eda135423de0491d",
         "type": "github"
       },
       "original": {

--- a/nix/postgresql/15.nix
+++ b/nix/postgresql/15.nix
@@ -1,4 +1,4 @@
 import ./generic.nix {
-  version = "15.7";
-  hash = "sha256-pG/klIWrY4Xjnau7tlT10wSSBvds1pXiJCaHKVIJmPc=";
+  version = "15.8";
+  hash = "sha256-RANRX5pp7rPv68mPMLjGlhIr/fiV6Ss7I/W452nty2o=";
 }

--- a/nix/postgresql/15.nix
+++ b/nix/postgresql/15.nix
@@ -1,4 +1,4 @@
 import ./generic.nix {
-  version = "15.6";
-  hash = "sha256-hFUUbtnGnJOlfelUrq0DAsr60DXCskIXXWqh4X68svs=";
+  version = "15.7";
+  hash = "sha256-pG/klIWrY4Xjnau7tlT10wSSBvds1pXiJCaHKVIJmPc=";
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR advances postgres 15 minor version to  15.8 from 15.6

nixpkgs remains pinned to the same version, as moving it forward breaks the build for pg_graphql. Advancing nixpkgs version will happen in a follow up PR.

There is also a small change to just use the latest version of v8 for plv8 instead of overriding and specifying, in an attempt to avoid triggering a re-build of the v8 package. 