### PR TITLE
fix: trigger docker image build on changes to ansible vars

### DIFF
--- a/.github/workflows/dockerhub-release-matrix.yml
+++ b/.github/workflows/dockerhub-release-matrix.yml
@@ -7,6 +7,7 @@ on:
       - release/*
     paths:
       - ".github/workflows/dockerhub-release-matrix.yml"
+      - "ansible/vars.yml"
   workflow_dispatch:
  
 jobs:


### PR DESCRIPTION
Currently postgres image builds are triggered manaully.