### PR TITLE
docs: schema.sql per maj version update

### DIFF
--- a/migrations/README.md
+++ b/migrations/README.md
@@ -130,7 +130,22 @@ After making changes to migrations, you should update the schema.sql files for e
 nix run .#dbmate-tool -- --version all
 ```
 
-This will create a schema.sql file for each major version of PostgreSQL and OrioleDB (the files are named like `schema-<ver>`, `schema-oriole-<ver>`). Commit these changes to your repository and push to your branch. The test.yml workflow will verify these changes against the test matrix.
+This will create automatically  schema.sql file for each major version of PostgreSQL and OrioleDB (the files are named like `schema-<ver>`, `schema-oriole-<ver>`). Commit these changes to your repository and push to your branch. The workflow in `.github/workflows/test.yml`  will re-run this command in CI, and perform a git diff to verify the idempotency of the migrations, and that the latest changes have been committed.
+
 ## Testing
 
-Migrations are tested in CI to ensure they do not raise an exception against previously released `supabase/postgres` docker images. The full version matrix is at [test.yml](./.github/workflows/test.yml) in the `supabase-version` variable.
+In addition to ci test mentioned above, you can test migrations locallay by running the following test for each major version of postgres one at a time.
+
+Examples:
+
+```
+nix build .#checks.aarch64-darwin.psql_15 -L
+nix build .#checks.aarch64-darwin.psql_17 -L
+nix build .#checks.aarch64-darwin.psql_orioledb-17 -L
+```
+
+(Note that the evaluation and nix build of the postgres packages "bundle" of each major version must succeed here, even though we run one version at a time. If you made changes to postgres or extensions, or wrappers those may rebuild here when you run this. Otherwise they will usually download the prebuilt version from the supabase nix binary cache)
+
+At the end of these commands, you will see the output of both `pg_regress` tests, and migration tests
+
+see [Adding Tests](https://github.com/supabase/postgres/blob/develop/nix/docs/adding-tests.md) for more information.

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -130,7 +130,7 @@ After making changes to migrations, you should update the schema.sql files for e
 nix run .#dbmate-tool -- --version all
 ```
 
-This will create a schema.sql file for each major version of PostgreSQL. Commit these changes to your repository and push to your branch. The test.yml workflow will verify these changes against the test matrix.
+This will create a schema.sql file for each major version of PostgreSQL and OrioleDB (the files are named like `schema-<ver>`, `schema-oriole-<ver>`). Commit these changes to your repository and push to your branch. The test.yml workflow will verify these changes against the test matrix.
 ## Testing
 
 Migrations are tested in CI to ensure they do not raise an exception against previously released `supabase/postgres` docker images. The full version matrix is at [test.yml](./.github/workflows/test.yml) in the `supabase-version` variable.

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -134,7 +134,7 @@ This will create automatically  schema.sql file for each major version of Postgr
 
 ## Testing
 
-In addition to ci test mentioned above, you can test migrations locallay by running the following test for each major version of postgres one at a time.
+In addition to ci test mentioned above, you can test migrations locally by running the following test for each major version of postgres one at a time.
 
 Examples:
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs needed coverage on updating schema.sql per major version based on feedback from @kangmingtay who tried to use the docs. They lacked this information. 