### PR TITLE
chore(qemu): ship the initialized data dir at a different location

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -9,7 +9,7 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.0.1.54-orioledb"
+  postgresorioledb-17: "17.0.1.55-orioledb"
   postgres17: "17.4.1.004"
   postgres15: "15.8.1.061"
 

--- a/ebssurrogate/scripts/qemu-bootstrap-nix.sh
+++ b/ebssurrogate/scripts/qemu-bootstrap-nix.sh
@@ -144,6 +144,7 @@ function clean_system {
 install_nix
 execute_stage2_playbook
 # we do not want to ship an initialized DB as this is performed as needed
-rm -rf /data/pgdata
+mkdir -p /db/template
+mv /data/pgdata /db/template
 clean_system
 cloud-init clean --logs


### PR DESCRIPTION
The reason for not shipping it originally was to avoid any possibility
of the server starting up off a datadir on ephemeral storage.

The initdb process itself is decently heavy though. We can tread the
middle ground between the two by shipping the datadir at a secondary
location, which the server never gets configured to run off. This
datadir can be moved to the appropriate place on persistent storage
prior to server startup. The simpler operation of copying the files
over should be faster than the initdb routine.