### PR TITLE
fix: upload gotrue binary as gz instead of xz

### DIFF
--- a/ansible/manifest-playbook.yml
+++ b/ansible/manifest-playbook.yml
@@ -18,25 +18,9 @@
     - name: gotrue - download commit archive
       get_url:
         url: "https://github.com/supabase/gotrue/releases/download/v{{ gotrue_release }}/auth-v{{ gotrue_release }}-arm64.tar.gz"
-        dest: /tmp/gotrue.tar.gz
+        dest: /tmp/auth-v{{ gotrue_release }}-arm64.tar.gz
         checksum: "{{ gotrue_release_checksum }}"
         timeout: 60
-
-    - name: gotrue - create /tmp/gotrue
-      file:
-        path: /tmp/gotrue
-        state: directory
-        mode: 0775
-
-    - name: gotrue - unpack archive in /tmp/gotrue
-      unarchive:
-        remote_src: yes
-        src: /tmp/gotrue.tar.gz
-        dest: /tmp/gotrue
-
-    - name: gotrue - pack archive
-      shell: |
-        cd /tmp && tar -cJf gotrue-v{{ gotrue_release }}-arm64.tar.xz gotrue
 
     - name: PostgREST - download ubuntu binary archive (arm)
       get_url:
@@ -82,7 +66,7 @@
         aws s3 cp /tmp/{{ item.file }} s3://{{ internal_artifacts_bucket }}/upgrades/{{ item.service }}/{{ item.file }}
       with_items:
         - service: gotrue
-          file: gotrue-v{{ gotrue_release }}-arm64.tar.xz
+          file: auth-v{{ gotrue_release }}-arm64.tar.gz
         - service: postgrest
           file: postgrest-{{ postgrest_release }}-arm64.tar.xz
         - service: supabase-admin-api


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Upload the gotrue binary as a `tar.gz` file instead of a `tar.xz` file
* When combined with https://github.com/supabase/helper-scripts/pull/917, which improves the download speed since it downloads the binary from the same bucket in the region, we can reap the benefits of faster decompression from gzip at the expense of a slightly larger file size (negligible because the download is fast)
* Perf comparison between decompressing a gz vs xz file:
```
$ time tar -xzf auth-v2.164.0-arm64.tar.gz

real	0m0.309s
user	0m0.287s
sys	0m0.057s

$ time tar -xf gotrue-v2.164.0-arm64.tar.xz

real	0m0.655s
user	0m0.617s
sys	0m0.088s
```
