### PR TITLE
feat: add test for security definer functions

### DIFF
--- a/nix/tests/expected/security.out
+++ b/nix/tests/expected/security.out
@@ -1,0 +1,30 @@
+-- get a list of security definer functions owned by supabase_admin
+-- this list should be vetted to ensure the functions are safe to use as security definer
+select
+    p.proname
+from pg_catalog.pg_proc p
+    left join pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+where p.proowner = (select oid from pg_catalog.pg_roles where rolname = 'supabase_admin')
+        and p.prosecdef = true
+order by 1;
+            proname             
+--------------------------------
+ dblink_connect_u
+ dblink_connect_u
+ disable_security_label_trigger
+ enable_security_label_trigger
+ get_key_by_id
+ get_key_by_name
+ get_named_keys
+ get_schema_version
+ increment_schema_version
+ mask_role
+ pgaudit_ddl_command_end
+ pgaudit_sql_drop
+ repack_trigger
+ st_estimatedextent
+ st_estimatedextent
+ st_estimatedextent
+ update_mask
+(17 rows)
+

--- a/nix/tests/expected/security.out
+++ b/nix/tests/expected/security.out
@@ -1,30 +1,30 @@
 -- get a list of security definer functions owned by supabase_admin
 -- this list should be vetted to ensure the functions are safe to use as security definer
 select
-    p.proname
+    n.nspname, p.proname
 from pg_catalog.pg_proc p
     left join pg_catalog.pg_namespace n ON n.oid = p.pronamespace
 where p.proowner = (select oid from pg_catalog.pg_roles where rolname = 'supabase_admin')
         and p.prosecdef = true
-order by 1;
-            proname             
---------------------------------
- dblink_connect_u
- dblink_connect_u
- disable_security_label_trigger
- enable_security_label_trigger
- get_key_by_id
- get_key_by_name
- get_named_keys
- get_schema_version
- increment_schema_version
- mask_role
- pgaudit_ddl_command_end
- pgaudit_sql_drop
- repack_trigger
- st_estimatedextent
- st_estimatedextent
- st_estimatedextent
- update_mask
+order by 1,2;
+ nspname  |            proname             
+----------+--------------------------------
+ graphql  | get_schema_version
+ graphql  | increment_schema_version
+ pgsodium | disable_security_label_trigger
+ pgsodium | enable_security_label_trigger
+ pgsodium | get_key_by_id
+ pgsodium | get_key_by_name
+ pgsodium | get_named_keys
+ pgsodium | mask_role
+ pgsodium | update_mask
+ public   | dblink_connect_u
+ public   | dblink_connect_u
+ public   | pgaudit_ddl_command_end
+ public   | pgaudit_sql_drop
+ public   | st_estimatedextent
+ public   | st_estimatedextent
+ public   | st_estimatedextent
+ repack   | repack_trigger
 (17 rows)
 

--- a/nix/tests/sql/security.sql
+++ b/nix/tests/sql/security.sql
@@ -1,0 +1,9 @@
+-- get a list of security definer functions owned by supabase_admin
+-- this list should be vetted to ensure the functions are safe to use as security definer
+select
+    p.proname
+from pg_catalog.pg_proc p
+    left join pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+where p.proowner = (select oid from pg_catalog.pg_roles where rolname = 'supabase_admin')
+        and p.prosecdef = true
+order by 1;

--- a/nix/tests/sql/security.sql
+++ b/nix/tests/sql/security.sql
@@ -1,9 +1,9 @@
 -- get a list of security definer functions owned by supabase_admin
 -- this list should be vetted to ensure the functions are safe to use as security definer
 select
-    p.proname
+    n.nspname, p.proname
 from pg_catalog.pg_proc p
     left join pg_catalog.pg_namespace n ON n.oid = p.pronamespace
 where p.proowner = (select oid from pg_catalog.pg_roles where rolname = 'supabase_admin')
         and p.prosecdef = true
-order by 1;
+order by 1,2;


### PR DESCRIPTION
## What kind of change does this PR introduce?

test

## What is the new behavior?

Adds security / regression checks to ensure new security definer functions aren't introduced without first being vetted.

## Additional context

Checks all extensions installed, if a new extension is added, it should be present in [prime.sql](https://github.com/supabase/postgres/blob/develop/nix/tests/prime.sql). If a new security definer function is introduced, it must be vetted and if safe, added to the output  in security.out

Fixes SEC-204