### PR TITLE
fix: only consider pgsodium to be valid if they are in these versions

### DIFF
--- a/migrations/db/migrations/20221207154255_create_pgsodium_and_vault.sql
+++ b/migrations/db/migrations/20221207154255_create_pgsodium_and_vault.sql
@@ -9,6 +9,7 @@ BEGIN
     select count(*) = 1 
     from pg_available_extensions 
     where name = 'pgsodium'
+    and default_version in ('3.1.6', '3.1.7', '3.1.8')
   );
   
   vault_exists = (

--- a/migrations/db/migrations/20221207154255_create_pgsodium_and_vault.sql
+++ b/migrations/db/migrations/20221207154255_create_pgsodium_and_vault.sql
@@ -9,7 +9,7 @@ BEGIN
     select count(*) = 1 
     from pg_available_extensions 
     where name = 'pgsodium'
-    and default_version in ('3.1.6', '3.1.7', '3.1.8')
+    and default_version in ('3.1.6', '3.1.7', '3.1.8', '3.1.9')
   );
   
   vault_exists = (


### PR DESCRIPTION
Starting with `3.1.6` as that was the version when Vault was enabled: https://github.com/supabase/postgres/blob/ebc72e2dd3fca8e84b27976f84e639962d49b033/ansible/vars.yml#L105