### PR TITLE
chore: bump aio image version, 15.1.1.90 on DockerHub is a tad broken and outdated, e.g. it has the removed pg_backtrace

### DIFF
--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.1.90"
+postgres-version = "15.1.1.93"


### PR DESCRIPTION
15.1.1.93 since there are already 15.1.1.91 and 15.1.1.92 versions on
Docker Hub.
