### PR TITLE
feat: update envoy lds config with auth jwks, oidc URLs, strip `sb-opk` header [15.6]

### DIFF
--- a/ansible/files/envoy_config/lds.yaml
+++ b/ansible/files/envoy_config/lds.yaml
@@ -254,8 +254,13 @@ resources:
                               type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
                       - match:
                           safe_regex:
+                            google_re2:
+                              max_program_size: 150
                             regex: >-
-                              /auth/v1/(verify|callback|authorize|sso/saml/(acs|metadata|slo))
+                              /auth/v1/(verify|callback|authorize|sso/saml/(acs|metadata|slo)|\.well-known/(openid-configuration|jwks\.json))
+                        request_headers_to_remove:
+                          - apikey
+                          - sb-opk
                         route:
                           cluster: gotrue
                           regex_rewrite:
@@ -269,6 +274,9 @@ resources:
                         typed_per_filter_config: *ref_0
                       - match:
                           prefix: /auth/v1/
+                        request_headers_to_remove:
+                          - apikey
+                          - sb-opk
                         route:
                           cluster: gotrue
                           prefix_rewrite: /
@@ -280,6 +288,7 @@ resources:
                               present_match: true
                         request_headers_to_remove:
                           - apikey
+                          - sb-opk
                         route:
                           cluster: postgrest
                           prefix_rewrite: /
@@ -293,6 +302,7 @@ resources:
                           prefix: /rest/v1/
                         request_headers_to_remove:
                           - apikey
+                          - sb-opk
                         route:
                           cluster: postgrest
                           prefix_rewrite: /
@@ -309,6 +319,7 @@ resources:
                               present_match: true
                         request_headers_to_remove:
                           - apikey
+                          - sb-opk
                         route:
                           cluster: postgrest_admin
                           prefix_rewrite: /
@@ -321,6 +332,7 @@ resources:
                           prefix: /rest-admin/v1/
                         request_headers_to_remove:
                           - apikey
+                          - sb-opk
                         route:
                           cluster: postgrest_admin
                           prefix_rewrite: /
@@ -330,18 +342,25 @@ resources:
                           header:
                             key: Content-Profile
                             value: graphql_public
+                        request_headers_to_remove:
+                          - apikey
+                          - sb-opk
                         route:
                           cluster: postgrest
                           prefix_rewrite: /rpc/graphql
                           timeout: 125s
                       - match:
                           prefix: /admin/v1/
+                        request_headers_to_remove:
+                          - sb-opk
                         route:
                           cluster: admin_api
                           prefix_rewrite: /
                           timeout: 600s
                       - match:
                           prefix: /customer/v1/privileged/
+                        request_headers_to_remove:
+                          - sb-opk
                         route:
                           cluster: admin_api
                           prefix_rewrite: /privileged/
@@ -365,6 +384,8 @@ resources:
                                           treat_missing_header_as_empty: true
                       - match:
                           prefix: /metrics/aggregated
+                        request_headers_to_remove:
+                          - sb-opk
                         route:
                           cluster: admin_api
                           prefix_rewrite: /supabase-internal/metrics

--- a/common-nix.vars.pkr.hcl
+++ b/common-nix.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.6.1.137"
+postgres-version = "15.6.1.138"


### PR DESCRIPTION
Updates the Envoy LDS file with the config coming from [this change](https://github.com/supabase/infrastructure/pull/20374).

Goal with changes:

- `sb-opk` header values should not be reaching downstream servers as this key could be accidentally logged.
- Allow new Auth public routes for asymmetric JWTs (`/auth/v1/.well-known/jwks.json` and `.../openid-configuration`).