### PR TITLE
chore: add pgrest v12.2 metrics endpoint as adminapi upstream source on AIO

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Aside from having [ufw](https://help.ubuntu.com/community/UFW),[fail2ban](https:
 | Goodie | Version | Description |
 | ------------- | :-------------: | ------------- |
 | [PgBouncer](https://www.pgbouncer.org/) | [1.16.1](http://www.pgbouncer.org/changelog.html#pgbouncer-116x) | Set up Connection Pooling. |
-| [PostgREST](https://postgrest.org/en/stable/) | [v10.1.1](https://github.com/PostgREST/postgrest/releases/tag/v10.1.1) | Instantly transform your database into an RESTful API. |
+| [PostgREST](https://postgrest.org/en/stable/) | [v12.2.3](https://github.com/PostgREST/postgrest/releases/tag/v12.2.3) | Instantly transform your database into an RESTful API. |
 | [WAL-G](https://github.com/wal-g/wal-g#wal-g) | [v2.0.1](https://github.com/wal-g/wal-g/releases/tag/v2.0.1) | Tool for physical database backup and recovery. |
 
 ## Install

--- a/docker/all-in-one/etc/adminapi/adminapi.yaml
+++ b/docker/all-in-one/etc/adminapi/adminapi.yaml
@@ -42,6 +42,13 @@ upstream_metrics_sources:
         value: {{ .ProjectRef }}
       - name: service_type
         value: gotrue
+  - name: postgrest
+    url: "http://localhost:3001/metrics"
+    labels_to_attach:
+      - name: supabase_project_ref
+        value: {{ .ProjectRef }}
+      - name: service_type
+        value: postgrest
 monitoring:
   disk_usage:
     enabled: true

--- a/testinfra/test_ami.py
+++ b/testinfra/test_ami.py
@@ -65,6 +65,10 @@ upstream_metrics_sources:
         name: gotrue
         url: 'http://localhost:9122/metrics'
         labels_to_attach: [{name: supabase_project_ref, value: aaaaaaaaaaaaaaaaaaaa}, {name: service_type, value: gotrue}]
+    -
+        name: postgrest
+        url: 'http://localhost:3001/metrics'
+        labels_to_attach: [{name: supabase_project_ref, value: aaaaaaaaaaaaaaaaaaaa}, {name: service_type, value: postgrest}]
 monitoring:
     disk_usage:
         enabled: true

--- a/testinfra/test_ami_nix.py
+++ b/testinfra/test_ami_nix.py
@@ -65,6 +65,10 @@ upstream_metrics_sources:
         name: gotrue
         url: 'http://localhost:9122/metrics'
         labels_to_attach: [{name: supabase_project_ref, value: aaaaaaaaaaaaaaaaaaaa}, {name: service_type, value: gotrue}]
+    -
+        name: postgrest
+        url: 'http://localhost:3001/metrics'
+        labels_to_attach: [{name: supabase_project_ref, value: aaaaaaaaaaaaaaaaaaaa}, {name: service_type, value: postgrest}]
 monitoring:
     disk_usage:
         enabled: true


### PR DESCRIPTION
Follow up from https://github.com/supabase/infrastructure/pull/19946, which adds to our AIO image, pgrest >= v12.2 /metrics endpoint to `upstream_metrics_sources`.