### PR TITLE
feat: for schema tests, try to use pg_dump

### DIFF
--- a/migrations/schema-15.sql
+++ b/migrations/schema-15.sql
@@ -1,3 +1,10 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 15.8
+-- Dumped by pg_dump version 15.8
+
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
@@ -996,10 +1003,5 @@ CREATE EVENT TRIGGER pgrst_drop_watch ON sql_drop
 
 --
 -- PostgreSQL database dump complete
---
-
-
---
--- Dbmate schema migrations
 --
 

--- a/migrations/schema-17.sql
+++ b/migrations/schema-17.sql
@@ -1,3 +1,10 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 17.4
+-- Dumped by pg_dump version 17.4
+
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
@@ -983,10 +990,5 @@ CREATE EVENT TRIGGER pgrst_drop_watch ON sql_drop
 
 --
 -- PostgreSQL database dump complete
---
-
-
---
--- Dbmate schema migrations
 --
 

--- a/migrations/schema-orioledb-17.sql
+++ b/migrations/schema-orioledb-17.sql
@@ -1,3 +1,10 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 17.0
+-- Dumped by pg_dump version 17.0
+
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
@@ -997,10 +1004,5 @@ CREATE EVENT TRIGGER pgrst_drop_watch ON sql_drop
 
 --
 -- PostgreSQL database dump complete
---
-
-
---
--- Dbmate schema migrations
 --
 

--- a/nix/tools/dbmate-tool.sh.in
+++ b/nix/tools/dbmate-tool.sh.in
@@ -187,17 +187,10 @@ perform_dump() {
     local attempt=1
     
     while [ $attempt -le $max_attempts ]; do
-        echo "Attempting dbmate dump (attempt $attempt/$max_attempts)"
+        echo "Attempting pg_dump (attempt $attempt/$max_attempts)"
         
-        # Run dbmate dump
-        if dbmate dump; then
-            # Post-process schema.sql to remove schema_migrations INSERT statements
-            if [ -f "db/schema.sql" ]; then
-                # Remove INSERT INTO schema_migrations lines
-                sed -i '/^INSERT INTO schema_migrations/d' db/schema.sql
-                echo "Schema dump completed successfully (schema_migrations data removed)"
-                return 0
-            fi
+        if "${PSQLBIN}/pg_dump" -h localhost -p "$PORTNO" -U "$PGSQL_SUPERUSER" -d postgres --schema-only --no-owner --no-privileges > "./db/schema.sql"; then
+            return 0
         fi
         
         echo "Dump attempt $attempt failed, waiting before retry..."


### PR DESCRIPTION
## What kind of change does this PR introduce?

dbmate works for generating new migrations, but it [causes problems for generating schema dumps](https://github.com/supabase/postgres/pull/1560#discussion_r2052967090) 

This PR attempts to switch to using pg_dump to generate the schemas, which are only used for testing idempotency of the migrations in ci. pg_dump likely will be good enough for that. 