### PR TITLE
feat: add an env var we can detect in various utilities for managing oriole instances

### DIFF
--- a/ansible/tasks/stage2-setup-postgres.yml
+++ b/ansible/tasks/stage2-setup-postgres.yml
@@ -49,6 +49,13 @@
         state: present
       when: is_psql_oriole and stage2_nix
       become: yes
+    
+    - name: Add ORIOLEDB_ENABLED environment variable
+      ansible.builtin.lineinfile:
+        path: /etc/environment
+        line: 'ORIOLEDB_ENABLED=true'
+      when: is_psql_oriole and stage2_nix
+      become: yes
 
 - name: Install Postgres from nix binary cache
   become: yes

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -9,7 +9,7 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "orioledb-17.0.1.001"
+  postgresorioledb-17: "orioledb-17.0.1.002"
   postgres15: "15.8.1.013"
   postgres16: "16.3.1.019"
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

creating a system-wide env var to detect when a machine is an orioledb image