### PR TITLE
pg_repack 1.5.2: Allow to run pg_repack by non-superuser

### DIFF
--- a/ansible/tasks/postgres-extensions/27-pg_repack.yml
+++ b/ansible/tasks/postgres-extensions/27-pg_repack.yml
@@ -13,7 +13,7 @@
    git:
      repo: https://github.com/reorg/pg_repack.git
      dest: /tmp/pg_repack
-     version: "ver_{{ pg_repack_release }}"
+     version: "{{ pg_repack_commit }}"
    become: yes
 
  - name: pg_repack - build

--- a/ansible/tasks/postgres-extensions/27-pg_repack.yml
+++ b/ansible/tasks/postgres-extensions/27-pg_repack.yml
@@ -13,7 +13,7 @@
    git:
      repo: https://github.com/reorg/pg_repack.git
      dest: /tmp/pg_repack
-     version: "{{ pg_repack_commit }}"
+     version: "ver_{{ pg_repack_release }}"
    become: yes
 
  - name: pg_repack - build

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -11,8 +11,8 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgres15: "15.8.1.007"
-  postgres16: "16.3.1.013"
+  postgres15: "15.8.1.008"
+  postgres16: "16.3.1.014"
 
 # Non Postgres Extensions
 pgbouncer_release: "1.19.0"
@@ -146,8 +146,7 @@ wrappers_release: "0.4.3"
 hypopg_release: "1.4.1"
 hypopg_release_checksum: sha256:9afe6357fd389d8d33fad81703038ce520b09275ec00153c6c89282bcdedd6bc
 
-pg_repack_release: "1.5.2"
-pg_repack_commit: "85b64c6d4f599b2988343c4e7121acab505c9006"
+pg_repack_release: "1.5.0"
 pg_repack_release_checksum: sha256:9a14d6a95bfa29f856aa10538238622c1f351d38eb350b196c06720a878ccc52
 
 pgvector_release: "0.7.4"

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -146,7 +146,8 @@ wrappers_release: "0.4.3"
 hypopg_release: "1.4.1"
 hypopg_release_checksum: sha256:9afe6357fd389d8d33fad81703038ce520b09275ec00153c6c89282bcdedd6bc
 
-pg_repack_release: "1.5.0"
+pg_repack_release: "1.5.2"
+pg_repack_commit: "85b64c6d4f599b2988343c4e7121acab505c9006"
 pg_repack_release_checksum: sha256:9a14d6a95bfa29f856aa10538238622c1f351d38eb350b196c06720a878ccc52
 
 pgvector_release: "0.7.4"

--- a/nix/ext/pg_repack.nix
+++ b/nix/ext/pg_repack.nix
@@ -11,15 +11,15 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pg_repack";
-  version = "1.5.0";
+  version = "1.5.2";
 
   buildInputs = postgresql.buildInputs ++ [ postgresql ];
 
   src = fetchFromGitHub {
     owner = "reorg";
     repo = "pg_repack";
-    rev = "ver_${finalAttrs.version}";
-    hash = "sha256-do80phyMxwcRIkYyUt9z02z7byNQhK+pbSaCUmzG+4c=";
+    rev = "85b64c6d4f599b2988343c4e7121acab505c9006";
+    hash = "sha256-lAuLI+vupusvn3uTzQ9OaLqkEfUVMCAwU9R70tTbb8Y=";
   };
 
   installPhase = ''


### PR DESCRIPTION
## What kind of change does this PR introduce?

- upgrade `pg_repack` from `1.5.0` to `1.5.2`.

## Additional context

New version will allow to run `pg_repack` by a non-superuser. Conversation on slack:
https://supabase.slack.com/archives/C02FHG9QQAF/p1730124043199329

PR on `pg_repack` repo:
https://github.com/reorg/pg_repack/pull/431

`1.5.2` doesn't have release or tag yet, therefore instead of the tag commit id is used (`85b64c6d4f599b2988343c4e7121acab505c9006`).

## Action Items

- [x] **New extension releases** were Checked for any breaking changes
- [x] **Extensions compatibility** Checked
    * Proceed to [extensions compatibility testing](#extensions-compatibility-testing), mark as done after everything is completed
- [ ] **Backup and Restore** Checked
    * Proceed to [backup testing](#backup-testing) while extensions are enabled
        - After every restore, re-run the tests specified at point [3.1](#extensions-compatibility-testing)

### Extensions compatibility testing

1. Enable every extension
    1. Check Postgres’ log output for any error messages while doing so
        1. This might unearth incompatibilities due to unsupported internal functions, missing libraries, or missing permissions
2. Disable every extension
    1. Check Postgres’ log output for any cleanup-related error messages
3. Re-enable each extension
    1. Run basic tests against the features they offer, e.g.:
        1. `pg_net` - execute HTTP requests
        2. `pg_graphql` - execute queries and mutations
        3. …to be filled in

### Backup Testing

Follow the testing steps steps for all the following cases:

- Pause on new Postgres version, restore on new Postgres version
- Pause on older Postgres version, restore on new Postgres version
- Run a single-file backup backup, restore the backup

#### Testing steps

1. Generate dummy data 
    * the ‘Countries’ or ‘Slack clone’ SQL editor snippets are decent datasets to work with, albeit limited
2. Save a db stats snapshot file
    * Do this by running `supa db-stats gather -p <project_ref>`
3. Backup the database, through pausing the project, or otherwise
4. Restore the backup, through unpausing the project or cli
5. Check the data has been recovered successfully
    1. Visual checks/navigating through the tables works
    2. Run `supa db-stats verify` against the project and the previously saved file