### PR TITLE
feat: bump gotrue to v2.163.2

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -17,8 +17,8 @@ postgrest_release: "12.2.3"
 postgrest_arm_release_checksum: sha1:fbfd6613d711ce1afa25c42d5df8f1b017f396f9
 postgrest_x86_release_checksum: sha1:61c513f91a8931be4062587b9d4a18b42acf5c05
 
-gotrue_release: 2.163.1
-gotrue_release_checksum: sha1:f4f3fee930ac72cadccbbcef1ff076d72e1c31c0
+gotrue_release: 2.163.2
+gotrue_release_checksum: sha1:31889bc8c498b924c2cb3b6c4084ef6e57ed97c0
 
 aws_cli_release: "2.2.7"
 

--- a/common-nix.vars.pkr.hcl
+++ b/common-nix.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.6.1.133"
+postgres-version = "15.6.1.134"


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Bumps the gotrue version to v2.163.2 (https://github.com/supabase/auth/releases/tag/v2.163.2)

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.