### PR TITLE
chore: bump versions for staging testing of latest 15.8

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -9,9 +9,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.0.1.007-orioledb"
-  postgres15: "15.8.1.017"
-  postgres16: "16.3.1.023"
+  postgresorioledb-17: "17.0.1.008-orioledb"
+  postgres15: "15.8.1.018"
+  postgres16: "16.3.1.024"
 
 # Non Postgres Extensions
 pgbouncer_release: "1.19.0"


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR only advances version numbers so that we can test  15.8 image as a release candidate