### PR TITLE
chore: rm xmrig src by setting attribute to throw

### DIFF
--- a/Dockerfile-15
+++ b/Dockerfile-15
@@ -67,6 +67,7 @@ WORKDIR /nixpg
 
 RUN nix profile install .#psql_15/bin 
 
+RUN nix store gc
 
 
 WORKDIR /

--- a/Dockerfile-orioledb-17
+++ b/Dockerfile-orioledb-17
@@ -68,7 +68,7 @@ WORKDIR /nixpg
 
 RUN nix profile install .#psql_orioledb-17/bin 
 
-
+RUN nix store gc
 
 WORKDIR /
 

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -8,8 +8,8 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.0.1.043-orioledb-rc-1"
-  postgres15: "15.8.1.049-rc-1"
+  postgresorioledb-17: "17.0.1.043-orioledb"
+  postgres15: "15.8.1.049"
 
 # Non Postgres Extensions
 pgbouncer_release: "1.19.0"

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -8,8 +8,8 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.0.1.042-orioledb"
-  postgres15: "15.8.1.048"
+  postgresorioledb-17: "17.0.1.043-orioledb-rc-1"
+  postgres15: "15.8.1.049-rc-1"
 
 # Non Postgres Extensions
 pgbouncer_release: "1.19.0"

--- a/flake.nix
+++ b/flake.nix
@@ -38,6 +38,9 @@
             # pull them from the overlays/ directory automatically, but we don't
             # want to have an arbitrary order, since it might matter. being
             # explicit is better.
+            (final: prev: {
+              xmrig = null;
+            })
             (import rust-overlay)
             (final: prev: {
               cargo-pgrx = final.callPackage ./nix/cargo-pgrx/default.nix {

--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
             # want to have an arbitrary order, since it might matter. being
             # explicit is better.
             (final: prev: {
-              xmrig = null;
+              xmrig = throw "The xmrig package has been explicitly disabled in this flake.";
             })
             (import rust-overlay)
             (final: prev: {


### PR DESCRIPTION
## What kind of change does this PR introduce?

xmrig is apparently an official nix package https://github.com/NixOS/nixpkgs/blob/nixpkgs-unstable/nixos/modules/services/misc/xmrig.nix

It is normal when installing a nix package, for nix to download the whole nix language package definition source code for all of the packages available in nixpkgs. However, only the executable binaries that you explicitly install are actually present.

Never the less, this pr sets the attribute for xmrig package to "throw", and runs garbage collect after install to remove any unrelated source , although the executable was NEVER installed or running at any time.

