### PR TITLE
fix: needed additional paths to release on merge to branches

### DIFF
--- a/.github/workflows/dockerhub-release-matrix.yml
+++ b/.github/workflows/dockerhub-release-matrix.yml
@@ -7,6 +7,8 @@ on:
       - release/*
     paths:
       - ".github/workflows/dockerhub-release-matrix.yml"
+      - "ansible/vars.yml"
+      - "Dockerfile-*"
   workflow_dispatch:
  
 jobs:


### PR DESCRIPTION
## What kind of change does this PR introduce?

This workflow needed the added paths to successfully build and release on merge to the branches it specifies. 