### PR TITLE
feat: enable runtime configuration reloads for auth

### DIFF
--- a/ansible/files/gotrue-optimizations.service.j2
+++ b/ansible/files/gotrue-optimizations.service.j2
@@ -5,6 +5,7 @@ Description=GoTrue (Auth) optimizations
 Type=oneshot
 # we don't want failures from this command to cause PG startup to fail
 ExecStart=/bin/bash -c "/opt/supabase-admin-api optimize auth --destination-config-file-path /etc/gotrue/gotrue.generated.env ; exit 0"
+ExecStartPost=/bin/bash -c "cp -a /etc/gotrue/gotrue.generated.env /etc/auth.d/20_generated.env ; exit 0"
 User=postgrest
 
 [Install]

--- a/ansible/files/gotrue.service.j2
+++ b/ansible/files/gotrue.service.j2
@@ -4,7 +4,7 @@ Description=Gotrue
 [Service]
 Type=simple
 WorkingDirectory=/opt/gotrue
-ExecStart=/opt/gotrue/gotrue
+ExecStart=/opt/gotrue/gotrue --config-dir /etc/auth.d
 User=gotrue
 Restart=always
 RestartSec=3

--- a/ansible/tasks/setup-gotrue.yml
+++ b/ansible/tasks/setup-gotrue.yml
@@ -30,6 +30,13 @@
     owner: gotrue
     mode: 0775
 
+- name: gotrue - create /etc/auth.d
+  file:
+    path: /etc/auth.d
+    state: directory
+    owner: gotrue
+    mode: 0755
+
 - name: gotrue - unpack archive in /opt/gotrue
   unarchive:
     remote_src: yes


### PR DESCRIPTION
As part of a longer term goal to support runtime configuration loading the auth team would like to make use of the `--config-dir` flag and ensure the `/etc/auth.d` folder is created. (Related: [auth - feat: config reloading](https://github.com/supabase/auth/pull/1771))

This is a small diff doing three things:

- Create the `/etc/auth.d` directory.
- Copies the `gotrue-optimizations.service.j2` to also copy the `gotrue.generated.env` file to the `/etc/auth.d` directory.
- Change the `gotrue.service.j2` to use the `--config-dir` flag set to the newly created `/etc/auth.d` directory.


## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Right now `gotrue.service` is started without the `--config-dir` flag.

## What is the new behavior?

The `gotrue.service`  will be started with the `--config-dir` flag, causing the service to reload configuration changes at runtime.

## Additional context

I tested this change and did notice the machines I have access to do not have the `/etc/gotrue` folder created, I also did not see that folder in the ansible configuration files. I chose to be safe and copy the same invalid path. If the path was an oversight and we want to also update the path of the generated config file to something that exists, I'm open to including that change here.