### PR TITLE
Move orioledb to extensions schema by default

### DIFF
--- a/migrations/README.md
+++ b/migrations/README.md
@@ -78,20 +78,18 @@ Additionally, [supabase/postgres](https://github.com/supabase/postgres/blob/deve
 
 ### Add a Migration
 
+First, start a local postgres server and apply the migrations
 ```shell
-# Start the database server
-cd docker
-docker compose up
+nix run .#dbmate-tool -- --version 15 --flake-url "."
 ```
 
-Then
+Then create a new migration
 ```shell
-# create a new migration
 cd migrations
 dbmate new '<some message>'
 ```
 
-Then, populate the migration at `./db/migrations/xxxxxxxxx_<some_message>` and make sure it execute sucessfully with
+Then, execute the migration at `./db/migrations/xxxxxxxxx_<some_message>` and make sure it runs sucessfully with
 
 ```shell
 dbmate up

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -80,9 +80,14 @@ Additionally, [supabase/postgres](https://github.com/supabase/postgres/blob/deve
 
 ```shell
 # Start the database server
-docker-compose up
+cd docker
+docker compose up
+```
 
+Then
+```shell
 # create a new migration
+cd migrations
 dbmate new '<some message>'
 ```
 

--- a/migrations/db/migrations/20250205144616_move_orioledb_to_extensions_schema.sql
+++ b/migrations/db/migrations/20250205144616_move_orioledb_to_extensions_schema.sql
@@ -1,0 +1,26 @@
+-- migrate:up
+do $$
+declare
+    ext_schema text;
+    extensions_schema_exists boolean;
+begin
+    -- check if the "extensions" schema exists
+    select exists (
+        select 1 from pg_namespace where nspname = 'extensions'
+    ) into extensions_schema_exists;
+
+    if extensions_schema_exists then
+        -- check if the "orioledb" extension is in the "public" schema
+        select nspname into ext_schema
+        from pg_extension e
+        join pg_namespace n on e.extnamespace = n.oid
+        where extname = 'orioledb';
+
+        if ext_schema = 'public' then
+            execute 'alter extension orioledb set schema extensions';
+        end if;
+    end if;
+end $$;
+
+-- migrate:down
+


### PR DESCRIPTION
Moves the orioledb extension to the extensions schema if:
- orioledb is enabled in the `public` schema
- the `extensions` schema exists

This is important because orioledb exposes some entities that we don't necessarily want exposed over APIs by default