### PR TITLE
pg16 blocker - Update pgsql_http

### DIFF
--- a/nix/ext/pgsql-http.nix
+++ b/nix/ext/pgsql-http.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "pgsql-http";
-  version = "1.5.0";
+  version = "1.6.0";
 
   buildInputs = [ curl postgresql ];
 
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner = "pramsey";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-+N/CXm4arRgvhglanfvO0FNOBUWV5RL8mn/9FpNvcjY=";
+    hash = "sha256-CPHfx7vhWfxkXsoKTzyFuTt47BPMvzi/pi1leGcuD60=";
   };
 
   installPhase = ''


### PR DESCRIPTION
Updates pgsql_http to 1.6.0 for pg16 support. Technically it already worked but this version is the first where its tested for.

There are 2 new functions in the API. No breaking changes. Test output did not need to be updated