### PR TITLE
feat: alter event trigger owner

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -9,9 +9,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.0.1.062-orioledb"
-  postgres17: "17.4.1.012"
-  postgres15: "15.8.1.069"
+  postgresorioledb-17: "17.0.1.062-orioledb-evttrig-2"
+  postgres17: "17.4.1.012-evttrig-2"
+  postgres15: "15.8.1.069-evttrig-2"
 
 # Non Postgres Extensions
 pgbouncer_release: "1.19.0"

--- a/migrations/db/migrations/20231020085357_revoke_writes_on_cron_job_from_postgres.sql
+++ b/migrations/db/migrations/20231020085357_revoke_writes_on_cron_job_from_postgres.sql
@@ -40,6 +40,7 @@ END;
 $$;
 
 drop event trigger if exists issue_pg_cron_access;
+alter function extensions.grant_pg_cron_access owner to supabase_admin;
 CREATE EVENT TRIGGER issue_pg_cron_access ON ddl_command_end
          WHEN TAG IN ('CREATE EXTENSION')
    EXECUTE FUNCTION extensions.grant_pg_cron_access();

--- a/migrations/db/migrations/20250402065937_alter_internal_event_triggers_owner_to_supabase_admin.sql
+++ b/migrations/db/migrations/20250402065937_alter_internal_event_triggers_owner_to_supabase_admin.sql
@@ -1,0 +1,10 @@
+-- migrate:up
+drop event trigger if exists issue_pg_net_access;
+
+alter function extensions.grant_pg_net_access owner to supabase_admin;
+
+CREATE EVENT TRIGGER issue_pg_net_access ON ddl_command_end
+  WHEN TAG IN ('CREATE EXTENSION')
+  EXECUTE FUNCTION extensions.grant_pg_net_access();
+
+-- migrate:down

--- a/nix/ext/supautils.nix
+++ b/nix/ext/supautils.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "supautils";
-  version = "2.6.0";
+  version = "2.7.3";
 
   buildInputs = [ postgresql ];
 
@@ -10,13 +10,13 @@ stdenv.mkDerivation rec {
     owner = "supabase";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-QNfUpQjqHNzbNqBvjb5a3GtNH9hjbBMDUK19xUU3LpI=";
+    hash = "sha256-QKQQUz6ObzqINTLZaMQtocOkYX0Rh61fBLoB+rZ64UM=";
   };
 
   installPhase = ''
     mkdir -p $out/lib
 
-    install -D *${postgresql.dlSuffix} -t $out/lib
+    install -D build/*${postgresql.dlSuffix} -t $out/lib
   '';
 
   meta = with lib; {

--- a/nix/tests/expected/evtrigs.out
+++ b/nix/tests/expected/evtrigs.out
@@ -12,14 +12,14 @@ join pg_namespace n_func
 where p.prorettype = 'event_trigger'::regtype;
                 evtname                 |    evtowner    | evtfunction_schema |            evtfunction             | function_owner 
 ----------------------------------------+----------------+--------------------+------------------------------------+----------------
- issue_pg_net_access                    | postgres       | extensions         | grant_pg_net_access                | postgres
  issue_pg_graphql_access                | supabase_admin | extensions         | grant_pg_graphql_access            | supabase_admin
  issue_graphql_placeholder              | supabase_admin | extensions         | set_graphql_placeholder            | supabase_admin
  pgrst_ddl_watch                        | supabase_admin | extensions         | pgrst_ddl_watch                    | supabase_admin
  pgrst_drop_watch                       | supabase_admin | extensions         | pgrst_drop_watch                   | supabase_admin
  graphql_watch_ddl                      | supabase_admin | graphql            | graphql.increment_schema_version   | supabase_admin
  graphql_watch_drop                     | supabase_admin | graphql            | graphql.increment_schema_version   | supabase_admin
- issue_pg_cron_access                   | supabase_admin | extensions         | grant_pg_cron_access               | postgres
+ issue_pg_cron_access                   | supabase_admin | extensions         | grant_pg_cron_access               | supabase_admin
+ issue_pg_net_access                    | supabase_admin | extensions         | grant_pg_net_access                | supabase_admin
  pg_tle_event_trigger_for_drop_function | supabase_admin | pgtle              | pgtle.pg_tle_feature_info_sql_drop | supabase_admin
  pgaudit_ddl_command_end                | supabase_admin | public             | pgaudit_ddl_command_end            | supabase_admin
  pgaudit_sql_drop                       | supabase_admin | public             | pgaudit_sql_drop                   | supabase_admin


### PR DESCRIPTION
Reland the needed changes in https://github.com/supabase/postgres/pull/1489 but without touching `init-scripts`.

Also bumps supautils to 2.7.3 which includes user-defined event triggers support.

Tests done on local infra (test AMI: `supabase-postgres-15.8.1.069-evttrig-1`):
- [ ] smoke test: create new project
- [ ] pause on older AMI (15.8.1.064), restore to older AMI
- [ ] pause on older AMI, restore to test AMI
- [ ] pause on test AMI, restore to test AMI