### PR TITLE
fix: skip installing ndisc issue resolver in qemu mode

### DIFF
--- a/ansible/files/adminapi.service.j2
+++ b/ansible/files/adminapi.service.j2
@@ -8,6 +8,9 @@ User=adminapi
 Restart=always
 RestartSec=3
 Environment="AWS_USE_DUALSTACK_ENDPOINT=true"
+{% if qemu_mode is defined and qemu_mode %}
+Environment="AWS_SDK_LOAD_CONFIG=true"
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -82,7 +82,7 @@
       import_tasks: tasks/fix_ipv6_ndisc.yml
       tags:
         - install-supabase-internal
-      when: debpkg_mode or nixpkg_mode
+      when: (debpkg_mode or nixpkg_mode) and (qemu_mode is undefined)
 
     - name: Start Postgres Database without Systemd
       become: yes

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -9,9 +9,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.0.1.57-orioledb"
-  postgres17: "17.4.1.007"
-  postgres15: "15.8.1.064"
+  postgresorioledb-17: "17.0.1.58-orioledb"
+  postgres17: "17.4.1.008"
+  postgres15: "15.8.1.065"
 
 # Non Postgres Extensions
 pgbouncer_release: "1.19.0"

--- a/ebssurrogate/scripts/qemu-bootstrap-nix.sh
+++ b/ebssurrogate/scripts/qemu-bootstrap-nix.sh
@@ -35,7 +35,7 @@ callbacks_enabled = timer, profile_tasks, profile_roles
 EOF
 	# Run Ansible playbook
 	export ANSIBLE_LOG_PATH=/tmp/ansible.log && export ANSIBLE_REMOTE_TEMP=/mnt/tmp
-	ansible-playbook ./ansible/playbook.yml --extra-vars '{"nixpkg_mode": true, "debpkg_mode": false, "stage2_nix": false}' \
+	ansible-playbook ./ansible/playbook.yml --extra-vars '{"nixpkg_mode": true, "debpkg_mode": false, "stage2_nix": false, "qemu_mode": true}' \
 		--extra-vars "postgresql_version=postgresql_${POSTGRES_MAJOR_VERSION}" \
 		--extra-vars "postgresql_major_version=${POSTGRES_MAJOR_VERSION}" \
 		--extra-vars "postgresql_major=${POSTGRES_MAJOR_VERSION}" \


### PR DESCRIPTION
The issue was caused by very frequent RAs in ec2 when operating in
IPv6 mode. The qemu artifact gets configured with a static IP instead,
so this service should no longer be needed.

Additionally, fixes the build process to correctly define qemu_mode
for both ansible calls.

Also ports over a change from our init code for adminapi config loading.