### PR TITLE
feat: tmp disable pg_net on macos and allow for server start on macos

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -128,7 +128,8 @@
         # use, but even if they did, keeping our own copies means that we can
         # rollout new versions of these critical things easier without having to
         # go through the upstream release engineering process.
-        ourExtensions = [
+      ourExtensions = let
+        baseExtensions = [
           ./nix/ext/rum.nix
           ./nix/ext/timescaledb.nix
           ./nix/ext/pgroonga.nix
@@ -147,7 +148,6 @@
           ./nix/ext/pg_cron.nix
           ./nix/ext/pgsql-http.nix
           ./nix/ext/pg_plan_filter.nix
-          ./nix/ext/pg_net.nix
           ./nix/ext/pg_hashids.nix
           ./nix/ext/pgsodium.nix
           ./nix/ext/pg_graphql.nix
@@ -162,7 +162,13 @@
           ./nix/ext/supautils.nix
           ./nix/ext/plv8.nix
         ];
+        
+        # Add pg_net only if NOT on macOS aarch64
+        pgNetExtension = if (system == "aarch64-darwin") 
+          then []
+          else [ ./nix/ext/pg_net.nix ];
 
+        in baseExtensions ++ pgNetExtension;
         #Where we import and build the orioledb extension, we add on our custom extensions
         # plus the orioledb option
         orioledbExtension = ourExtensions ++ [ ./nix/ext/orioledb.nix ];
@@ -462,7 +468,8 @@
                 --subst-var-by 'LOCALES' '${localeArchive}' \
                 --subst-var-by 'EXTENSION_CUSTOM_SCRIPTS_DIR' "$out/extension-custom-scripts" \
                 --subst-var-by 'MECAB_LIB' '${basePackages.psql_15.exts.pgroonga}/lib/groonga/plugins/tokenizers/tokenizer_mecab.so' \
-                --subst-var-by 'GROONGA_DIR' '${supabase-groonga}' 
+                --subst-var-by 'GROONGA_DIR' '${supabase-groonga}' \
+                --subst-var-by 'CURRENT_SYSTEM' '${system}'
 
               chmod +x $out/bin/start-postgres-server
             '';

--- a/nix/tools/run-server.sh.in
+++ b/nix/tools/run-server.sh.in
@@ -32,12 +32,14 @@ EXTENSION_CUSTOM_SCRIPTS=@EXTENSION_CUSTOM_SCRIPTS_DIR@
 GROONGA=@GROONGA_DIR@
 DATDIR=$(mktemp -d)
 LOCALE_ARCHIVE=@LOCALES@
+CURRENT_SYSTEM=@CURRENT_SYSTEM@
 export LOCALE_ARCHIVE
 export LANG=en_US.UTF-8
 export LANGUAGE=en_US.UTF-8
 export LC_ALL=en_US.UTF-8
 export LANG=en_US.UTF-8
 export LC_CTYPE=en_US.UTF-8
+echo "Current system is $CURRENT_SYSTEM"
 mkdir -p "$DATDIR"
 echo "NOTE: using port $PORTNO for server"
 echo "NOTE: using temporary directory $DATDIR for data, which will not be removed"
@@ -61,5 +63,10 @@ pgsodium.getkey_script = '$PGSODIUM_GETKEY_SCRIPT'" \
 -e "\$a\\
 session_preload_libraries = 'supautils'" \
 "$PSQL_CONF_FILE" > "$DATDIR/postgresql.conf"
+if [ "$CURRENT_SYSTEM" = "aarch64-darwin" ]; then
+    echo "NOTE: using aarch64-darwin system"
+    sed -i '' 's/ pg_net,//g' "$DATDIR/postgresql.conf"
+    sed -i '' 's/ pg_net,//g' "$DATDIR/supautils.conf"
+fi
 export GRN_PLUGINS_DIR=$GROONGA/lib/groonga/plugins
 postgres --config-file="$DATDIR/postgresql.conf" -p "$PORTNO" -D "$DATDIR" -k /tmp


### PR DESCRIPTION
## What kind of change does this PR introduce?

A temporary conditional to take pg_net out of macos builds and server runs. Once macos issues are resolved for pg_net we'll revert this. 