### PR TITLE
chore: Set precedence to use ipv4 resolution in gettaddrinfo

### DIFF
--- a/ansible/tasks/internal/optimizations.yml
+++ b/ansible/tasks/internal/optimizations.yml
@@ -37,3 +37,10 @@
     - popularity-contest
     - ubuntu-advantage-tools
   when: debpkg_mode or stage2_nix
+
+- name: prefer ipv4 connection resolution
+  become: yes
+  replace:
+    path: /etc/gai.conf
+    regexp: "#precedence ::ffff:0:0/96  100"
+    replace: "precedence ::ffff:0:0/96  100"

--- a/common-nix.vars.pkr.hcl
+++ b/common-nix.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.6.1.121"
+postgres-version = "15.6.1.122"


### PR DESCRIPTION
* By default address resolution will look to use IPv6 addresses
* This change allows IPv4 address lookup to be preferred and is necessary when ensuring traffic is routed through a dedicated IPv4 address on AWS
* Has no effect on instances without a dedicated IPv4 address
