### PR TITLE
feat: bump gotrue version to v2.162.0

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -17,8 +17,8 @@ postgrest_release: "12.2.3"
 postgrest_arm_release_checksum: sha1:fbfd6613d711ce1afa25c42d5df8f1b017f396f9
 postgrest_x86_release_checksum: sha1:61c513f91a8931be4062587b9d4a18b42acf5c05
 
-gotrue_release: 2.161.0
-gotrue_release_checksum: sha1:8e45f3511fee8f99a0b1567c73673991a0a5986c
+gotrue_release: 2.162.0
+gotrue_release_checksum: sha1:855b23bd002577290c7d42d7042ac0f5316984b1
 
 aws_cli_release: "2.2.7"
 

--- a/common-nix.vars.pkr.hcl
+++ b/common-nix.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.8.1.000"
+postgres-version = "15.8.1.001"

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.1.93"
+postgres-version = "15.1.1.94"


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Bumps the gotrue version to v2.162.0 (see [changelog](https://github.com/supabase/auth/releases/tag/v2.162.0))
Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.