### PR TITLE
test: pgmq functions' owner modification

### DIFF
--- a/nix/tests/expected/pgmq.out
+++ b/nix/tests/expected/pgmq.out
@@ -51,7 +51,7 @@ select
   msg_id,
   read_ct,
   message
-from 
+from
   pgmq.pop('Foo');
  msg_id | read_ct | message 
 --------+---------+---------
@@ -139,3 +139,52 @@ CONTEXT:  PL/pgSQL function pgmq.format_table_name(text,text) line 5 at RAISE
 PL/pgSQL function pgmq.create_non_partitioned(text) line 3 during statement block local variable initialization
 SQL statement "SELECT pgmq.create_non_partitioned(queue_name)"
 PL/pgSQL function pgmq."create"(text) line 3 at PERFORM
+\echo
+
+-- pgmq schema functions with owners (ownership is modified on ansible/files/postgresql_extension_custom_scripts/pgmq/after-create.sql)
+select
+  n.nspname as schema_name,
+  p.proname as function_name,
+  r.rolname as owner
+from
+  pg_proc p
+join
+  pg_namespace n on p.pronamespace = n.oid
+join
+  pg_roles r on p.proowner = r.oid
+where
+  n.nspname = 'pgmq'
+order by
+  p.proname;
+ schema_name |         function_name         |  owner   
+-------------+-------------------------------+----------
+ pgmq        | _belongs_to_pgmq              | postgres
+ pgmq        | _ensure_pg_partman_installed  | postgres
+ pgmq        | _get_partition_col            | postgres
+ pgmq        | _get_pg_partman_major_version | postgres
+ pgmq        | _get_pg_partman_schema        | postgres
+ pgmq        | archive                       | postgres
+ pgmq        | archive                       | postgres
+ pgmq        | convert_archive_partitioned   | postgres
+ pgmq        | create                        | postgres
+ pgmq        | create_non_partitioned        | postgres
+ pgmq        | create_partitioned            | postgres
+ pgmq        | create_unlogged               | postgres
+ pgmq        | delete                        | postgres
+ pgmq        | delete                        | postgres
+ pgmq        | detach_archive                | postgres
+ pgmq        | drop_queue                    | postgres
+ pgmq        | format_table_name             | postgres
+ pgmq        | list_queues                   | postgres
+ pgmq        | metrics                       | postgres
+ pgmq        | metrics_all                   | postgres
+ pgmq        | pop                           | postgres
+ pgmq        | purge_queue                   | postgres
+ pgmq        | read                          | postgres
+ pgmq        | read_with_poll                | postgres
+ pgmq        | send                          | postgres
+ pgmq        | send_batch                    | postgres
+ pgmq        | set_vt                        | postgres
+ pgmq        | validate_queue_name           | postgres
+(28 rows)
+

--- a/nix/tests/sql/pgmq.sql
+++ b/nix/tests/sql/pgmq.sql
@@ -35,7 +35,7 @@ select
   msg_id,
   read_ct,
   message
-from 
+from
   pgmq.pop('Foo');
 
 
@@ -84,7 +84,20 @@ select
 select pgmq.create('F--oo');
 select pgmq.create('F$oo');
 select pgmq.create($$F'oo$$);
+\echo
 
-
-
-
+-- pgmq schema functions with owners (ownership is modified on ansible/files/postgresql_extension_custom_scripts/pgmq/after-create.sql)
+select
+  n.nspname as schema_name,
+  p.proname as function_name,
+  r.rolname as owner
+from
+  pg_proc p
+join
+  pg_namespace n on p.pronamespace = n.oid
+join
+  pg_roles r on p.proowner = r.oid
+where
+  n.nspname = 'pgmq'
+order by
+  p.proname;


### PR DESCRIPTION
The change on https://github.com/supabase/postgres/pull/1362 modified pgmq functions default owner, which is `supabase_admin`, to `postgres`.

This tests function owners of pgmq.

Partly addresses https://github.com/supabase/postgres/issues/1536.