### PR TITLE
fix: AIO - update platform defaults position on postgresql.conf

### DIFF
--- a/docker/all-in-one/entrypoint.sh
+++ b/docker/all-in-one/entrypoint.sh
@@ -101,7 +101,7 @@ function setup_postgres {
   mv /etc/postgresql.schema.sql /docker-entrypoint-initdb.d/migrations/99-schema.sql
 
   tar -xzvf "$INIT_PAYLOAD_PATH" -C / ./etc/postgresql-custom/pgsodium_root.key
-  echo "include = '/etc/postgresql-custom/postgresql-platform-defaults.conf'" >>$PG_CONF
+  sed -i "/# Automatically generated optimizations/i # Supabase Platform Defaults\ninclude = '/etc/postgresql-custom/platform-defaults.conf'\n" $PG_CONF
 
   # TODO (darora): walg enablement is temporarily performed here until changes from https://github.com/supabase/postgres/pull/639 get picked up
   # other things will still be needed in the future (auth_delay config)

--- a/docker/all-in-one/etc/postgresql-custom/postgresql-platform-defaults.conf
+++ b/docker/all-in-one/etc/postgresql-custom/postgresql-platform-defaults.conf
@@ -1,8 +1,6 @@
 # these get imported _after_ the user specified overrides
 row_security = on
 wal_level = logical
-max_wal_senders = 10
-max_replication_slots = 5
 log_connections = on
 statement_timeout = 120000
 jit = off


### PR DESCRIPTION
- (AIO) Update position of our platform defaults in postgresql.conf
- (AIO) update platform-defaults to remove keys that are setup in optimized overrides.