### PR TITLE
fix: update wrappers server options post-upgrade

### DIFF
--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/complete.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/complete.sh
@@ -42,8 +42,34 @@ function execute_wrappers_patch {
     option_rec RECORD;
     vault_secrets RECORD;
   BEGIN
-    IF EXISTS (SELECT FROM pg_available_extension_versions WHERE name = 'wrappers' AND version = '0.4.6')
-      AND EXISTS (SELECT FROM pg_extension WHERE extname = 'wrappers')
+    IF EXISTS (SELECT FROM pg_extension WHERE extname = 'wrappers' AND extversion NOT IN (
+      '0.1.0',
+      '0.1.1',
+      '0.1.4',
+      '0.1.5',
+      '0.1.6',
+      '0.1.7',
+      '0.1.8',
+      '0.1.9',
+      '0.1.10',
+      '0.1.11',
+      '0.1.12',
+      '0.1.14',
+      '0.1.15',
+      '0.1.16',
+      '0.1.17',
+      '0.1.18',
+      '0.1.19',
+      '0.2.0',
+      '0.3.0',
+      '0.3.1',
+      '0.4.0',
+      '0.4.1',
+      '0.4.2',
+      '0.4.3',
+      '0.4.4',
+      '0.4.5'
+    ))
     THEN
       FOR server_rec IN
         SELECT srvname, srvoptions


### PR DESCRIPTION
Wrappers were previously using `vault.secrets.key_id`, which will no longer work with new Vault; we migrate it to use `vault.secrets.id` instead.

Tested on local infra with the same steps as [this](https://github.com/supabase/infrastructure/pull/22555), swapping out the pause & restore step with upgrading the project via Project Settings > Infrastructure

TODO:
- [x] merge https://github.com/supabase/supabase/pull/35075