### PR TITLE
fix: pgbouncer ownership

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -8,8 +8,8 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.0.1.042-orioledb"
-  postgres15: "15.8.1.048"
+  postgresorioledb-17: "17.0.1.044-orioledb"
+  postgres15: "15.8.1.051"
 
 # Non Postgres Extensions
 pgbouncer_release: "1.19.0"

--- a/migrations/db/migrations/20250312095419_pgbouncer_ownership.sql
+++ b/migrations/db/migrations/20250312095419_pgbouncer_ownership.sql
@@ -1,0 +1,5 @@
+-- migrate:up
+alter function pgbouncer.get_auth owner to supabase_admin;
+grant execute on function pgbouncer.get_auth(p_usename text) to postgres;
+
+-- migrate:down

--- a/nix/tests/expected/security.out
+++ b/nix/tests/expected/security.out
@@ -7,24 +7,25 @@ from pg_catalog.pg_proc p
 where p.proowner = (select oid from pg_catalog.pg_roles where rolname = 'supabase_admin')
         and p.prosecdef = true
 order by 1,2;
- nspname  |            proname             
-----------+--------------------------------
- graphql  | get_schema_version
- graphql  | increment_schema_version
- pgsodium | disable_security_label_trigger
- pgsodium | enable_security_label_trigger
- pgsodium | get_key_by_id
- pgsodium | get_key_by_name
- pgsodium | get_named_keys
- pgsodium | mask_role
- pgsodium | update_mask
- public   | dblink_connect_u
- public   | dblink_connect_u
- public   | pgaudit_ddl_command_end
- public   | pgaudit_sql_drop
- public   | st_estimatedextent
- public   | st_estimatedextent
- public   | st_estimatedextent
- repack   | repack_trigger
-(17 rows)
+  nspname  |            proname             
+-----------+--------------------------------
+ graphql   | get_schema_version
+ graphql   | increment_schema_version
+ pgbouncer | get_auth
+ pgsodium  | disable_security_label_trigger
+ pgsodium  | enable_security_label_trigger
+ pgsodium  | get_key_by_id
+ pgsodium  | get_key_by_name
+ pgsodium  | get_named_keys
+ pgsodium  | mask_role
+ pgsodium  | update_mask
+ public    | dblink_connect_u
+ public    | dblink_connect_u
+ public    | pgaudit_ddl_command_end
+ public    | pgaudit_sql_drop
+ public    | st_estimatedextent
+ public    | st_estimatedextent
+ public    | st_estimatedextent
+ repack    | repack_trigger
+(18 rows)
 


### PR DESCRIPTION
Tested on stg:
- [x] supavisor & pgbouncer conns on a new project (`supabase-postgres-15.8.1.048-pgbouncer-1`)
- [x] supavisor & pgbouncer conns after unpause