### PR TITLE
chore: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 * @supabase/backend @supabase/postgres
-migrations/ @supabase/cli @supabase/backend
+migrations/ @supabase/dev-workflows @supabase/postgres @supabase/backend
 docker/orioledb @supabase/postgres @supabase/backend
 common.vars.pkr.hcl @supabase/postgres @supabase/backend


### PR DESCRIPTION
Rename CLI team, and add PG team as owner on migrations