### PR TITLE
Pin pg_repack version 1.5.2 based on tag

### DIFF
--- a/nix/ext/pg_repack.nix
+++ b/nix/ext/pg_repack.nix
@@ -18,8 +18,8 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "reorg";
     repo = "pg_repack";
-    rev = "85b64c6d4f599b2988343c4e7121acab505c9006";
-    hash = "sha256-lAuLI+vupusvn3uTzQ9OaLqkEfUVMCAwU9R70tTbb8Y=";
+    rev = "ver_${finalAttrs.version}";
+    hash = "sha256-wfjiLkx+S3zVrAynisX1GdazueVJ3EOwQEPcgUQt7eA=";
   };
 
   installPhase = ''


### PR DESCRIPTION
## What kind of change does this PR introduce?

- upgrade `pg_repack` from `85b64c6d4f599b2988343c4e7121acab505c9006` to `ver_1.5.2`.

## Additional context

New `pg_repack` version was released and it is possible to use tag instead of the commit id:
https://github.com/reorg/pg_repack/releases/tag/ver_1.5.2

Commit id was pinned before because the version wasn't released yet:
https://github.com/supabase/postgres/pull/1314

## Action Items

- [x] **New extension releases** were Checked for any breaking changes
- [x] **Extensions compatibility** Checked
    * Proceed to [extensions compatibility testing](#extensions-compatibility-testing), mark as done after everything is completed
- [ ] **Backup and Restore** Checked
    * Proceed to [backup testing](#backup-testing) while extensions are enabled
        - After every restore, re-run the tests specified at point [3.1](#extensions-compatibility-testing)

Since `pg_repack` doesn't have persistent metadata it might be not necessary to run `Backup and Restore` test.

### Extensions compatibility testing

1. Enable every extension
    1. Check Postgres’ log output for any error messages while doing so
        1. This might unearth incompatibilities due to unsupported internal functions, missing libraries, or missing permissions
2. Disable every extension
    1. Check Postgres’ log output for any cleanup-related error messages
3. Re-enable each extension
    1. Run basic tests against the features they offer, e.g.:
        1. `pg_net` - execute HTTP requests
        2. `pg_graphql` - execute queries and mutations
        3. …to be filled in

### Backup Testing

Follow the testing steps steps for all the following cases:

- Pause on new Postgres version, restore on new Postgres version
- Pause on older Postgres version, restore on new Postgres version
- Run a single-file backup backup, restore the backup

#### Testing steps

1. Generate dummy data 
    * the ‘Countries’ or ‘Slack clone’ SQL editor snippets are decent datasets to work with, albeit limited
2. Save a db stats snapshot file
    * Do this by running `supa db-stats gather -p <project_ref>`
3. Backup the database, through pausing the project, or otherwise
4. Restore the backup, through unpausing the project or cli
5. Check the data has been recovered successfully
    1. Visual checks/navigating through the tables works
    2. Run `supa db-stats verify` against the project and the previously saved file