### PR TITLE
chore: fix nix build on macos and address space on gh runner

### DIFF
--- a/.github/workflows/testinfra-nix.yml
+++ b/.github/workflows/testinfra-nix.yml
@@ -90,8 +90,8 @@ jobs:
       - name: Clean up after AMI stage 1
         if: always()  # Run even if previous steps fail
         run: |
-          nix-collect-garbage -d  # Delete old generations of all profiles
-          rm -rf /tmp/*  # Clean temporary files
+          sudo nix-collect-garbage -d  # Delete old generations of all profiles
+          sudo rm -rf /tmp/*  # Clean temporary files
           df -h /  # Display available space
 
       - name: Build AMI stage 2
@@ -103,8 +103,8 @@ jobs:
       - name: Clean up after AMI stage 2
         if: always()  # Run even if previous steps fail
         run: |
-          nix-collect-garbage -d  # Delete old generations of all profiles
-          rm -rf /tmp/*  # Clean temporary files
+          sudo nix-collect-garbage -d  # Delete old generations of all profiles
+          sudo rm -rf /tmp/*  # Clean temporary files
           df -h /  # Display available space
 
       - name: Run tests

--- a/.github/workflows/testinfra-nix.yml
+++ b/.github/workflows/testinfra-nix.yml
@@ -19,6 +19,12 @@ jobs:
       
       - uses: DeterminateSystems/nix-installer-action@main
 
+      - name: Clean Nix store before build
+        run: |
+          nix-collect-garbage -d
+          nix-store --optimize
+          df -h /  # Display available space
+
       - name: Set PostgreSQL versions
         id: set-versions
         run: |
@@ -80,12 +86,26 @@ jobs:
           packer init amazon-arm64-nix.pkr.hcl
           GIT_SHA=${{github.sha}}
           packer build -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${GITHUB_RUN_ID}" -var-file="development-arm.vars.pkr.hcl" -var-file="common-nix.vars.pkr.hcl" -var "ansible_arguments=" -var "postgres-version=${{ steps.random.outputs.random_string }}" -var "region=ap-southeast-1" -var 'ami_regions=["ap-southeast-1"]' -var "force-deregister=true" -var "ansible_arguments=-e postgresql_major=${POSTGRES_MAJOR_VERSION}" amazon-arm64-nix.pkr.hcl
-      
+
+      - name: Clean up after AMI stage 1
+        if: always()  # Run even if previous steps fail
+        run: |
+          nix-collect-garbage -d  # Delete old generations of all profiles
+          rm -rf /tmp/*  # Clean temporary files
+          df -h /  # Display available space
+
       - name: Build AMI stage 2
         run: |
           packer init stage2-nix-psql.pkr.hcl
           GIT_SHA=${{github.sha}}
           packer build -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${GITHUB_RUN_ID}" -var "postgres_major_version=${POSTGRES_MAJOR_VERSION}" -var-file="development-arm.vars.pkr.hcl" -var-file="common-nix.vars.pkr.hcl"  -var "postgres-version=${{ steps.random.outputs.random_string }}" -var "region=ap-southeast-1" -var 'ami_regions=["ap-southeast-1"]' -var "force-deregister=true" -var "git_sha=${GITHUB_SHA}"  stage2-nix-psql.pkr.hcl 
+
+      - name: Clean up after AMI stage 2
+        if: always()  # Run even if previous steps fail
+        run: |
+          nix-collect-garbage -d  # Delete old generations of all profiles
+          rm -rf /tmp/*  # Clean temporary files
+          df -h /  # Display available space
 
       - name: Run tests
         timeout-minutes: 10

--- a/.github/workflows/testinfra-nix.yml
+++ b/.github/workflows/testinfra-nix.yml
@@ -21,8 +21,8 @@ jobs:
 
       - name: Clean Nix store before build
         run: |
-          nix-collect-garbage -d
-          nix-store --optimize
+          sudo nix-collect-garbage -d || true
+          sudo nix-store --optimize || true
           df -h /  # Display available space
 
       - name: Set PostgreSQL versions

--- a/nix/ext/wrappers/default.nix
+++ b/nix/ext/wrappers/default.nix
@@ -43,14 +43,16 @@ buildPgrxExtension_0_12_9 rec {
     POSTGRES_LIB = "${postgresql}/lib";
     RUSTFLAGS = "-C link-arg=-undefined -C link-arg=dynamic_lookup";
     # Calculate unique port for each PostgreSQL version:
-    # - Take first 2 chars of version (e.g., "15" from "15.8", "17" from "17.0")
-    # - Convert to number and subtract 15 to get offset
-    # - Add to base port 5435
+    # - Check if version contains underscore (indicating OrioleDB)
+    # - Add 1 to port if it's OrioleDB
+    # - Add 2 for each major version above 15
     # Examples:
-    # - PostgreSQL 15.8 → 5435 + (15-15) = 5435
-    # - PostgreSQL 17.0 → 5435 + (17-15) = 5437
-    # - PostgreSQL 17.4 → 5435 + (17-15) = 5437
-    PGPORT = toString (5435 + (builtins.fromJSON (builtins.substring 0 2 postgresql.version)) - 15);
+    # - PostgreSQL 15.8 → 5435 + 0 + (15-15)*2 = 5435
+    # - PostgreSQL 17_0 (OrioleDB) → 5435 + 1 + (17-15)*2 = 5440
+    # - PostgreSQL 17.4 → 5435 + 0 + (17-15)*2 = 5439
+    PGPORT = toString (5435 + 
+      (if builtins.match ".*_.*" postgresql.version != null then 1 else 0) +  # +1 for OrioleDB
+      ((builtins.fromJSON (builtins.substring 0 2 postgresql.version)) - 15) * 2);  # +2 for each major version
   };
 
   OPENSSL_NO_VENDOR = 1;

--- a/nix/ext/wrappers/default.nix
+++ b/nix/ext/wrappers/default.nix
@@ -38,11 +38,19 @@ buildPgrxExtension_0_12_9 rec {
 
   NIX_LDFLAGS = "-L${postgresql}/lib -lpq";
 
-  # Set necessary environment variables for pgrx
+  # Set necessary environment variables for pgrx in darwin only
   env = lib.optionalAttrs stdenv.isDarwin {
     POSTGRES_LIB = "${postgresql}/lib";
     RUSTFLAGS = "-C link-arg=-undefined -C link-arg=dynamic_lookup";
-    PGPORT = "5435";
+    # Calculate unique port for each PostgreSQL version:
+    # - Take first 2 chars of version (e.g., "15" from "15.8", "17" from "17.0")
+    # - Convert to number and subtract 15 to get offset
+    # - Add to base port 5435
+    # Examples:
+    # - PostgreSQL 15.8 → 5435 + (15-15) = 5435
+    # - PostgreSQL 17.0 → 5435 + (17-15) = 5437
+    # - PostgreSQL 17.4 → 5435 + (17-15) = 5437
+    PGPORT = toString (5435 + (builtins.fromJSON (builtins.substring 0 2 postgresql.version)) - 15);
   };
 
   OPENSSL_NO_VENDOR = 1;


### PR DESCRIPTION
The nix build was failing on macos due to port collisions when nix flake check is run.

So, we do some math on the version and create a port depending on the version. This only impacts darwin/macos at this time so the setting is limited to that architecture.

On our hosted github runner, we run out of space. So, we introduce a few cleanup operations to cut down on the build up of files there. 