### PR TITLE
chore: update pgpsql-http version 

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -9,9 +9,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "orioledb-17.0.1.005"
-  postgres15: "15.8.1.015"
-  postgres16: "16.3.1.021"
+  postgresorioledb-17: "orioledb-17.0.1.007"
+  postgres15: "15.8.1.017"
+  postgres16: "16.3.1.023"
 
 # Non Postgres Extensions
 pgbouncer_release: "1.19.0"
@@ -78,8 +78,7 @@ pgaudit_release_checksum: sha256:8f4a73e451c88c567e516e6cba7dc1e23bc91686bb6f1f7
 
 pgjwt_release: 9742dab1b2f297ad3811120db7b21451bca2d3c9
 
-pgsql_http_release: "1.5.0"
-pgsql_http_release_checksum: sha256:43efc9e82afcd110f205b86b8d28d1355d39b6b134161e9661a33a1346818f5d
+pgsql_http_release: "1.6.1"
 
 plpgsql_check_release: "2.2.5"
 plpgsql_check_release_checksum: sha256:6c3a3c5faf3f9689425c6db8a6b20bf4cd5e7144a055e29538eae980c7232573

--- a/nix/ext/pgsql-http.nix
+++ b/nix/ext/pgsql-http.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "pgsql-http";
-  version = "1.6.0";
+  version = "1.6.1";
 
   buildInputs = [ curl postgresql ];
 
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner = "pramsey";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-CPHfx7vhWfxkXsoKTzyFuTt47BPMvzi/pi1leGcuD60=";
+    hash = "sha256-C8eqi0q1dnshUAZjIsZFwa5FTYc7vmATF3vv2CReWPM=";
   };
 
   installPhase = ''


### PR DESCRIPTION
## What kind of change does this PR introduce?

An update of minor version of pgsql-http 

Brings the following fixes

CURL option: CURLOPT_CONNECTTIMEOUT_MS by @krsvital in https://github.com/pramsey/pgsql-http/pull/174
CURL options: CURLOPT_SSLKEY_BLOB and CURLOPT_SSLCERT_BLOB
Avoid null termination issues when posting binary content


closes #1348 