### PR TITLE
feat: update envoy lds with origin protection keys

### DIFF
--- a/ansible/files/envoy_config/lds.supabase.yaml
+++ b/ansible/files/envoy_config/lds.supabase.yaml
@@ -82,6 +82,25 @@ resources:
                                         name: ':path'
                                         string_match:
                                           contains: apikey=supabase_admin_key
+                        origin_protection_key_missing:
+                          permissions:
+                            - any: true
+                          principals:
+                            - not_id:
+                                header:
+                                  name: sb-opk
+                                  present_match: true
+                        origin_protection_key_not_valid:
+                          permissions:
+                            - any: true
+                          principals:
+                            - not_id:
+                                or_ids:
+                                  ids:
+                                    - header:
+                                        name: sb-opk
+                                        string_match:
+                                          exact: supabase_origin_protection_key
                 - name: envoy.filters.http.lua
                   typed_config:
                     '@type': >-

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -9,9 +9,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.0.1.016-orioledb"
-  postgres15: "15.8.1.026"
-  postgres16: "16.3.1.032"
+  postgresorioledb-17: "17.0.1.017-orioledb"
+  postgres15: "15.8.1.027"
+  postgres16: "16.3.1.033"
 
 # Non Postgres Extensions
 pgbouncer_release: "1.19.0"


### PR DESCRIPTION
Updates the `lds.supabase.yaml` file to include origin protection keys by default. The string `supabase_origin_protection_key` is replaced with the exact OPK during [project initialization](https://github.com/supabase/infrastructure/blob/develop/init-scripts/project/00-init.sh#L115).

See also:
- https://github.com/supabase/postgres/pull/1325