### PR TITLE
chore: we do not use the --migrate down so removing that statement

### DIFF
--- a/migrations/db/migrations/20241031003909_create_orioledb.sql
+++ b/migrations/db/migrations/20241031003909_create_orioledb.sql
@@ -9,4 +9,3 @@ begin
 end $$;
 
 -- migrate:down
-drop extension if exists orioledb;


### PR DESCRIPTION
## What kind of change does this PR introduce?

We typically do not use `--migrate down` in our migrations, and so removing the statement to stop the undesired removal on restore