### PR TITLE
chore: bump to v4 to fix deprecation failure

### DIFF
--- a/.github/workflows/dockerhub-release-matrix.yml
+++ b/.github/workflows/dockerhub-release-matrix.yml
@@ -195,7 +195,7 @@ jobs:
             $"versions=$versions_str" | save --append $env.GITHUB_ENV
           '
       - name: Download Results Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           pattern: merge_results-*
       - name: Combine Results


### PR DESCRIPTION
## What kind of change does this PR introduce?

download artifact v3 was failing because it is deprecated https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

updating to v4