### PR TITLE
pg16 blocker - Update postgis

### DIFF
--- a/migrations/tests/extensions/01-postgis.sql
+++ b/migrations/tests/extensions/01-postgis.sql
@@ -19,7 +19,7 @@ grant all privileges on all sequences in schema tiger, tiger_data to postgres wi
 alter default privileges in schema tiger, tiger_data grant all on tables to postgres with grant option;
 alter default privileges in schema tiger, tiger_data grant all on routines to postgres with grant option;
 alter default privileges in schema tiger, tiger_data grant all on sequences to postgres with grant option;
-
+SET search_path TO extensions, public, tiger, tiger_data;
 -- postgres role should have access
 set local role postgres;
 select tiger.pprint_addy(tiger.pagc_normalize_address('710 E Ben White Blvd, Austin, TX 78704'));

--- a/nix/ext/postgis.nix
+++ b/nix/ext/postgis.nix
@@ -22,13 +22,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "postgis";
-  version = "3.3.2";
+  version = "3.3.7";
 
   outputs = [ "out" "doc" ];
 
   src = fetchurl {
     url = "https://download.osgeo.org/postgis/source/postgis-${version}.tar.gz";
-    sha256 = "sha256-miohnaAFoXMKOdGVmhx87GGbHvsAm2W+gP/CW60pkGg=";
+    sha256 = "sha256-UHJKDd5JrcJT5Z4CTYsY/va+ToU0GUPG1eHhuXTkP84=";
   };
 
   buildInputs = [ libxml2 postgresql geos proj gdal json_c protobufc pcre2.dev sfcgal ]


### PR DESCRIPTION
Bump postgis 3.3.1 to 3.3.7 for pg 16 (and 17) support

There is no public interface difference. The diff exists in files changed because functions signatures for the postgis_tiger_geocoder including the type `norm_addy` went from being went from schema qualified e.g. `tiger.norm_addy` to unqualified `norm_addy`
