### PR TITLE
chore: bump pg_jsonschema version to support pg 17

### DIFF
--- a/nix/ext/pg_jsonschema.nix
+++ b/nix/ext/pg_jsonschema.nix
@@ -1,18 +1,18 @@
-{ lib, stdenv, fetchFromGitHub, postgresql, buildPgrxExtension_0_11_3, cargo, rust-bin }:
+{ lib, stdenv, fetchFromGitHub, postgresql, buildPgrxExtension_0_12_6, cargo, rust-bin }:
 let
-  rustVersion = "1.76.0";
+  rustVersion = "1.80.0";
   cargo = rust-bin.stable.${rustVersion}.default;
 in
-buildPgrxExtension_0_11_3 rec {
+buildPgrxExtension_0_12_6 rec {
   pname = "pg_jsonschema";
-  version = "0.3.1";
+  version = "0.3.3";
   inherit postgresql;
 
   src = fetchFromGitHub {
     owner = "supabase";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-YdKpOEiDIz60xE7C+EzpYjBcH0HabnDbtZl23CYls6g=";
+    hash = "sha256-Au1mqatoFKVq9EzJrpu1FVq5a1kBb510sfC980mDlsU=";
   };
 
   nativeBuildInputs = [ cargo ];
@@ -20,7 +20,7 @@ buildPgrxExtension_0_11_3 rec {
   # update the following array when the pg_jsonschema version is updated
   # required to ensure that extensions update scripts from previous versions are generated
 
-  previousVersions = ["0.3.0" "0.2.0" "0.1.4" "0.1.4" "0.1.2" "0.1.1" "0.1.0"];
+  previousVersions = ["0.3.1" "0.3.0" "0.2.0" "0.1.4" "0.1.4" "0.1.2" "0.1.1" "0.1.0"];
   CARGO="${cargo}/bin/cargo";
   #darwin env needs PGPORT to be unique for build to not clash with other pgrx extensions
   env = lib.optionalAttrs stdenv.isDarwin {
@@ -28,8 +28,12 @@ buildPgrxExtension_0_11_3 rec {
     RUSTFLAGS = "-C link-arg=-undefined -C link-arg=dynamic_lookup";
     PGPORT = "5433";
   };
-  cargoHash = "sha256-VcS+efMDppofuFW2zNrhhsbC28By3lYekDFquHPta2g=";
 
+  cargoLock = {
+    lockFile = "${src}/Cargo.lock";
+    allowBuiltinFetchGit = false;
+  };
+  
   # FIXME (aseipp): testsuite tries to write files into /nix/store; we'll have
   # to fix this a bit later.
   doCheck = false;


### PR DESCRIPTION
## What kind of change does this PR introduce?

bump pg_jsonschema version to 0.3.3 to support pg 17