### PR TITLE
fix: disable pgsodium event trigger when swapping roles

### DIFF
--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/common.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/common.sh
@@ -203,6 +203,10 @@ declare
 begin
   set local search_path = '';
 
+  if exists (select from pg_event_trigger where evtname = 'pgsodium_trg_mask_update') then
+    alter event trigger pgsodium_trg_mask_update disable;
+  end if;
+
   alter role postgres rename to supabase_admin_;
   alter role supabase_admin rename to postgres;
   alter role supabase_admin_ rename to supabase_admin;
@@ -507,6 +511,10 @@ begin
       execute(format('grant %s on table %s to %s %s', rec.privilege_type, (obj->>'oid')::oid::regclass, rec.grantee::regrole, case when rec.is_grantable then 'with grant option' else '' end));
     end loop;
   end loop;
+
+  if exists (select from pg_event_trigger where evtname = 'pgsodium_trg_mask_update') then
+    alter event trigger pgsodium_trg_mask_update enable;
+  end if;
 end
 $$;
 


### PR DESCRIPTION
pgsodium drops `decrypted_*` views when we run `alter table ... owner to ...`, making the [list of relations](https://github.com/supabase/postgres/blob/5e431fa3ddf204b7fe6072260167c3e1d2f27e7e/ansible/files/admin_api_scripts/pg_upgrade_scripts/common.sh#L188) stale. This causes [some grants](https://github.com/supabase/postgres/blob/5e431fa3ddf204b7fe6072260167c3e1d2f27e7e/ansible/files/admin_api_scripts/pg_upgrade_scripts/common.sh#L511) to fail because these views no longer exist when the grants are run.

- [x] Sanity tested on stg:
```
CREATE TABLE public.users (
	id bigserial primary key,
	secret text);

select * from pgsodium.create_key();

SECURITY LABEL FOR pgsodium	ON COLUMN public.users.secret
  IS 'ENCRYPT WITH KEY ID <the key>';
```