### PR TITLE
fix: use pg_ctl instead of initdb, and bump versions

### DIFF
--- a/ansible/tasks/setup-postgres.yml
+++ b/ansible/tasks/setup-postgres.yml
@@ -239,12 +239,12 @@
       become: yes
       become_user: postgres
       shell: >
-        source /var/lib/postgresql/.bashrc && initdb -D /var/lib/postgresql/data 
-        --allow-group-access 
-        --username=supabase_admin 
-        --locale-provider=icu 
-        --encoding=UTF-8 
-        --icu-locale=en_US.UTF-8 
+        source /var/lib/postgresql/.bashrc && /usr/lib/postgresql/bin/pg_ctl -D /var/lib/postgresql/data initdb
+        -o "--allow-group-access"
+        -o "--username=supabase_admin"
+        -o "--locale-provider=icu"
+        -o "--encoding=UTF-8"
+        -o "--icu-locale=en_US.UTF-8"
       args:
         executable: /bin/bash
       environment:

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,8 +10,8 @@ postgres_major:
 # Full version strings for each major version
 postgres_release:
   postgresorioledb-17: "17.0.1.55-orioledb"
-  postgres17: "17.4.1.004"
-  postgres15: "15.8.1.061"
+  postgres17: "17.4.1.005"
+  postgres15: "15.8.1.062"
 
 # Non Postgres Extensions
 pgbouncer_release: "1.19.0"


### PR DESCRIPTION
All versions need to be bumped at once for Release AMI ci actions to succeed. 