### PR TITLE
feat: control shared_buffers value if oriole prior to start

### DIFF
--- a/ansible/files/postgres_prestart.sh.j2
+++ b/ansible/files/postgres_prestart.sh.j2
@@ -19,31 +19,44 @@ get_shared_buffers() {
 update_orioledb_buffers() {
    local pg_conf="/etc/postgresql/postgresql.conf"
    local value="$1"
+   
+   # Update orioledb.main_buffers
    if grep -q "^orioledb.main_buffers = " "$pg_conf"; then
        sed -i "s/^orioledb.main_buffers = .*/orioledb.main_buffers = $value/" "$pg_conf"
    else
        echo "orioledb.main_buffers = $value" >> "$pg_conf"
    fi
+   
+   # Update shared_buffers during alpha release to 32MB
+   # TODO will need to add logic here for different ec2 sizes
+   if grep -q "^shared_buffers = " "$pg_conf"; then
+       sed -i "s/^shared_buffers = .*/shared_buffers = 32MB/" "$pg_conf"
+   else
+       echo "shared_buffers = 32MB" >> "$pg_conf"
+   fi
+}
+
+setup_locales() {
+    # Initial locale setup
+    if [ $(cat /etc/locale.gen | grep -c en_US.UTF-8) -eq 0 ]; then
+    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
+    fi
+
+    if [ $(locale -a | grep -c en_US.utf8) -eq 0 ]; then
+    locale-gen
+    fi
 }
 
 main() {
-   local has_orioledb=$(check_orioledb_enabled)
-   if [ "$has_orioledb" -lt 1 ]; then
-       return 0
-   fi
-   local shared_buffers_value=$(get_shared_buffers)
-   if [ ! -z "$shared_buffers_value" ]; then
-       update_orioledb_buffers "$shared_buffers_value"
-   fi
+    setup_locales
+    local has_orioledb=$(check_orioledb_enabled)
+    if [ "$has_orioledb" -lt 1 ]; then
+        return 0
+    fi
+    local shared_buffers_value=$(get_shared_buffers)
+    if [ ! -z "$shared_buffers_value" ]; then
+        update_orioledb_buffers "$shared_buffers_value"
+    fi
 }
-
-# Initial locale setup
-if [ $(cat /etc/locale.gen | grep -c en_US.UTF-8) -eq 0 ]; then
-   echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
-fi
-
-if [ $(locale -a | grep -c en_US.utf8) -eq 0 ]; then
-   locale-gen
-fi
 
 main


### PR DESCRIPTION
## What kind of change does this PR introduce?

oriole needs different shared_buffer treatment/lower value, so for now we'll detect and set oriole to 32MB shared_buffers.

Once we have multiple sizes available, we'll check instance size and stagger it. 