### PR TITLE
fix: pkg changes for wrappers using cargo-pgrx 0.12.6

### DIFF
--- a/nix/ext/wrappers/default.nix
+++ b/nix/ext/wrappers/default.nix
@@ -11,7 +11,7 @@
 , rust-bin
 }:
 let
-  rustVersion = "1.76.0";
+  rustVersion = "1.80.0";
   cargo = rust-bin.stable.${rustVersion}.default;
 in
 buildPgrxExtension_0_12_6 rec {
@@ -27,23 +27,33 @@ buildPgrxExtension_0_12_6 rec {
     rev = "v${version}";
     hash = "sha256-CkoNMoh40zbQL4V49ZNYgv3JjoNWjODtTpHn+L8DdZA=";
   };
+  #cargoSha256 = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
   nativeBuildInputs = [ pkg-config cargo ];
-  buildInputs = [ openssl ] ++ lib.optionals (stdenv.isDarwin) [ 
+  buildInputs = [ openssl postgresql ] ++ lib.optionals (stdenv.isDarwin) [ 
     darwin.apple_sdk.frameworks.CoreFoundation 
     darwin.apple_sdk.frameworks.Security 
     darwin.apple_sdk.frameworks.SystemConfiguration 
   ];
+
+  NIX_LDFLAGS = "-L${postgresql.lib}/lib -lpq";
+
+  # Set necessary environment variables for pgrx
+  env = lib.optionalAttrs stdenv.isDarwin {
+    POSTGRES_LIB = "${postgresql}/lib";
+    RUSTFLAGS = "-C link-arg=-undefined -C link-arg=dynamic_lookup";
+    PGPORT = "5435";
+  };
+
   OPENSSL_NO_VENDOR = 1;
   #need to set this to 2 to avoid cpu starvation
   CARGO_BUILD_JOBS = "2";
   CARGO="${cargo}/bin/cargo";
+  
   cargoLock = {
     lockFile = "${src}/Cargo.lock";
-    outputHashes = {
-      "clickhouse-rs-1.0.0-alpha.1" = "sha256-0zmoUo/GLyCKDLkpBsnLAyGs1xz6cubJhn+eVqMEMaw=";
-    };
+    allowBuiltinFetchGit = true;
   };
-  postPatch = "cp ${cargoLock.lockFile} Cargo.lock";
+  
   buildAndTestSubdir = "wrappers";
   buildFeatures = [
     "helloworld_fdw"
@@ -65,6 +75,7 @@ buildPgrxExtension_0_12_6 rec {
   preBuild = ''
     echo "Processing git tags..."
     echo '${builtins.concatStringsSep "," previousVersions}' | sed 's/,/\n/g' > git_tags.txt
+    export RUSTC_BOOTSTRAP=1
   '';
 
   postInstall = ''

--- a/nix/ext/wrappers/default.nix
+++ b/nix/ext/wrappers/default.nix
@@ -27,7 +27,7 @@ buildPgrxExtension_0_12_6 rec {
     rev = "v${version}";
     hash = "sha256-CkoNMoh40zbQL4V49ZNYgv3JjoNWjODtTpHn+L8DdZA=";
   };
-  #cargoSha256 = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+ 
   nativeBuildInputs = [ pkg-config cargo ];
   buildInputs = [ openssl postgresql ] ++ lib.optionals (stdenv.isDarwin) [ 
     darwin.apple_sdk.frameworks.CoreFoundation 
@@ -35,7 +35,7 @@ buildPgrxExtension_0_12_6 rec {
     darwin.apple_sdk.frameworks.SystemConfiguration 
   ];
 
-  NIX_LDFLAGS = "-L${postgresql.lib}/lib -lpq";
+  NIX_LDFLAGS = "-L${postgresql}/lib -lpq";
 
   # Set necessary environment variables for pgrx
   env = lib.optionalAttrs stdenv.isDarwin {
@@ -75,7 +75,6 @@ buildPgrxExtension_0_12_6 rec {
   preBuild = ''
     echo "Processing git tags..."
     echo '${builtins.concatStringsSep "," previousVersions}' | sed 's/,/\n/g' > git_tags.txt
-    export RUSTC_BOOTSTRAP=1
   '';
 
   postInstall = ''


### PR DESCRIPTION
## What kind of change does this PR introduce?

The original error 

`error: A hash was specified for clickhouse-rs-1.0.0-alpha.1, but there is no corresponding git dependency.`

was resolved by 


```
  cargoLock = {
    lockFile = "${src}/Cargo.lock";
    allowBuiltinFetchGit = true;
  };
```

The newer version of the buildPgxExtension was able just to use the lockfile and the builtin fetch git capability.


In addition I added env vars for building on macOS

```
  env = lib.optionalAttrs stdenv.isDarwin {
    POSTGRES_LIB = "${postgresql}/lib";
    RUSTFLAGS = "-C link-arg=-undefined -C link-arg=dynamic_lookup";
    PGPORT = "5435";
  };
```

These weren't needed with the previous version of cargo-pgrx builder, but they are now. Similar to what we have here https://github.com/supabase/wrappers/blob/v0.4.3/.cargo/config.toml gave PGPORT a unique number which helps tests pass and avoid collisions. 


I also bumped up the version of rust in the packages to 1.80.0 which 

Added `NIX_LDFLAGS = "-L${postgresql}/lib -lpq";` for when linking, to look in PostgreSQL's lib directory and link against the PostgreSQL client library