### PR TITLE
chore: update admin api to 0.84.1

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -9,9 +9,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.0.1.074-orioledb"
-  postgres17: "17.4.1.024"
-  postgres15: "15.8.1.081"
+  postgresorioledb-17: "17.0.1.075-orioledb"
+  postgres17: "17.4.1.025"
+  postgres15: "15.8.1.082"
 
 # Non Postgres Extensions
 pgbouncer_release: "1.19.0"
@@ -52,7 +52,7 @@ postgres_exporter_release_checksum:
   arm64: sha256:29ba62d538b92d39952afe12ee2e1f4401250d678ff4b354ff2752f4321c87a0
   amd64: sha256:cb89fc5bf4485fb554e0d640d9684fae143a4b2d5fa443009bd29c59f9129e84
 
-adminapi_release: 0.84.0
+adminapi_release: 0.84.1
 adminmgr_release: 0.25.0
 
 vector_x86_deb: "https://packages.timber.io/vector/0.22.3/vector_0.22.3-1_amd64.deb"


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bumping Admin API to version `0.84.1`.