### PR TITLE
chore: name oriole ami with conventions used through the rest of supa…

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -9,9 +9,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "orioledb-17.0.1.005"
-  postgres15: "15.8.1.015"
-  postgres16: "16.3.1.021"
+  postgresorioledb-17: "17.0.1.006"
+  postgres15: "15.8.1.016"
+  postgres16: "16.3.1.022"
 
 # Non Postgres Extensions
 pgbouncer_release: "1.19.0"


### PR DESCRIPTION
…base systems

Our system uses `supabase-postgres-${majorver}-*` and oriole ami naming needs to be in line with that convention 