### PR TITLE
chore: keep oriole numbering consistent

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -9,9 +9,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.0.1.61-orioledb"
-  postgres17: "17.4.1.011"
-  postgres15: "15.8.1.068"
+  postgresorioledb-17: "17.0.1.062-orioledb"
+  postgres17: "17.4.1.012"
+  postgres15: "15.8.1.069"
 
 # Non Postgres Extensions
 pgbouncer_release: "1.19.0"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Somehow leading "0" was removed from oriole release numbering. This PR re-introduces this to keep it consistent