### PR TITLE
fix: wrappers server options again

### DIFF
--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/complete.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/complete.sh
@@ -42,7 +42,8 @@ function execute_wrappers_patch {
     option_rec RECORD;
     vault_secrets RECORD;
   BEGIN
-    IF EXISTS (SELECT FROM pg_extension WHERE extname = 'wrappers' AND extversion NOT IN (
+    IF EXISTS (SELECT FROM pg_extension WHERE extname = 'wrappers')
+      AND EXISTS (SELECT FROM pg_available_extension_versions WHERE name = 'wrappers' AND version NOT IN (
       '0.1.0',
       '0.1.1',
       '0.1.4',


### PR DESCRIPTION
If e.g. upgrading from Wrappers 0.4.5 to 0.4.6, when the check happens, `pg_extension` still registers Wrappers as version 0.4.5. This only gets updated during `run_generated_sql`.

So instead we check the availability of non-old Wrappers versions in `pg_available_extension_versions`.