### PR TITLE
pgmq migration safety

### DIFF
--- a/migrations/db/migrations/20241215003910_backfill_pgmq_metadata.sql
+++ b/migrations/db/migrations/20241215003910_backfill_pgmq_metadata.sql
@@ -34,9 +34,9 @@ begin
         	join pg_catalog.pg_namespace n
 				on c.relnamespace = n.oid
         where
-			n.nspname = 'pgmq'
-			and c.relname like 'q_%'
-	 		and c.relkind in ('r', 'p', 'u')
+            n.nspname = 'pgmq'
+            and c.relname like 'q_%'
+            and c.relkind in ('r', 'p', 'u')
         on conflict (queue_name) do nothing;
     end if;
 end $$;

--- a/migrations/db/migrations/20241215003910_backfill_pgmq_metadata.sql
+++ b/migrations/db/migrations/20241215003910_backfill_pgmq_metadata.sql
@@ -3,10 +3,24 @@ do $$
 begin
     -- Check if the pgmq.meta table exists
     if exists (
-        select 1
-        from pg_catalog.pg_class c
-        join pg_catalog.pg_namespace n on c.relnamespace = n.oid
-        where n.nspname = 'pgmq' and c.relname = 'meta'
+        select
+            1
+        from
+            pg_catalog.pg_class c
+        join pg_catalog.pg_namespace n
+            on c.relnamespace = n.oid
+        where
+            n.nspname = 'pgmq'
+            and c.relname = 'meta'
+            and c.relkind = 'r' -- regular table
+            -- Make sure only expected columns exist and are correctly named
+            and (
+                select array_agg(attname::text order by attname)
+                from pg_catalog.pg_attribute a
+                where
+                a.attnum > 0
+                and a.attrelid = c.oid 
+            ) = array['created_at', 'is_partitioned', 'is_unlogged', 'queue_name']::text[]
     ) then
         -- Insert data into pgmq.meta for all tables matching the naming pattern 'pgmq.q_<queue_name>'
         insert into pgmq.meta (queue_name, is_partitioned, is_unlogged, created_at)
@@ -22,7 +36,8 @@ begin
         where
 			n.nspname = 'pgmq'
 			and c.relname like 'q_%'
-	 		and c.relkind in ('r', 'p', 'u');
+	 		and c.relkind in ('r', 'p', 'u')
+        on conflict (queue_name) do nothing;
     end if;
 end $$;
 


### PR DESCRIPTION
- Updates the `pgmq` migration to ensure idempotency with on-conflict clause
- Validates that the pgmq.meta table is a regular table with expected columns so if the extension changes in the future it doesn't introduce a problem for us