### PR TITLE
Fix suffix parsing for staging releases

### DIFF
--- a/.github/workflows/ami-release-nix.yml
+++ b/.github/workflows/ami-release-nix.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Run checks if triggered manually
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
-          SUFFIX=$(sudo nix run nixpkgs#yq -- '.postgres_release["postgres${{ matrix.postgres_version }}"]' ansible/vars.yml | sed -E 's/[0-9\.]+(.*)$/\1/')
+          SUFFIX=$(sudo nix run nixpkgs#yq -- ".postgres_release[\"postgres${{ matrix.postgres_version }}\"]" ansible/vars.yml | sed -E 's/[0-9\.]+(.*)$/\1/')
           if [[ -z $SUFFIX ]] ; then
             echo "Version must include non-numeric characters if built manually."
             exit 1


### PR DESCRIPTION
Currently, running `ami-release-nix.yml` on staging image with a suffix fails to parse with

```
copying path '/nix/store/w18zywvzwvsf5gyvs0hbbv3vlpq9zn6k-python3.12-yq-3.4.3' from 'https://cache.nixos.org/'...
jq: error: syntax error, unexpected LITERAL (Unix shell quoting issues?) at <top-level>, line 1:
.postgres_release["postgres"15""]                            
jq: 1 compile error
yq: Error running jq: BrokenPipeError: [Errno 32] Broken pipe.
Version must include non-numeric characters if built manually.
```
[ref](https://github.com/supabase/postgres/actions/runs/11615174469/job/32345148295#step:6:77)

this PR fixes the parsing issue