### PR TITLE
fix: upgrade pgbouncer to v1.24.1

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -9,13 +9,13 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.0.1.066-orioledb"
-  postgres17: "17.4.1.016"
-  postgres15: "15.8.1.073"
+  postgresorioledb-17: "17.0.1.067-orioledb"
+  postgres17: "17.4.1.017"
+  postgres15: "15.8.1.074"
 
 # Non Postgres Extensions
-pgbouncer_release: "1.19.0"
-pgbouncer_release_checksum: sha256:af0b05e97d0e1fd9ad45fe00ea6d2a934c63075f67f7e2ccef2ca59e3d8ce682
+pgbouncer_release: "1.24.1"
+pgbouncer_release_checksum: sha256:da72a3aba13072876d055a3e58dd4aba4a5de4ed6148e73033185245598fd3e0
 
 # to get these use
 # wget https://github.com/PostgREST/postgrest/releases/download/v12.2.3/postgrest-v12.2.3-ubuntu-aarch64.tar.xz -q -O- | sha1sum

--- a/migrations/db/migrations/20250417190610_update_pgbouncer_get_auth.sql
+++ b/migrations/db/migrations/20250417190610_update_pgbouncer_get_auth.sql
@@ -1,0 +1,24 @@
+-- migrate:up
+
+create or replace function pgbouncer.get_auth(p_usename text) returns table (username text, password text)
+    language plpgsql security definer
+    as $$
+begin
+    raise debug 'PgBouncer auth request: %', p_usename;
+
+    return query
+    select 
+        rolname::text, 
+        case when rolvaliduntil < now() 
+            then null 
+            else rolpassword::text 
+        end 
+    from pg_authid 
+    where rolname=$1 and rolcanlogin;
+end;
+$$;
+
+-- from migrations/db/migrations/20250312095419_pgbouncer_ownership.sql
+grant execute on function pgbouncer.get_auth(p_usename text) to postgres;
+
+-- migrate:down


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Upgrades the pgbouncer version used from 1.19.0 to 1.24.1 which fixes CVE-2025-2291, which allowed expired passwords to still be accepted. 
* See slack thread for more context (https://supabase.slack.com/archives/C02AK9166FR/p1744856490947809?thread_ts=1744832076.291779&cid=C02AK9166FR)