### PR TITLE
chore: bump to PostgREST v12.2.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Unmodified Postgres with some useful plugins. Our goal with this repo is not to 
 | Goodie | Version | Description |
 | ------------- | :-------------: | ------------- |
 | [PgBouncer](https://www.pgbouncer.org/) | [1.19.0](http://www.pgbouncer.org/changelog.html#pgbouncer-119x) | Set up Connection Pooling. |
-| [PostgREST](https://postgrest.org/en/stable/) | [v12.2.3](https://github.com/PostgREST/postgrest/releases/tag/v12.2.3) | Instantly transform your database into an RESTful API. |
+| [PostgREST](https://postgrest.org/en/stable/) | [v12.2.8](https://github.com/PostgREST/postgrest/releases/tag/v12.2.8) | Instantly transform your database into an RESTful API. |
 | [WAL-G](https://github.com/wal-g/wal-g#wal-g) | [v2.0.1](https://github.com/wal-g/wal-g/releases/tag/v2.0.1) | Tool for physical database backup and recovery. | -->
 
 ## Install

--- a/ansible/tasks/setup-postgrest.yml
+++ b/ansible/tasks/setup-postgrest.yml
@@ -50,7 +50,7 @@
 
 - name: PostgREST - download ubuntu binary archive (x86)
   get_url:
-    url: "https://github.com/PostgREST/postgrest/releases/download/v{{ postgrest_release }}/postgrest-v{{ postgrest_release }}-linux-static-x64.tar.xz"
+    url: "https://github.com/PostgREST/postgrest/releases/download/v{{ postgrest_release }}/postgrest-v{{ postgrest_release }}-linux-static-x86-64.tar.xz"
     dest: /tmp/postgrest.tar.xz
     checksum: "{{ postgrest_x86_release_checksum }}"
     timeout: 60    

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -9,20 +9,20 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.0.1.59-orioledb"
-  postgres17: "17.4.1.009"
-  postgres15: "15.8.1.066"
+  postgresorioledb-17: "17.0.1.59-orioledb-pgrst-1"
+  postgres17: "17.4.1.010-pgrst-1"
+  postgres15: "15.8.1.067-pgrst-1"
 
 # Non Postgres Extensions
 pgbouncer_release: "1.19.0"
 pgbouncer_release_checksum: sha256:af0b05e97d0e1fd9ad45fe00ea6d2a934c63075f67f7e2ccef2ca59e3d8ce682
 
 # to get these use
-# wget https://github.com/PostgREST/postgrest/releases/download/v12.2.3/postgrest-v12.2.3-ubuntu-aarch64.tar.xz -q -O- | sha1sum
-# wget https://github.com/PostgREST/postgrest/releases/download/v12.2.3/postgrest-v12.2.3-linux-static-x64.tar.xz -q -O- | sha1sum
-postgrest_release: "12.2.3"
-postgrest_arm_release_checksum: sha1:fbfd6613d711ce1afa25c42d5df8f1b017f396f9
-postgrest_x86_release_checksum: sha1:61c513f91a8931be4062587b9d4a18b42acf5c05
+# wget https://github.com/PostgREST/postgrest/releases/download/v12.2.8/postgrest-v12.2.8-ubuntu-aarch64.tar.xz -q -O- | sha1sum
+# wget https://github.com/PostgREST/postgrest/releases/download/v12.2.8/postgrest-v12.2.8-linux-static-x86-64.tar.xz -q -O- | sha1sum
+postgrest_release: "12.2.8"
+postgrest_arm_release_checksum: sha1:56e72424ce301886539dd0d4e8a9308119298d8e
+postgrest_x86_release_checksum: sha1:6200d4e35673b20718f4ac90815b96cc85f035b6
 
 gotrue_release: 2.170.0
 gotrue_release_checksum: sha1:a5741163de7d8da490c013cc8566c7210ed9f6fe


### PR DESCRIPTION
Bumps PostgREST from v12.2.3 to [v12.2.8](https://github.com/PostgREST/postgrest/releases/tag/v12.2.8) (patch release).

Adds some bug fixes like JWT cache not removing expired entries and showing `503` HTTP errors in the logs (useful for support using Logflare).