### PR TITLE
feat: remove api key checks in envoy

### DIFF
--- a/ansible/files/envoy_config/lds.supabase.yaml
+++ b/ansible/files/envoy_config/lds.supabase.yaml
@@ -189,6 +189,10 @@ resources:
                                   prefix: /metrics/aggregated
                                 invert_match: true
                     status_code: 401
+                    headers_to_add:
+                      - header:
+                          key: x-sb-error-code
+                          value: '%RESPONSE_CODE_DETAILS%'
                     body_format_override:
                       json_format:
                         message: >-

--- a/ansible/files/envoy_config/lds.supabase.yaml
+++ b/ansible/files/envoy_config/lds.supabase.yaml
@@ -37,51 +37,6 @@ resources:
                     rules:
                       action: DENY
                       policies:
-                        api_key_missing:
-                          permissions:
-                            - any: true
-                          principals:
-                            - not_id:
-                                or_ids:
-                                  ids:
-                                    - header:
-                                        name: apikey
-                                        present_match: true
-                                    - header:
-                                        name: ':path'
-                                        string_match:
-                                          contains: apikey=
-                        api_key_not_valid:
-                          permissions:
-                            - any: true
-                          principals:
-                            - not_id:
-                                or_ids:
-                                  ids:
-                                    - header:
-                                        name: apikey
-                                        string_match:
-                                          exact: anon_key
-                                    - header:
-                                        name: apikey
-                                        string_match:
-                                          exact: service_key
-                                    - header:
-                                        name: apikey
-                                        string_match:
-                                          exact: supabase_admin_key
-                                    - header:
-                                        name: ':path'
-                                        string_match:
-                                          contains: apikey=anon_key
-                                    - header:
-                                        name: ':path'
-                                        string_match:
-                                          contains: apikey=service_key
-                                    - header:
-                                        name: ':path'
-                                        string_match:
-                                          contains: apikey=supabase_admin_key
                         origin_protection_key_missing:
                           permissions:
                             - any: true
@@ -383,24 +338,6 @@ resources:
                         route:
                           cluster: admin_api
                           prefix_rewrite: /privileged/
-                        typed_per_filter_config:
-                          envoy.filters.http.rbac:
-                            '@type': >-
-                              type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
-                            rbac:
-                              rules:
-                                action: DENY
-                                policies:
-                                  basic_auth:
-                                    permissions:
-                                      - any: true
-                                    principals:
-                                      - header:
-                                          name: authorization
-                                          invert_match: true
-                                          string_match:
-                                            exact: Basic c2VydmljZV9yb2xlOnNlcnZpY2Vfa2V5
-                                          treat_missing_header_as_empty: true
                       - match:
                           prefix: /metrics/aggregated
                         request_headers_to_remove:

--- a/ansible/files/envoy_config/lds.yaml
+++ b/ansible/files/envoy_config/lds.yaml
@@ -215,6 +215,10 @@ resources:
                                   prefix: /metrics/aggregated
                                 invert_match: true
                     status_code: 401
+                    headers_to_add:
+                      - header:
+                          key: x-sb-error-code
+                          value: '%RESPONSE_CODE_DETAILS%'
                     body_format_override:
                       json_format:
                         message: >-

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -8,8 +8,8 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.0.1.040-orioledb"
-  postgres15: "15.8.1.046"
+  postgresorioledb-17: "17.0.1.041-orioledb"
+  postgres15: "15.8.1.047"
 
 # Non Postgres Extensions
 pgbouncer_release: "1.19.0"


### PR DESCRIPTION
Removes API key (`anon`, `service_role`) checks from Envoy as new projects no longer need these. They were superseded by origin protection keys and API key checks at API gateway.