### PR TITLE
fix: schema name escaping

### DIFF
--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/common.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/common.sh
@@ -341,7 +341,7 @@ begin
                             else obj->>'role'
                        end
                      , case when obj->>'schema' is null then ''
-                            else format('in schema %s', (obj->>'schema')::regnamespace)
+                            else format('in schema %I', obj->>'schema')
                        end
                      , rec.privilege_type
                      , case when obj->>'objtype' = 'r' then 'tables'
@@ -369,7 +369,7 @@ begin
         execute(format('alter default privileges for role %I %s grant %s on %s to %s %s'
                      , obj->>'role'
                      , case when obj->>'schema' is null then ''
-                            else format('in schema %s', (obj->>'schema')::regnamespace)
+                            else format('in schema %I', obj->>'schema')
                        end
                      , rec.privilege_type
                      , case when obj->>'objtype' = 'r' then 'tables'


### PR DESCRIPTION
`schemaname::regnamespace` only works if the name is already quoted - e.g. for a schema named `MySchema`, `'"MySchema"'::regnamespace` works but `'MySchema'::regnamespace` doesn't. So we use `%I` formatting instead.

- [x] sanity tested on stg:
```
create schema "MySchema";
alter default privileges for role postgres in schema "MySchema" grant all on tables to anon;
```