### PR TITLE
Sam/plv8 version update

### DIFF
--- a/nix/ext/0001-build-Allow-using-V8-from-system.patch
+++ b/nix/ext/0001-build-Allow-using-V8-from-system.patch
@@ -1,46 +1,44 @@
 diff --git a/Makefile b/Makefile
-index 38879cc..6e78eeb 100644
+index a705c11..08b952b 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -20,6 +20,7 @@ OBJS = $(SRCS:.cc=.o)
+@@ -13,11 +13,14 @@ OBJS = $(SRCS:.cc=.o)
  MODULE_big = plv8-$(PLV8_VERSION)
  EXTENSION = plv8
- PLV8_DATA = plv8.control plv8--$(PLV8_VERSION).sql $(wildcard upgrade/*.sql)
+ PLV8_DATA = plv8.control plv8--$(PLV8_VERSION).sql
 +USE_SYSTEM_V8 = 0
  
- 
- # Platform detection
-@@ -41,6 +42,7 @@ PGXS := $(shell $(PG_CONFIG) --pgxs)
- PG_VERSION_NUM := $(shell cat `$(PG_CONFIG) --includedir-server`/pg_config*.h \
- 		   | perl -ne 'print $$1 and exit if /PG_VERSION_NUM\s+(\d+)/')
+ ifeq ($(OS),Windows_NT)
+ 	# noop for now
+ else
++	ifeq ($(USE_SYSTEM_V8),0)
+ 	SHLIB_LINK += -Ldeps/v8-cmake/build
++	endif
+ 	UNAME_S := $(shell uname -s)
+ 	ifeq ($(UNAME_S),Darwin)
+ 		CCFLAGS += -stdlib=libc++
+@@ -34,6 +37,7 @@ ifeq ($(NUMPROC),0)
+ 	NUMPROC = 1
+ endif
  
 +ifeq ($(USE_SYSTEM_V8),0)
- AUTOV8_DIR = build/v8
- AUTOV8_OUT = build/v8/out.gn/obj
- AUTOV8_STATIC_LIBS = -lv8_libplatform -lv8_libbase
-@@ -66,6 +68,7 @@ v8:
- 	make -f Makefiles/Makefile.macos v8
- endif
- endif
+ SHLIB_LINK += -Ldeps/v8-cmake/build
+ 
+ all: v8 $(OBJS)
+@@ -46,11 +50,16 @@ deps/v8-cmake/build/libv8_libbase.a:
+ 	@cd deps/v8-cmake && mkdir -p build && cd build && cmake -Denable-fPIC=ON -DCMAKE_BUILD_TYPE=Release ../ && make -j $(NUMPROC)
+ 
+ v8: deps/v8-cmake/build/libv8_libbase.a
++else
++all: $(OBJS)
 +endif
  
  # enable direct jsonb conversion by default
  CCFLAGS += -DJSONB_DIRECT_CONVERSION
-@@ -83,6 +86,7 @@ ifdef BIGINT_GRACEFUL
- endif
- 
  
 +ifeq ($(USE_SYSTEM_V8),0)
- # We're gonna build static link.  Rip it out after include Makefile
- SHLIB_LINK := $(filter-out -lv8, $(SHLIB_LINK))
- 
-@@ -101,6 +105,7 @@ else
- 		SHLIB_LINK += -lrt -std=c++14 
- 	endif
- endif
+ CCFLAGS += -Ideps/v8-cmake/v8/include -std=c++17
 +endif
  
- DATA = $(PLV8_DATA)
- ifndef DISABLE_DIALECT
--- 
-2.37.3
+ ifdef EXECUTION_TIMEOUT
+ 	CCFLAGS += -DEXECUTION_TIMEOUT

--- a/nix/ext/0001-build-Allow-using-V8-from-system.patch
+++ b/nix/ext/0001-build-Allow-using-V8-from-system.patch
@@ -1,44 +1,46 @@
 diff --git a/Makefile b/Makefile
-index a705c11..08b952b 100644
+index 38879cc..6e78eeb 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -13,11 +13,14 @@ OBJS = $(SRCS:.cc=.o)
+@@ -20,6 +20,7 @@ OBJS = $(SRCS:.cc=.o)
  MODULE_big = plv8-$(PLV8_VERSION)
  EXTENSION = plv8
  PLV8_DATA = plv8.control plv8--$(PLV8_VERSION).sql
 +USE_SYSTEM_V8 = 0
  
- ifeq ($(OS),Windows_NT)
- 	# noop for now
- else
-+	ifeq ($(USE_SYSTEM_V8),0)
- 	SHLIB_LINK += -Ldeps/v8-cmake/build
-+	endif
- 	UNAME_S := $(shell uname -s)
- 	ifeq ($(UNAME_S),Darwin)
- 		CCFLAGS += -stdlib=libc++
-@@ -34,6 +37,7 @@ ifeq ($(NUMPROC),0)
- 	NUMPROC = 1
- endif
+ 
+ # Platform detection
+@@ -41,6 +42,7 @@ PGXS := $(shell $(PG_CONFIG) --pgxs)
+ PG_VERSION_NUM := $(shell cat `$(PG_CONFIG) --includedir-server`/pg_config*.h \
+ 		   | perl -ne 'print $$1 and exit if /PG_VERSION_NUM\s+(\d+)/')
  
 +ifeq ($(USE_SYSTEM_V8),0)
- SHLIB_LINK += -Ldeps/v8-cmake/build
- 
- all: v8 $(OBJS)
-@@ -46,11 +50,16 @@ deps/v8-cmake/build/libv8_libbase.a:
- 	@cd deps/v8-cmake && mkdir -p build && cd build && cmake -Denable-fPIC=ON -DCMAKE_BUILD_TYPE=Release ../ && make -j $(NUMPROC)
- 
- v8: deps/v8-cmake/build/libv8_libbase.a
-+else
-+all: $(OBJS)
+ AUTOV8_DIR = build/v8
+ AUTOV8_OUT = build/v8/out.gn/obj
+ AUTOV8_STATIC_LIBS = -lv8_libplatform -lv8_libbase
+@@ -66,6 +68,7 @@ v8:
+ 	make -f Makefiles/Makefile.macos v8
+ endif
+ endif
 +endif
  
  # enable direct jsonb conversion by default
  CCFLAGS += -DJSONB_DIRECT_CONVERSION
+@@ -83,6 +86,7 @@ ifdef BIGINT_GRACEFUL
+ endif
+ 
  
 +ifeq ($(USE_SYSTEM_V8),0)
- CCFLAGS += -Ideps/v8-cmake/v8/include -std=c++17
+ # We're gonna build static link.  Rip it out after include Makefile
+ SHLIB_LINK := $(filter-out -lv8, $(SHLIB_LINK))
+ 
+@@ -101,6 +105,7 @@ else
+ 		SHLIB_LINK += -lrt -std=c++14 
+ 	endif
+ endif
 +endif
  
- ifdef EXECUTION_TIMEOUT
- 	CCFLAGS += -DEXECUTION_TIMEOUT
+ DATA = $(PLV8_DATA)
+ ifndef DISABLE_DIALECT
+-- 
+2.37.3

--- a/nix/ext/plv8.nix
+++ b/nix/ext/plv8.nix
@@ -1,7 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitHub
-, nodejs_20
+, v8
 , perl
 , postgresql
 # For test
@@ -10,17 +10,15 @@
 , gnugrep
 }:
 
-let
-  libv8 = nodejs_20.libv8;
-in stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation (finalAttrs: {
   pname = "plv8";
-  version = "3.2.2";
+  version = "3.1.10";
 
   src = fetchFromGitHub {
     owner = "plv8";
     repo = "plv8";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-azO33v22EF+/sTNmwswxyDR0PhrvWfTENuLu6JgSGJ0=";
+    hash = "sha256-g1A/XPC0dX2360Gzvmo9/FSQnM6Wt2K4eR0pH0p9fz4=";
   };
 
   patches = [
@@ -34,7 +32,7 @@ in stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    libv8
+    v8
     postgresql
   ];
 
@@ -44,7 +42,7 @@ in stdenv.mkDerivation (finalAttrs: {
     # Nixpkgs build a v8 monolith instead of separate v8_libplatform.
     "USE_SYSTEM_V8=1"
     "SHLIB_LINK=-lv8"
-    "V8_OUTDIR=${libv8}/lib"
+    "V8_OUTDIR=${v8}/lib"
   ];
 
   installFlags = [
@@ -57,6 +55,8 @@ in stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     patchShebangs ./generate_upgrade.sh
+    substituteInPlace generate_upgrade.sh \
+      --replace " 2.3.10 " " 2.3.10 2.3.11 2.3.12 2.3.13 2.3.14 2.3.15 "
   '';
 
   postInstall = ''


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR updates plv8 to 3.1.10 which is the last version of the project that still builds plcoffee, plls, plv8 and also is has support for pg16 (although this still needs to be tested and we may need to make contributions to plv8 or patches on our end to round out support after testing)


Notes: we need to move to plv8 3.2.x to support using v8 sourced from nodejs 20_x will be in a future PR. 

This PR has been tested on `aarch64-darwin x86_64-linux aarch-64-linux` 