### PR TITLE
pg16 blocker - Update timescaledb apache to 2.16.1

### DIFF
--- a/nix/ext/timescaledb.nix
+++ b/nix/ext/timescaledb.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "timescaledb${lib.optionalString (!enableUnfree) "-apache"}";
-  version = "2.9.1";
+  version = "2.16.1";
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ postgresql openssl libkrb5 ];
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     owner = "timescale";
     repo = "timescaledb";
     rev = version;
-    hash = "sha256-fvVSxDiGZAewyuQ2vZDb0I6tmlDXl6trjZp8+qDBtb8=";
+    hash = "sha256-sLxWdBmih9mgiO51zLLxn9uwJVYc5JVHJjSWoADoJ+w=";
   };
 
   cmakeFlags = [ "-DSEND_TELEMETRY_DEFAULT=OFF" "-DREGRESS_CHECKS=OFF" "-DTAP_CHECKS=OFF" ]


### PR DESCRIPTION
Updates from 2.9.1 to 2.16.1

This update unblocks Postgres 16 as 2.9.1 does not support pg16

- [Changelog](https://github.com/timescale/timescaledb/blob/main/CHANGELOG.md#2161-2024-08-06)

Public Interface Changes (removed functions)
- public | add_data_node
- public | alter_data_node
- public | attach_data_node
- public | create_distributed_hypertable
- public | create_distributed_restore_point
- public | delete_data_node
- public | detach_data_node
- public | distributed_exec
- public | set_replication_factor
- public | timescaledb_fdw_handler
- public | timescaledb_fdw_validator

All of those relate to distributed hypertables which are no longer supported by timescale AO version 2.13. Its possible but very unlikely this functionality was used on the platform, and less likely that there is anything in pg_depends that would break an upgrade. 

We'll have to call this "risk accepted"

Note: There are some other function signature changes in `_internal` schemas