### PR TITLE
chore: bump admin api version and sb ami version

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -52,7 +52,7 @@ postgres_exporter_release_checksum:
   arm64: sha256:29ba62d538b92d39952afe12ee2e1f4401250d678ff4b354ff2752f4321c87a0
   amd64: sha256:cb89fc5bf4485fb554e0d640d9684fae143a4b2d5fa443009bd29c59f9129e84
 
-adminapi_release: 0.83.0
+adminapi_release: 0.83.1
 adminmgr_release: 0.25.0
 
 vector_x86_deb: "https://packages.timber.io/vector/0.22.3/vector_0.22.3-1_amd64.deb"

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -9,9 +9,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.0.1.072-orioledb"
-  postgres17: "17.4.1.022"
-  postgres15: "15.8.1.079"
+  postgresorioledb-17: "17.0.1.073-orioledb"
+  postgres17: "17.4.1.023"
+  postgres15: "15.8.1.080"
 
 # Non Postgres Extensions
 pgbouncer_release: "1.19.0"
@@ -52,7 +52,7 @@ postgres_exporter_release_checksum:
   arm64: sha256:29ba62d538b92d39952afe12ee2e1f4401250d678ff4b354ff2752f4321c87a0
   amd64: sha256:cb89fc5bf4485fb554e0d640d9684fae143a4b2d5fa443009bd29c59f9129e84
 
-adminapi_release: 0.82.0
+adminapi_release: 0.83.0
 adminmgr_release: 0.25.0
 
 vector_x86_deb: "https://packages.timber.io/vector/0.22.3/vector_0.22.3-1_amd64.deb"


### PR DESCRIPTION
## What kind of change does this PR introduce?
This PR bumps the version of Admin API to be bundled in with the SB AMI build. The update itself relates to tracking installed PG extensions and their versions on each project and writing that out for restores.