### PR TITLE
chore: allow manually releasing migrations on stg

### DIFF
--- a/.github/workflows/publish-migrations-staging.yml
+++ b/.github/workflows/publish-migrations-staging.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Same as Release Migrations - Prod. Allow manually releasing migrations so we can test new migrations on restores before actually merging PRs to `develop`