### PR TITLE
Feature/support mac M architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ result*
 #IDE
 .idea/
 .vscode/
+.aider*
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -830,26 +830,16 @@ ARG supautils_release_amd64_deb_checksum
 
 RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 
-# Set up a script to download the correct package
-RUN echo '#!/bin/sh' > /tmp/download_supautils.sh && \
-    echo 'set -e' >> /tmp/download_supautils.sh && \
-    echo 'if [ "$TARGETARCH" = "amd64" ]; then' >> /tmp/download_supautils.sh && \
-    echo '    CHECKSUM="${supautils_release_amd64_deb_checksum}"' >> /tmp/download_supautils.sh && \
-    echo '    ARCH="amd64"' >> /tmp/download_supautils.sh && \
-    echo 'elif [ "$TARGETARCH" = "arm64" ]; then' >> /tmp/download_supautils.sh && \
-    echo '    CHECKSUM="${supautils_release_arm64_deb_checksum}"' >> /tmp/download_supautils.sh && \
-    echo '    ARCH="arm64"' >> /tmp/download_supautils.sh && \
-    echo 'else' >> /tmp/download_supautils.sh && \
-    echo '    echo "Unsupported architecture: $TARGETARCH" >&2' >> /tmp/download_supautils.sh && \
-    echo '    exit 1' >> /tmp/download_supautils.sh && \
-    echo 'fi' >> /tmp/download_supautils.sh && \
-    echo 'CHECKSUM=$(echo $CHECKSUM | sed "s/^sha256://")' >> /tmp/download_supautils.sh && \
-    echo 'curl -fsSL -o /tmp/supautils.deb \\' >> /tmp/download_supautils.sh && \
-    echo '    "https://github.com/supabase/supautils/releases/download/v${supautils_release}/supautils-v${supautils_release}-pg${postgresql_major}-$ARCH-linux-gnu.deb"' >> /tmp/download_supautils.sh && \
-    echo 'echo "$CHECKSUM  /tmp/supautils.deb" | sha256sum -c -' >> /tmp/download_supautils.sh && \
-    chmod +x /tmp/download_supautils.sh
+# Add the external download script
+ADD scripts/download_supautils.sh /tmp/download_supautils.sh
 
 # Run the script to download and verify the package
+ARG supautils_release_arm64_deb_checksum
+ARG supautils_release_amd64_deb_checksum
+ENV supautils_release=${supautils_release} \
+    postgresql_major=${postgresql_major} \
+    supautils_release_arm64_deb_checksum=${supautils_release_arm64_deb_checksum} \
+    supautils_release_amd64_deb_checksum=${supautils_release_amd64_deb_checksum}
 RUN /tmp/download_supautils.sh && rm /tmp/download_supautils.sh
 
 ####################

--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ See all installation instructions in the [repo wiki](https://github.com/supabase
 | Supabase Postgres: PostgREST Bundle | Coming Soon | Coming Soon | Coming Soon |
 | Supabase Postgres: Complete Bundle | Coming Soon | Coming Soon | Coming Soon |
 
-### Quick Build
+### Quick Cloud Build
+
+Uses Amazon build cluster.
 
 ```bash
 $ time packer build -timestamp-ui \
@@ -87,6 +89,24 @@ $ time packer build -timestamp-ui \
   --var "ami_regions=<insert desired regions>" \
   amazon-arm.json
 ```
+
+### Quick Local Build
+
+Uses docker
+```bash
+# Setup a docker buildx instance, if not already present.
+docker buildx inspect || docker buildx create --use
+# Build all architectures
+docker buildx build \
+  $(yq 'to_entries | map(select(.value|type == "!!str")) |  map(" --build-arg " + .key + "=" + .value) | join("")' 'ansible/vars.yml') \
+  --target production \
+  --tag 'custom_supabase_postgres' \
+  --platform 'linux/arm64/v8,linux/amd64' \
+  --load \
+  .
+```
+
+After this you can use the `docker run custom_supabase_postgres` command to start your local instance.
 
 ## Motivation
 

--- a/scripts/download_supautils.sh
+++ b/scripts/download_supautils.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -e
+# Ensure mandatory environment variables are set
+: "${supautils_release:?Environment variable supautils_release is required}"
+: "${postgresql_major:?Environment variable postgresql_major is required}"
+: "${supautils_release_arm64_deb_checksum:?Environment variable supautils_release_arm64_deb_checksum is required}"
+: "${supautils_release_amd64_deb_checksum:?Environment variable supautils_release_amd64_deb_checksum is required}"
+
+# Fallback to uname -m if TARGETARCH is not set
+TARGETARCH=${TARGETARCH:-$(uname -m)}
+
+if [ "$TARGETARCH" = "amd64" ]; then
+    CHECKSUM="${supautils_release_amd64_deb_checksum}"
+    ARCH="amd64"
+elif [ "$TARGETARCH" = "arm64" ]; then
+    CHECKSUM="${supautils_release_arm64_deb_checksum}"
+    ARCH="arm64"
+else
+    echo "Unsupported architecture: $TARGETARCH" >&2
+    exit 1
+fi
+CHECKSUM=$(echo $CHECKSUM | sed "s/^sha256://")
+curl -fsSL -o /tmp/supautils.deb \
+    "https://github.com/supabase/supautils/releases/download/v${supautils_release}/supautils-v${supautils_release}-pg${postgresql_major}-$ARCH-linux-gnu.deb"
+CHECKSUM_LINE=$(echo "$CHECKSUM  /tmp/supautils.deb")
+echo "$CHECKSUM_LINE" | sha256sum -c -

--- a/scripts/download_supautils.sh
+++ b/scripts/download_supautils.sh
@@ -9,10 +9,10 @@ set -e
 # Fallback to uname -m if TARGETARCH is not set
 TARGETARCH=${TARGETARCH:-$(uname -m)}
 
-if [ "$TARGETARCH" = "amd64" ]; then
+if [ "$TARGETARCH" = "x86_64" ] || [ "$TARGETARCH" = "amd64" ]; then
     CHECKSUM="${supautils_release_amd64_deb_checksum}"
     ARCH="amd64"
-elif [ "$TARGETARCH" = "arm64" ]; then
+elif [ "$TARGETARCH" = "arm64" ] || [ "$TARGETARCH" = "aarch64" ]; then
     CHECKSUM="${supautils_release_arm64_deb_checksum}"
     ARCH="arm64"
 else


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add support for building on a mac with the M-series processors.

## What is the current behavior?

The command
```
docker buildx build \
  $(yq 'to_entries | map(select(.value|type == "!!str")) |  map(" --build-arg " + .key + "=" + .value) | join("")' 'ansible/vars.yml') \
  --target production \
  --tag 'custom_supabase_postgres' \
  --platform 'linux/arm64/v8,linux/amd64' \
  --load \
  .
```
Fails with unsupported architecture because aarch64 is not supported.

Please link any relevant issues here.

## What is the new behavior?

It builds on mac with the M1 processor.

## Additional context

I've also documented how to quickly build multi-arch images locally.