### PR TITLE
fix: clickhouse deps needs git on path to install and/or build

### DIFF
--- a/ansible/tasks/stage2-setup-postgres.yml
+++ b/ansible/tasks/stage2-setup-postgres.yml
@@ -3,6 +3,15 @@
 #   shell: |
 #     sudo -u postgres bash -c ". /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh && nix profile install nixpkgs#openjdk11"
 # It was decided to leave pljava disabled at https://github.com/supabase/postgres/pull/690 therefore removing this task
+
+- name: Install Git for Nix package management
+  become: yes
+  apt:
+    name: git
+    state: present
+    update_cache: yes
+  when: stage2_nix
+
 - name: Install Postgres from nix binary cache
   become: yes
   shell: |
@@ -34,6 +43,14 @@
     sudo -u postgres bash -c ". /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh && nix profile install github:supabase/postgres/{{ git_commit_sha }}#{{postgresql_version}}_src"
   when: stage2_nix
 
+- name: Install Git for Nix package management
+  become: yes
+  apt:
+    name: git
+    state: present
+    update_cache: yes
+  when: stage2_nix
+  
 - name: Set ownership and permissions for /etc/ssl/private
   become: yes
   file:


### PR DESCRIPTION
## What kind of change does this PR introduce?

clickhouse deps needs git on path to install and/or build 