### PR TITLE
chore: bump adminapi version to include postgres restarts optional check

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -55,7 +55,7 @@ postgres_exporter_release_checksum:
   arm64: sha256:29ba62d538b92d39952afe12ee2e1f4401250d678ff4b354ff2752f4321c87a0
   amd64: sha256:cb89fc5bf4485fb554e0d640d9684fae143a4b2d5fa443009bd29c59f9129e84
 
-adminapi_release: 0.71.1
+adminapi_release: 0.73.1
 adminmgr_release: 0.24.0
 
 # Postgres Extensions

--- a/common.vars.pkr.hcl
+++ b/common.vars.pkr.hcl
@@ -1,1 +1,1 @@
-postgres-version = "15.1.1.95"
+postgres-version = "15.8.1.029"

--- a/docker/all-in-one/Dockerfile
+++ b/docker/all-in-one/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.4
 ARG postgres_version=15.1.1.49
 
 ARG pgbouncer_release=1.18.0


### PR DESCRIPTION
## What kind of change does this PR introduce?

Upgrade admin api to include admin api upgrade

## What is the current behavior?

Process panic when running AIO image outside of `systemd`

## What is the new behavior?

Process is stable in and out of `systemd` environment

## Additional context

N/A