### PR TITLE
fix: exclude partitioned indexes when swapping owners

### DIFF
--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/common.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/common.sh
@@ -196,7 +196,7 @@ declare
     where true
       and n.nspname != 'information_schema'
       and not starts_with(n.nspname, 'pg_')
-      and c.relkind not in ('c', 'i')
+      and c.relkind not in ('c', 'i', 'I')
   );
   rec record;
   obj jsonb;


### PR DESCRIPTION
```
ERROR:  cannot change owner of index "mytable_pkey"
HINT:  Change the ownership of the index's table, instead.
CONTEXT:  SQL statement "alter table myschema.mytable_pkey owner to postgres;"
```