### PR TITLE
feat: bump auth to v2.161.0

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -17,8 +17,8 @@ postgrest_release: "12.2.3"
 postgrest_arm_release_checksum: sha1:fbfd6613d711ce1afa25c42d5df8f1b017f396f9
 postgrest_x86_release_checksum: sha1:61c513f91a8931be4062587b9d4a18b42acf5c05
 
-gotrue_release: 2.160.0
-gotrue_release_checksum: sha1:391b3f174e3d82cc806b2ba8d65253b7b2c874a6
+gotrue_release: 2.161.0
+gotrue_release_checksum: sha1:8e45f3511fee8f99a0b1567c73673991a0a5986c
 
 aws_cli_release: "2.2.7"
 

--- a/common-nix.vars.pkr.hcl
+++ b/common-nix.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.6.1.123"
+postgres-version = "15.6.1.124"


### PR DESCRIPTION
Bumps Auth to v2.161.0: https://github.com/supabase/auth/releases/tag/v2.161.0