### PR TITLE
fix: pgmq ownership

### DIFF
--- a/ansible/files/postgresql_extension_custom_scripts/pgmq/after-create.sql
+++ b/ansible/files/postgresql_extension_custom_scripts/pgmq/after-create.sql
@@ -1,0 +1,19 @@
+do $$
+declare
+  extoid oid := (select oid from pg_extension where extname = 'pgmq');
+  r record;
+begin
+  set local search_path = '';
+  update pg_extension set extowner = 'postgres'::regrole where extname = 'pgmq';
+  for r in (select * from pg_depend where refobjid = extoid) loop
+    if r.classid = 'pg_type'::regclass then
+      execute(format('alter type %s owner to postgres;', r.objid::regtype));
+    elsif r.classid = 'pg_proc'::regclass then
+      execute(format('alter function %s(%s) owner to postgres;', r.objid::regproc, pg_get_function_identity_arguments(r.objid)));
+    elsif r.classid = 'pg_class'::regclass then
+      execute(format('alter table %s owner to postgres;', r.objid::regclass));
+    else
+      raise exception 'error on pgmq after-create script: unexpected object type %', r.classid;
+    end if;
+  end loop;
+end $$;

--- a/common-nix.vars.pkr.hcl
+++ b/common-nix.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.6.1.145"
+postgres-version = "15.6.1.145-pgmq-1"

--- a/common-nix.vars.pkr.hcl
+++ b/common-nix.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.6.1.145-pgmq-1"
+postgres-version = "15.6.1.146"


### PR DESCRIPTION
Automatically assigns ownership of the pgmq extension and associated entities to `postgres` from `supabase_admin`.

This is already the case by default. However, when projects are paused and restored, they are restored with supabase_admin, which alters their ownership and makes the extension inoperable.