### PR TITLE
chore: bump gotrue to v2.171.0

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -9,9 +9,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.0.1.065-orioledb"
-  postgres17: "17.4.1.015"
-  postgres15: "15.8.1.072"
+  postgresorioledb-17: "17.0.1.066-orioledb"
+  postgres17: "17.4.1.016"
+  postgres15: "15.8.1.073"
 
 # Non Postgres Extensions
 pgbouncer_release: "1.19.0"
@@ -24,8 +24,8 @@ postgrest_release: "12.2.3"
 postgrest_arm_release_checksum: sha1:fbfd6613d711ce1afa25c42d5df8f1b017f396f9
 postgrest_x86_release_checksum: sha1:61c513f91a8931be4062587b9d4a18b42acf5c05
 
-gotrue_release: 2.170.0
-gotrue_release_checksum: sha1:a5741163de7d8da490c013cc8566c7210ed9f6fe
+gotrue_release: 2.171.0
+gotrue_release_checksum: sha1:9199d177e653c12202db4b12532853afc6493d32
 
 aws_cli_release: "2.23.11"
 


### PR DESCRIPTION
* upgrade gotrue version to v2.171.0 (see [changelog](https://github.com/supabase/auth/releases/tag/v2.171.0))