### PR TITLE
chore: bump wrappers to v0.4.3

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -141,7 +141,7 @@ groonga_release_checksum: sha256:1c2d1a6981c1ad3f02a11aff202b15ba30cb1c6147f1fa9
 pgroonga_release: "3.0.7"
 pgroonga_release_checksum: sha256:885ff3878cc30e9030e5fc56d561bc8b66df3ede1562c9d802bc0ea04fe5c203
 
-wrappers_release: "0.4.2"
+wrappers_release: "0.4.3"
 
 hypopg_release: "1.4.1"
 hypopg_release_checksum: sha256:9afe6357fd389d8d33fad81703038ce520b09275ec00153c6c89282bcdedd6bc

--- a/nix/ext/wrappers/default.nix
+++ b/nix/ext/wrappers/default.nix
@@ -4,7 +4,7 @@
 , openssl
 , pkg-config
 , postgresql
-, buildPgrxExtension_0_11_3
+, buildPgrxExtension_0_12_6
 , cargo
 , darwin
 , jq
@@ -14,18 +14,18 @@ let
   rustVersion = "1.76.0";
   cargo = rust-bin.stable.${rustVersion}.default;
 in
-buildPgrxExtension_0_11_3 rec {
+buildPgrxExtension_0_12_6 rec {
   pname = "supabase-wrappers";
-  version = "0.4.2";
+  version = "0.4.3";
   # update the following array when the wrappers version is updated
   # required to ensure that extensions update scripts from previous versions are generated
-  previousVersions = ["0.4.1" "0.4.0" "0.3.1" "0.3.0" "0.2.0" "0.1.19" "0.1.18" "0.1.17" "0.1.16" "0.1.15" "0.1.14" "0.1.12" "0.1.11" "0.1.10" "0.1.9" "0.1.8" "0.1.7" "0.1.6" "0.1.5" "0.1.4" "0.1.1" "0.1.0"];
+  previousVersions = ["0.4.2" "0.4.1" "0.4.0" "0.3.1" "0.3.0" "0.2.0" "0.1.19" "0.1.18" "0.1.17" "0.1.16" "0.1.15" "0.1.14" "0.1.12" "0.1.11" "0.1.10" "0.1.9" "0.1.8" "0.1.7" "0.1.6" "0.1.5" "0.1.4" "0.1.1" "0.1.0"];
   inherit postgresql;
   src = fetchFromGitHub {
     owner = "supabase";
     repo = "wrappers";
     rev = "v${version}";
-    hash = "sha256-ut3IQED6ANXgabiHoEUdfSrwkuuYYSpRoeWdtBvSe64=";
+    hash = "sha256-CkoNMoh40zbQL4V49ZNYgv3JjoNWjODtTpHn+L8DdZA=";
   };
   nativeBuildInputs = [ pkg-config cargo ];
   buildInputs = [ openssl ] ++ lib.optionals (stdenv.isDarwin) [ 


### PR DESCRIPTION
## What kind of change does this PR introduce?

- upgrade `wrappers` from _v0.4.2_ to _v0.4.3_

v0.4.3 release note: https://github.com/supabase/wrappers/releases/tag/v0.4.3

## Additional context

Add any other context or screenshots.

## Action Items

- [ ] **New extension releases** were Checked for any breaking changes
- [x] **Extensions compatibility** Checked
    * Proceed to [extensions compatibility testing](#extensions-compatibility-testing), mark as done after everything is completed
- [x] **Backup and Restore** Checked
    * Proceed to [backup testing](#backup-testing) while extensions are enabled
        - After every restore, re-run the tests specified at point [3.1](#extensions-compatibility-testing)

### Extensions compatibility testing

1. Enable every extension
    1. Check Postgres’ log output for any error messages while doing so
        1. This might unearth incompatibilities due to unsupported internal functions, missing libraries, or missing permissions
2. Disable every extension
    1. Check Postgres’ log output for any cleanup-related error messages
3. Re-enable each extension
    1. Run basic tests against the features they offer, e.g.:
        1. `pg_net` - execute HTTP requests
        2. `pg_graphql` - execute queries and mutations
        3. …to be filled in

### Backup Testing

Follow the testing steps steps for all the following cases:

- Pause on new Postgres version, restore on new Postgres version
- Pause on older Postgres version, restore on new Postgres version
- Run a single-file backup backup, restore the backup

#### Testing steps

1. Generate dummy data 
    * the ‘Countries’ or ‘Slack clone’ SQL editor snippets are decent datasets to work with, albeit limited
2. Save a db stats snapshot file
    * Do this by running `supa db-stats gather -p <project_ref>`
3. Backup the database, through pausing the project, or otherwise
4. Restore the backup, through unpausing the project or cli
5. Check the data has been recovered successfully
    1. Visual checks/navigating through the tables works
    2. Run `supa db-stats verify` against the project and the previously saved file