### PR TITLE
fix: change qemu build to oriole

### DIFF
--- a/.github/workflows/qemu-image-build.yml
+++ b/.github/workflows/qemu-image-build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set PostgreSQL versions - only builds pg17 atm
         id: set-versions
         run: |
-          VERSIONS=$(nix run nixpkgs#yq --  '.postgres_major[1]' ansible/vars.yml | nix run nixpkgs#jq -- -R -s -c 'split("\n")[:-1]')
+          VERSIONS=$(nix run nixpkgs#yq --  '.postgres_major[2]' ansible/vars.yml | nix run nixpkgs#jq -- -R -s -c 'split("\n")[:-1]')
           echo "postgres_versions=$VERSIONS" >> $GITHUB_OUTPUT
 
   build:

--- a/ansible/tasks/setup-postgres.yml
+++ b/ansible/tasks/setup-postgres.yml
@@ -255,7 +255,7 @@
         LOCALE_ARCHIVE: /usr/lib/locale/locale-archive
       vars:
         ansible_command_timeout: 60
-      when: stage2_nix and is_psql_oriole or is_psql_17
+      when: stage2_nix and (is_psql_oriole or is_psql_17)
 
 - name: copy PG systemd unit
   template:

--- a/ebssurrogate/scripts/qemu-bootstrap-nix.sh
+++ b/ebssurrogate/scripts/qemu-bootstrap-nix.sh
@@ -106,7 +106,7 @@ EOF
 
 function clean_legacy_things {
     # removes things that are bundled for legacy reasons, but we can start without for our newer artifacts
-    apt-get unmark zlib1g* # TODO (darora): need to make sure that there aren't other things that still need this
+    apt-mark auto zlib1g* # TODO (darora): need to make sure that there aren't other things that still need this
     apt-get -y purge kong
     apt-get autoremove -y
 }
@@ -135,7 +135,12 @@ function clean_system {
 	mkdir /var/log/sysstat
 
 	chown -R postgres:postgres /var/log/wal-g
-	chmod -R 0300 /var/log/wal-g
+	# moving up fixes from init scripts
+	chmod -R 0310 /var/log/wal-g
+	chmod 0340 /var/log/wal-g/pitr.log
+
+	chmod 0600 /etc/vector/vector.yaml
+	chown vector:vector /etc/vector/vector.yaml
 
 	# # audit logs directory for apparmor
 	mkdir /var/log/audit


### PR DESCRIPTION
The array we grab the version from was re-ordered as PG17 non-oriole was introduced. A more robust mechanism can be added later but this array is rarely adjusted, so this is likely good enough for now.

Also moves up some fixes from the init-scripts, and removes Kong from the qemu artifact.