### PR TITLE
test: role privileges on vault objects and indexes

### DIFF
--- a/nix/tests/expected/vault.out
+++ b/nix/tests/expected/vault.out
@@ -1,42 +1,88 @@
-select
-  1
-from
-  vault.create_secret('my_s3kre3t');
- ?column? 
-----------
-        1
-(1 row)
+-- Tests role privileges on the vault objects
+-- INSERT and UPDATE privileges should not be present on the vault tables for postgres and service_role, only SELECT and DELETE
+WITH schema_obj AS (
+  SELECT oid, nspname
+  FROM pg_namespace
+  WHERE nspname = 'vault'
+)
+SELECT
+  s.nspname AS schema,
+  c.relname AS object_name,
+  acl.grantee::regrole::text AS grantee,
+  acl.privilege_type
+FROM pg_class c
+JOIN schema_obj s ON s.oid = c.relnamespace
+CROSS JOIN LATERAL aclexplode(c.relacl) AS acl
+WHERE c.relkind IN ('r', 'v', 'm', 'f', 'p')
+  AND acl.privilege_type <> 'MAINTAIN'
+UNION ALL
+SELECT
+  s.nspname AS schema,
+  p.proname AS object_name,
+  acl.grantee::regrole::text AS grantee,
+  acl.privilege_type
+FROM pg_proc p
+JOIN schema_obj s ON s.oid = p.pronamespace
+CROSS JOIN LATERAL aclexplode(p.proacl) AS acl
+ORDER BY object_name, grantee, privilege_type;
+ schema |        object_name        |    grantee     | privilege_type 
+--------+---------------------------+----------------+----------------
+ vault  | _crypto_aead_det_decrypt  | postgres       | EXECUTE
+ vault  | _crypto_aead_det_decrypt  | supabase_admin | EXECUTE
+ vault  | _crypto_aead_det_encrypt  | supabase_admin | EXECUTE
+ vault  | _crypto_aead_det_noncegen | supabase_admin | EXECUTE
+ vault  | create_secret             | postgres       | EXECUTE
+ vault  | create_secret             | supabase_admin | EXECUTE
+ vault  | decrypted_secrets         | postgres       | DELETE
+ vault  | decrypted_secrets         | postgres       | SELECT
+ vault  | decrypted_secrets         | supabase_admin | DELETE
+ vault  | decrypted_secrets         | supabase_admin | INSERT
+ vault  | decrypted_secrets         | supabase_admin | REFERENCES
+ vault  | decrypted_secrets         | supabase_admin | SELECT
+ vault  | decrypted_secrets         | supabase_admin | TRIGGER
+ vault  | decrypted_secrets         | supabase_admin | TRUNCATE
+ vault  | decrypted_secrets         | supabase_admin | UPDATE
+ vault  | secrets                   | postgres       | DELETE
+ vault  | secrets                   | postgres       | SELECT
+ vault  | secrets                   | supabase_admin | DELETE
+ vault  | secrets                   | supabase_admin | INSERT
+ vault  | secrets                   | supabase_admin | REFERENCES
+ vault  | secrets                   | supabase_admin | SELECT
+ vault  | secrets                   | supabase_admin | TRIGGER
+ vault  | secrets                   | supabase_admin | TRUNCATE
+ vault  | secrets                   | supabase_admin | UPDATE
+ vault  | update_secret             | postgres       | EXECUTE
+ vault  | update_secret             | supabase_admin | EXECUTE
+(26 rows)
 
-select
-  1
-from
-  vault.create_secret(
-    'another_s3kre3t',
-    'unique_name',
-    'This is the description'
-  );
- ?column? 
-----------
-        1
-(1 row)
+-- vault indexes with owners
+SELECT
+    ns.nspname AS schema,
+    t.relname AS table,
+    i.relname AS index_name,
+    r.rolname AS index_owner,
+    CASE
+        WHEN idx.indisunique THEN 'Unique'
+        ELSE 'Non Unique'
+    END AS index_type
+FROM
+    pg_class t
+JOIN
+    pg_namespace ns ON t.relnamespace = ns.oid
+JOIN
+    pg_index idx ON t.oid = idx.indrelid
+JOIN
+    pg_class i ON idx.indexrelid = i.oid
+JOIN
+    pg_roles r ON i.relowner = r.oid
+WHERE
+    ns.nspname = 'vault'
+ORDER BY
+    t.relname,
+    i.relname;
+ schema |  table  |    index_name    |  index_owner   | index_type 
+--------+---------+------------------+----------------+------------
+ vault  | secrets | secrets_name_idx | supabase_admin | Unique
+ vault  | secrets | secrets_pkey     | supabase_admin | Unique
+(2 rows)
 
