### PR TITLE
Enabled log_statement = 'ddl' by default.

### DIFF
--- a/docker/all-in-one/etc/postgresql-custom/postgresql-platform-defaults.conf
+++ b/docker/all-in-one/etc/postgresql-custom/postgresql-platform-defaults.conf
@@ -5,3 +5,4 @@ log_connections = on
 statement_timeout = 120000
 jit = off
 pgaudit.log = 'ddl'
+log_statement = 'ddl'


### PR DESCRIPTION
Postgres `log_statement` config allows logging of DDL statements by default. This can be very useful in some debugging scenarios, and also helpful for assisting users when tables have been accidentally `DROP`'ed or altered.