### PR TITLE
bump to pg_net 0.13.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -128,8 +128,7 @@
         # use, but even if they did, keeping our own copies means that we can
         # rollout new versions of these critical things easier without having to
         # go through the upstream release engineering process.
-      ourExtensions = let
-        baseExtensions = [
+        ourExtensions = [
           ./nix/ext/rum.nix
           ./nix/ext/timescaledb.nix
           ./nix/ext/pgroonga.nix
@@ -148,6 +147,7 @@
           ./nix/ext/pg_cron.nix
           ./nix/ext/pgsql-http.nix
           ./nix/ext/pg_plan_filter.nix
+          ./nix/ext/pg_net.nix
           ./nix/ext/pg_hashids.nix
           ./nix/ext/pgsodium.nix
           ./nix/ext/pg_graphql.nix
@@ -161,13 +161,7 @@
           ./nix/ext/supautils.nix
           ./nix/ext/plv8.nix
         ];
-        
-        # Add pg_net only if NOT on macOS aarch64
-        pgNetExtension = if (system == "aarch64-darwin") 
-          then []
-          else [ ./nix/ext/pg_net.nix ];
 
-        in baseExtensions ++ pgNetExtension;
         #Where we import and build the orioledb extension, we add on our custom extensions
         # plus the orioledb option
         orioledbExtension = ourExtensions ++ [ ./nix/ext/orioledb.nix ];
@@ -467,8 +461,7 @@
                 --subst-var-by 'LOCALES' '${localeArchive}' \
                 --subst-var-by 'EXTENSION_CUSTOM_SCRIPTS_DIR' "$out/extension-custom-scripts" \
                 --subst-var-by 'MECAB_LIB' '${basePackages.psql_15.exts.pgroonga}/lib/groonga/plugins/tokenizers/tokenizer_mecab.so' \
-                --subst-var-by 'GROONGA_DIR' '${supabase-groonga}' \
-                --subst-var-by 'CURRENT_SYSTEM' '${system}'
+                --subst-var-by 'GROONGA_DIR' '${supabase-groonga}' 
 
               chmod +x $out/bin/start-postgres-server
             '';

--- a/nix/ext/pg_net.nix
+++ b/nix/ext/pg_net.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "pg_net";
-  version = "0.11.0";
+  version = "0.13.0";
 
   buildInputs = [ curl postgresql ];
 
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner = "supabase";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-XN441jXK1q+I/LZRNwvzbSsebXHgZ8iYsslZvcPFlAs=";
+    hash = "sha256-FRaTZPCJQPYAFmsJg22hYJJ0+gH1tMdDQoCQgiqEnaA=";
   };
 
   env.NIX_CFLAGS_COMPILE = "-Wno-error";

--- a/nix/tools/run-server.sh.in
+++ b/nix/tools/run-server.sh.in
@@ -32,14 +32,12 @@ EXTENSION_CUSTOM_SCRIPTS=@EXTENSION_CUSTOM_SCRIPTS_DIR@
 GROONGA=@GROONGA_DIR@
 DATDIR=$(mktemp -d)
 LOCALE_ARCHIVE=@LOCALES@
-CURRENT_SYSTEM=@CURRENT_SYSTEM@
 export LOCALE_ARCHIVE
 export LANG=en_US.UTF-8
 export LANGUAGE=en_US.UTF-8
 export LC_ALL=en_US.UTF-8
 export LANG=en_US.UTF-8
 export LC_CTYPE=en_US.UTF-8
-echo "Current system is $CURRENT_SYSTEM"
 mkdir -p "$DATDIR"
 echo "NOTE: using port $PORTNO for server"
 echo "NOTE: using temporary directory $DATDIR for data, which will not be removed"
@@ -63,10 +61,5 @@ pgsodium.getkey_script = '$PGSODIUM_GETKEY_SCRIPT'" \
 -e "\$a\\
 session_preload_libraries = 'supautils'" \
 "$PSQL_CONF_FILE" > "$DATDIR/postgresql.conf"
-if [ "$CURRENT_SYSTEM" = "aarch64-darwin" ]; then
-    echo "NOTE: using aarch64-darwin system"
-    sed -i '' 's/ pg_net,//g' "$DATDIR/postgresql.conf"
-    sed -i '' 's/ pg_net,//g' "$DATDIR/supautils.conf"
-fi
 export GRN_PLUGINS_DIR=$GROONGA/lib/groonga/plugins
 postgres --config-file="$DATDIR/postgresql.conf" -p "$PORTNO" -D "$DATDIR" -k /tmp


### PR DESCRIPTION
This is now compatible with macos, so it also reverts "feat: tmp disable pg_net on macos and allow for server start on macos (#1289) 7db7e1a9e34b9ffb9b0e3372ccf08eb4fa772f4b.

- CHANGELOG for v0.12.0: https://github.com/supabase/pg_net/releases/tag/v0.12.0
- CHANGELOG for v0.13.0: https://github.com/supabase/pg_net/releases/tag/v0.13.0