### PR TITLE
Update timescale derivation to disallow non-apache configs

### DIFF
--- a/nix/ext/timescaledb.nix
+++ b/nix/ext/timescaledb.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, postgresql, openssl, libkrb5, enableUnfree ? true }:
+{ lib, stdenv, fetchFromGitHub, cmake, postgresql, openssl, libkrb5 }:
 
 stdenv.mkDerivation rec {
   pname = "timescaledb-apache";
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     changelog = "https://github.com/timescale/timescaledb/blob/${version}/CHANGELOG.md";
     maintainers = with maintainers; [ samrose ];
     platforms = postgresql.meta.platforms;
-    license = with licenses; if enableUnfree then tsl else asl20;
+    license = licenses.asl20;
     broken = versionOlder postgresql.version "13";
   };
 }

--- a/nix/ext/timescaledb.nix
+++ b/nix/ext/timescaledb.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, cmake, postgresql, openssl, libkrb5, enableUnfree ? true }:
 
 stdenv.mkDerivation rec {
-  pname = "timescaledb${lib.optionalString (!enableUnfree) "-apache"}";
+  pname = "timescaledb-apache";
   version = "2.16.1";
 
   nativeBuildInputs = [ cmake ];
@@ -14,8 +14,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-sLxWdBmih9mgiO51zLLxn9uwJVYc5JVHJjSWoADoJ+w=";
   };
 
-  cmakeFlags = [ "-DSEND_TELEMETRY_DEFAULT=OFF" "-DREGRESS_CHECKS=OFF" "-DTAP_CHECKS=OFF" ]
-    ++ lib.optionals (!enableUnfree) [ "-DAPACHE_ONLY=ON" ]
+  cmakeFlags = [ "-DSEND_TELEMETRY_DEFAULT=OFF" "-DREGRESS_CHECKS=OFF" "-DTAP_CHECKS=OFF" "-DAPACHE_ONLY=1" ]
     ++ lib.optionals stdenv.isDarwin [ "-DLINTER=OFF" ];
 
   # Fix the install phase which tries to install into the pgsql extension dir,

--- a/nix/tests/expected/timescale.out
+++ b/nix/tests/expected/timescale.out
@@ -1,3 +1,10 @@
+-- Confirm we're running the apache version
+show timescaledb.license;
+ timescaledb.license 
+---------------------
+ apache
+(1 row)
+
 -- Create schema v
 create schema v;
 -- Create a table in the v schema

--- a/nix/tests/sql/timescale.sql
+++ b/nix/tests/sql/timescale.sql
@@ -1,3 +1,6 @@
+-- Confirm we're running the apache version
+show timescaledb.license;
+
 -- Create schema v
 create schema v;
 


### PR DESCRIPTION
Updates the timescaledb extension derivation such that it always builds the Apache 