### PR TITLE
feat: enable GTiff GDAL driver for PostGIS raster

### DIFF
--- a/Dockerfile-156
+++ b/Dockerfile-156
@@ -54,10 +54,10 @@ RUN apt update -y && apt install -y \
 RUN adduser --system  --home /var/lib/postgresql --no-create-home --shell /bin/bash --group --gecos "PostgreSQL administrator" postgres
 RUN adduser --system  --no-create-home --shell /bin/bash --group  wal-g
 RUN curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install linux \
---init none \
---no-confirm \
---extra-conf "substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com" \
---extra-conf "trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=% cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+    --init none \
+    --no-confirm \
+    --extra-conf "substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com" \
+    --extra-conf "trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=% cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
 
 ENV PATH="${PATH}:/nix/var/nix/profiles/default/bin"
 
@@ -136,9 +136,9 @@ FROM base as gosu
 ARG TARGETARCH
 # Install dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-   gnupg \
-   ca-certificates \
-   && rm -rf /var/lib/apt/lists/*
+    gnupg \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 # Download binary
 ARG GOSU_VERSION=1.16
 ARG GOSU_GPG_KEY=B42F6819007F00F88E364FD4036A9C25BF357DD4
@@ -185,6 +185,12 @@ RUN sed -i \
     usermod -aG postgres wal-g && \
     mkdir -p /etc/postgresql-custom && \
     chown postgres:postgres /etc/postgresql-custom
+
+# Ensure postgresql-platform-defaults.conf is included
+RUN echo "include = '/etc/postgresql-custom/postgresql-platform-defaults.conf'" >> /etc/postgresql/postgresql.conf && \
+    touch /etc/postgresql-custom/postgresql-platform-defaults.conf && \
+    chown postgres:postgres /etc/postgresql-custom/postgresql-platform-defaults.conf && \
+    chmod 644 /etc/postgresql-custom/postgresql-platform-defaults.conf
 
 # # Include schema migrations
 COPY migrations/db /docker-entrypoint-initdb.d/

--- a/Dockerfile-156
+++ b/Dockerfile-156
@@ -188,9 +188,7 @@ RUN sed -i \
 
 # Ensure postgresql-platform-defaults.conf is included
 RUN echo "include = '/etc/postgresql-custom/postgresql-platform-defaults.conf'" >> /etc/postgresql/postgresql.conf && \
-    touch /etc/postgresql-custom/postgresql-platform-defaults.conf && \
-    chown postgres:postgres /etc/postgresql-custom/postgresql-platform-defaults.conf && \
-    chmod 644 /etc/postgresql-custom/postgresql-platform-defaults.conf
+    install -m 0644 -g postgres -o postgres /dev/null /etc/postgresql-custom/postgresql-platform-defaults.conf
 
 # # Include schema migrations
 COPY migrations/db /docker-entrypoint-initdb.d/

--- a/docker/all-in-one/etc/postgresql-custom/postgresql-platform-defaults.conf
+++ b/docker/all-in-one/etc/postgresql-custom/postgresql-platform-defaults.conf
@@ -5,3 +5,6 @@ log_connections = on
 statement_timeout = 120000
 jit = off
 pgaudit.log = 'ddl'
+
+# Enable GTiff GDAL driver for PostGIS raster functionality
+postgis.gdal_enabled_drivers = 'GTiff'


### PR DESCRIPTION
## Description
Enable GTiff GDAL driver by default for PostGIS raster functionality.

## Problem
Currently, despite postgis_raster being enabled, none of the required GDAL drivers are enabled, leading to:
`rt_util_gdal_open: Cannot open file. All GDAL drivers disabled`

## Solution
- Add `postgis.gdal_enabled_drivers = 'GTiff'` to platform defaults configuration
- Ensure postgresql-platform-defaults.conf is properly included in main PostgreSQL configuration
- Set appropriate file permissions and ownership

## Changes
1. Added to `postgresql-platform-defaults.conf`: