### PR TITLE
chore: update our nix pkg for pg_graphql too

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -68,6 +68,11 @@
               buildPgrxExtension_0_12_6 = prev.buildPgrxExtension.override {
                 cargo-pgrx = final.cargo-pgrx.cargo-pgrx_0_12_6;
               };
+
+              buildPgrxExtension_0_12_9 = prev.buildPgrxExtension.override {
+                cargo-pgrx = final.cargo-pgrx.cargo-pgrx_0_12_9;
+              };
+
             })
             (final: prev: {
               postgresql = final.callPackage ./nix/postgresql/default.nix {
@@ -394,6 +399,7 @@
           supabase-groonga = supabase-groonga;
           cargo-pgrx_0_11_3 = pkgs.cargo-pgrx.cargo-pgrx_0_11_3;
           cargo-pgrx_0_12_6 = pkgs.cargo-pgrx.cargo-pgrx_0_12_6;
+          cargo-pgrx_0_12_9 = pkgs.cargo-pgrx.cargo-pgrx_0_12_9;
           # PostgreSQL versions.
           psql_15 = postgresVersions.psql_15;
           psql_orioledb-17 = postgresVersions.psql_orioledb-17;

--- a/nix/cargo-pgrx/default.nix
+++ b/nix/cargo-pgrx/default.nix
@@ -66,5 +66,10 @@ in
     hash = "sha256-7aQkrApALZe6EoQGVShGBj0UIATnfOy2DytFj9IWdEA=";
     cargoHash = "sha256-Di4UldQwAt3xVyvgQT1gUhdvYUVp7n/a72pnX45kP0w=";
   };
+  cargo-pgrx_0_12_9 = generic {
+    version = "0.12.9";
+    hash = "sha256-aR3DZAjeEEAjLQfZ0ZxkjLqTVMIEbU0UiZ62T4BkQq8=";
+    cargoHash = "sha256-53HKhvsKLTa2JCByLEcK3UzWXoM+LTatd98zvS1C9no=";
+  };
   inherit rustPlatform;
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

- upgrade _extension_ from _v0.0.0_ to _v0.0.0_

## Additional context

Add any other context or screenshots.

## Action Items

- [ ] **New extension releases** were Checked for any breaking changes
- [ ] **Extensions compatibility** Checked
    * Proceed to [extensions compatibility testing](#extensions-compatibility-testing), mark as done after everything is completed
- [ ] **Backup and Restore** Checked
    * Proceed to [backup testing](#backup-testing) while extensions are enabled
        - After every restore, re-run the tests specified at point [3.1](#extensions-compatibility-testing)

### Extensions compatibility testing

1. Enable every extension
    1. Check Postgres’ log output for any error messages while doing so
        1. This might unearth incompatibilities due to unsupported internal functions, missing libraries, or missing permissions
2. Disable every extension
    1. Check Postgres’ log output for any cleanup-related error messages
3. Re-enable each extension
    1. Run basic tests against the features they offer, e.g.:
        1. `pg_net` - execute HTTP requests
        2. `pg_graphql` - execute queries and mutations
        3. …to be filled in

### Backup Testing

Follow the testing steps steps for all the following cases:

- Pause on new Postgres version, restore on new Postgres version
- Pause on older Postgres version, restore on new Postgres version
- Run a single-file backup backup, restore the backup

#### Testing steps

1. Generate dummy data 
    * the ‘Countries’ or ‘Slack clone’ SQL editor snippets are decent datasets to work with, albeit limited
2. Save a db stats snapshot file
    * Do this by running `supa db-stats gather -p <project_ref>`
3. Backup the database, through pausing the project, or otherwise
4. Restore the backup, through unpausing the project or cli
5. Check the data has been recovered successfully
    1. Visual checks/navigating through the tables works
    2. Run `supa db-stats verify` against the project and the previously saved file