### PR TITLE
feat: release new adminapi and admin-mgr for physical backup pausing

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -9,9 +9,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.0.1.56-orioledb"
-  postgres17: "17.4.1.006"
-  postgres15: "15.8.1.063"
+  postgresorioledb-17: "17.0.1.57-orioledb"
+  postgres17: "17.4.1.007"
+  postgres15: "15.8.1.064"
 
 # Non Postgres Extensions
 pgbouncer_release: "1.19.0"
@@ -46,7 +46,6 @@ kong_deb_checksum: sha1:2086f6ccf8454fe64435252fea4d29d736d7ec61
 
 nginx_release: 1.22.0
 nginx_release_checksum: sha1:419efb77b80f165666e2ee406ad8ae9b845aba93
-
 
 postgres_exporter_release: "0.15.0"
 postgres_exporter_release_checksum:

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -53,8 +53,8 @@ postgres_exporter_release_checksum:
   arm64: sha256:29ba62d538b92d39952afe12ee2e1f4401250d678ff4b354ff2752f4321c87a0
   amd64: sha256:cb89fc5bf4485fb554e0d640d9684fae143a4b2d5fa443009bd29c59f9129e84
 
-adminapi_release: 0.76.0
-adminmgr_release: 0.24.1
+adminapi_release: 0.77.0
+adminmgr_release: 0.25.0
 
 vector_x86_deb: "https://packages.timber.io/vector/0.22.3/vector_0.22.3-1_amd64.deb"
 vector_arm_deb: "https://packages.timber.io/vector/0.22.3/vector_0.22.3-1_arm64.deb"


### PR DESCRIPTION
## What kind of change does this PR introduce?
Releasing new versions of `adminapi` and `admin-mgr` relating to pause and restore on physical backups. These add the ability to restore from a named checkpoint in WAL files.