### PR TITLE
Allow user defined role for start-client

### DIFF
--- a/nix/tools/run-client.sh.in
+++ b/nix/tools/run-client.sh.in
@@ -7,6 +7,7 @@
 PSQL_VERSION="15"
 MIGRATION_FILE=""
 PORTNO="@PGSQL_DEFAULT_PORT@"
+PSQL_USER="postgres"
 
 # Function to display help
 print_help() {
@@ -15,6 +16,7 @@ print_help() {
     echo "Options:"
     echo "  -v, --version [15|16|orioledb-16]  Specify the PostgreSQL version to use (required)"
     echo "  -f, --file FILE                    Provide a custom migration script"
+    echo "  -u, --user USER                    Specify the user/role to use (default: postgres)"
     echo "  -h, --help                         Show this help message"
     echo
     echo "Description:"
@@ -29,6 +31,7 @@ print_help() {
     echo "  nix run .#start-client -- --version 15"
     echo "  nix run .#start-client -- --version 16 --file custom_migration.sql"
     echo "  nix run .#start-client -- --version 16 --port 5433"
+    echo "  nix run .#start-client -- --version 16 --user supabase_admin"
 }
 
 # Parse arguments
@@ -49,6 +52,15 @@ while [[ "$#" -gt 0 ]]; do
                 shift 2
             else
                 echo "Error: --file requires a filename"
+                exit 1
+            fi
+            ;;
+        -u|--user)
+            if [[ -n "$2" && ! "$2" =~ ^- ]]; then
+                PSQL_USER="$2"
+                shift 2
+            else
+                echo "Error: --user requires an argument"
                 exit 1
             fi
             ;;
@@ -137,4 +149,4 @@ fi
 # psql -v ON_ERROR_STOP=1 --no-password --no-psqlrc -U supabase_admin -p "$PORTNO" -h localhost -c 'SELECT extensions.pg_stat_statements_reset(); SELECT pg_stat_reset();' postgres || true
 
 # Start interactive psql session
-exec psql -U postgres -p "$PORTNO" -h localhost postgres
+exec psql -U "$PSQL_USER" -p "$PORTNO" -h localhost postgres


### PR DESCRIPTION
Add the option to pass a `-u, --user` flag to `nix run .#start-client` to set which role to start the connection with.

By default it continues to use `postgres` but you can now also use `supabase_admin` in case you're debugging a permissions issue or otherwise need security to get out of the way while working