### PR TITLE
fix(upgrades): wrappers 4.2.0 -> wrappers 4.2.0

### DIFF
--- a/nix/ext/wrappers/default.nix
+++ b/nix/ext/wrappers/default.nix
@@ -89,6 +89,7 @@ buildPgrxExtension_0_11_3 rec {
      echo "Warning: $main_sql_file not found"
    fi
    mv $out/lib/wrappers-${version}.so $out/lib/wrappers.so
+   ln -s $out/lib/wrappers.so $out/lib/wrappers-${version}.so
  
   echo "Creating wrappers.so symlinks to support pg_upgrade..."
   if [ -f "$out/lib/wrappers.so" ]; then


### PR DESCRIPTION
* Wrappers has had its .so file renamed to `wrappers.so`, while symlinking previous versions to this
* pg_upgrade for older AMI releases is still looking for `wrappers-${version}.so to operate the upgrade against`