### PR TITLE
Upgrade pg_graphql to 1.5.8

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -117,7 +117,7 @@ libsodium_release_checksum: sha256:6f504490b342a4f8a4c4a02fc9b866cbef8622d5df4e5
 pgsodium_release: "3.1.8"
 pgsodium_release_checksum: sha256:4d027aeee5163f3f33740d269938a120d1593a41c3701c920d2a1de80aa97486
 
-pg_graphql_release: "1.5.7"
+pg_graphql_release: "1.5.8"
 
 pg_jsonschema_release: "0.2.0"
 

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.1.93"
+postgres-version = "15.1.1.94"

--- a/nix/ext/pg_graphql.nix
+++ b/nix/ext/pg_graphql.nix
@@ -2,7 +2,7 @@
 
 buildPgrxExtension_0_11_3 rec {
   pname = "pg_graphql";
-  version = "1.5.7";
+  version = "1.5.8";
   inherit postgresql;
 
   src = fetchFromGitHub {
@@ -14,7 +14,7 @@ buildPgrxExtension_0_11_3 rec {
 
   nativeBuildInputs = [ cargo ];
   buildInputs = [ postgresql ];
-  
+
   CARGO="${cargo}/bin/cargo";
   #darwin env needs PGPORT to be unique for build to not clash with other pgrx extensions
   env = lib.optionalAttrs stdenv.isDarwin {


### PR DESCRIPTION
## What kind of change does this PR introduce?

- upgrade pg_graphql from v1.5.7 to v1.5.8

## Additional context

The patch to `pg_graphql` is backwards compatible.

## Action Items

- [ ] **New extension releases** were Checked for any breaking changes
- [ ] **Extensions compatibility** Checked
    * Proceed to [extensions compatibility testing](#extensions-compatibility-testing), mark as done after everything is completed
- [ ] **Backup and Restore** Checked
    * Proceed to [backup testing](#backup-testing) while extensions are enabled
        - After every restore, re-run the tests specified at point [3.1](#extensions-compatibility-testing)

### Extensions compatibility testing

1. Enable every extension
    1. Check Postgres’ log output for any error messages while doing so
        1. This might unearth incompatibilities due to unsupported internal functions, missing libraries, or missing permissions
2. Disable every extension
    1. Check Postgres’ log output for any cleanup-related error messages
3. Re-enable each extension
    1. Run basic tests against the features they offer, e.g.:
        1. `pg_net` - execute HTTP requests
        2. `pg_graphql` - execute queries and mutations
        3. …to be filled in

### Backup Testing

Follow the testing steps steps for all the following cases:

- Pause on new Postgres version, restore on new Postgres version
- Pause on older Postgres version, restore on new Postgres version
- Run a single-file backup backup, restore the backup

#### Testing steps

1. Generate dummy data 
    * the ‘Countries’ or ‘Slack clone’ SQL editor snippets are decent datasets to work with, albeit limited
2. Save a db stats snapshot file
    * Do this by running `supa db-stats gather -p <project_ref>`
3. Backup the database, through pausing the project, or otherwise
4. Restore the backup, through unpausing the project or cli
5. Check the data has been recovered successfully
    1. Visual checks/navigating through the tables works
    2. Run `supa db-stats verify` against the project and the previously saved file