### PR TITLE
Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,3 @@
-* @supabase/backend
-migrations/ @supabase/cli @supabase/backend
-docker/orioledb @supabase/postgres @supabase/backend
-common.vars.pkr.hcl @supabase/postgres @supabase/backend
+* @supabase/postgres
+.github @supabase/backend @supabase/postgres
+migrations/ @supabase/cli @supabase/backend @supabase/postgres


### PR DESCRIPTION
- `supbase/postgres` as the default owner
- `supabase/backend` approves anything in `.github/`
- `supabase/backend` continues to approve any new or edited migrations