-insert into vault.secrets (secret)
-values
-  ('s3kre3t_k3y');
-select
-  name,
-  description
-from
-  vault.decrypted_secrets 
-order by
-  created_at desc 
-limit
-  3;
-    name     |       description       
--------------+-------------------------
-             | 
- unique_name | This is the description
-             | 
-(3 rows)
-
- 

--- a/nix/tests/sql/vault.sql
+++ b/nix/tests/sql/vault.sql
@@ -1,30 +1,53 @@
-select
-  1
-from
-  vault.create_secret('my_s3kre3t');
+-- Tests role privileges on the vault objects
+-- INSERT and UPDATE privileges should not be present on the vault tables for postgres and service_role, only SELECT and DELETE
+WITH schema_obj AS (
+  SELECT oid, nspname
+  FROM pg_namespace
+  WHERE nspname = 'vault'
+)
+SELECT
+  s.nspname AS schema,
+  c.relname AS object_name,
+  acl.grantee::regrole::text AS grantee,
+  acl.privilege_type
+FROM pg_class c
+JOIN schema_obj s ON s.oid = c.relnamespace
+CROSS JOIN LATERAL aclexplode(c.relacl) AS acl
+WHERE c.relkind IN ('r', 'v', 'm', 'f', 'p')
+  AND acl.privilege_type <> 'MAINTAIN'
+UNION ALL
+SELECT
+  s.nspname AS schema,
+  p.proname AS object_name,
+  acl.grantee::regrole::text AS grantee,
+  acl.privilege_type
+FROM pg_proc p
+JOIN schema_obj s ON s.oid = p.pronamespace
+CROSS JOIN LATERAL aclexplode(p.proacl) AS acl
+ORDER BY object_name, grantee, privilege_type;
 
-select
-  1
-from
-  vault.create_secret(
-    'another_s3kre3t',
-    'unique_name',
-    'This is the description'
-  );
-
-insert into vault.secrets (secret)
-values
-  ('s3kre3t_k3y');
-
-select
-  name,
-  description
-from
-  vault.decrypted_secrets 
-order by
-  created_at desc 
-limit
-  3;
- 
-
-
+-- vault indexes with owners
+SELECT
+    ns.nspname AS schema,
+    t.relname AS table,
+    i.relname AS index_name,
+    r.rolname AS index_owner,
+    CASE
+        WHEN idx.indisunique THEN 'Unique'
+        ELSE 'Non Unique'
+    END AS index_type
+FROM
+    pg_class t
+JOIN
+    pg_namespace ns ON t.relnamespace = ns.oid
+JOIN
+    pg_index idx ON t.oid = idx.indrelid
+JOIN
+    pg_class i ON idx.indexrelid = i.oid
+JOIN
+    pg_roles r ON i.relowner = r.oid
+WHERE
+    ns.nspname = 'vault'
+ORDER BY
+    t.relname,
+    i.relname;


### PR DESCRIPTION
Improves the previous tests while reducing britleness and revealing more implicit privileges.

- Reveals privileges on the `_crypto_aead_det_*` functions.
- Avoids testing the signature of functions (which was done by function calls), which is already done on z_15_ext_interface.out. 
```
  supabase_vault         | vault                    | create_secret                                    | new_secret text, new_name text, new_description text, new_key_id uuid                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | uuid
  supabase_vault         | vault                    | update_secret                                    | secret_id uuid, new_secret text, new_name text, new_description text, new_key_id uuid                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | void
```
(https://github.com/supabase/postgres/blob/9bdefbcb7cc00b0692562c889b6c7d625120bd66/nix/tests/expected/z_15_ext_interface.out#L4754-L4755)
- Unique index test is added while also revealing the index owner.
- Avoids testing error messages, which can change across versions.
- Avoids testing implementation details, and reduces verboseness.