### PR TITLE
feat: add origin protection key enforcement for envoy in `lds.supabase.yaml`

### DIFF
--- a/ansible/files/envoy_config/lds.supabase.yaml
+++ b/ansible/files/envoy_config/lds.supabase.yaml
@@ -82,6 +82,27 @@ resources:
                                         name: ':path'
                                         string_match:
                                           contains: apikey=supabase_admin_key
+                        origin_protection_key_missing:
+                          permissions:
+                            - any: true
+                          principals:
+                            - not_id:
+                                or_ids:
+                                  ids:
+                                    - header:
+                                        name: sb-opk
+                                        present_match: true
+                        origin_protection_key_not_valid:
+                          permissions:
+                            - any: true
+                          principals:
+                            - not_id:
+                                or_ids:
+                                  ids:
+                                    - header:
+                                        name: sb-opk
+                                        string_match:
+                                          exact: supabase_origin_protection_key
                 - name: envoy.filters.http.lua
                   typed_config:
                     '@type': >-


### PR DESCRIPTION
Adds enforcement for the origin protection key header value in the `lds.supabase.yaml` Envoy config file. It is generated by running `scripts/update-envoy-config.sh` in `worker` of the infra repo ([PR](https://github.com/supabase/infrastructure/pull/20665)).

Based on:
- https://github.com/supabase/postgres/pull/1325