### PR TITLE
pg_net 0.11 on 15.6 release branch

### DIFF
--- a/common-nix.vars.pkr.hcl
+++ b/common-nix.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.6.1.134"
+postgres-version = "15.6.1.135"

--- a/nix/ext/pg_net.nix
+++ b/nix/ext/pg_net.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "pg_net";
-  version = "0.10.0";
+  version = "0.11.0";
 
   buildInputs = [ curl postgresql ];
 
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner = "supabase";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-R9Mzw5gvV7b2R59LTOzuOc0AI99+3ncFNzijI4mySUg=";
+    hash = "sha256-XN441jXK1q+I/LZRNwvzbSsebXHgZ8iYsslZvcPFlAs=";
   };
 
   env.NIX_CFLAGS_COMPILE = "-Wno-error";
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/{lib,share/postgresql/extension}
 
-    cp *.so      $out/lib
+    cp *${postgresql.dlSuffix}      $out/lib
     cp sql/*.sql $out/share/postgresql/extension
     cp *.control $out/share/postgresql/extension
   '';


### PR DESCRIPTION
Upgrades pg_net from 0.10.0 to 0.11.0 on the pg 15.6 release branch.

We have multiple customers waiting for this release. Its already in the 15.8 image

Note: this version contains a MacOS incompatibility so the CI job for that will fail. Steve is working on a fix but it'll take too long to wait for