### PR TITLE
feat: update rust to 1.84.0 and related needed changes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -123,11 +123,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1728538411,
-        "narHash": "sha256-f0SBJz1eZ2yOuKUr5CA9BHULGXVSn6miBuUWdTyhUhU=",
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
         "type": "github"
       },
       "original": {
@@ -151,11 +151,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1729045942,
-        "narHash": "sha256-HjmK0x5Zm2TK2vFpC7XBM2e3EDNVnAIuEoU2FkeN8xw=",
+        "lastModified": 1746758179,
+        "narHash": "sha256-JECUw1YBEsTsVauvupRzE5ykZaJoyhHCpoY87ZZJGas=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9de3cea452d2401d6f93c06ad985178a4e11d1fc",
+        "rev": "4fd00513eac6b6140c5dced3e1b8133e2369a0f8",
         "type": "github"
       },
       "original": {

--- a/nix/ext/pg_graphql.nix
+++ b/nix/ext/pg_graphql.nix
@@ -27,7 +27,9 @@ buildPgrxExtension_0_12_9 rec {
   # Setting RUSTFLAGS in env to ensure it's available for all phases
   env = lib.optionalAttrs stdenv.isDarwin {
     POSTGRES_LIB = "${postgresql}/lib";
-    PGPORT = if (lib.versions.major postgresql.version) == "17" then "5440" else "5439";
+    PGPORT = toString (5430 + 
+      (if builtins.match ".*_.*" postgresql.version != null then 1 else 0) +  # +1 for OrioleDB
+      ((builtins.fromJSON (builtins.substring 0 2 postgresql.version)) - 15) * 2);  # +2 for each major version
     RUSTFLAGS = "-C link-arg=-undefined -C link-arg=dynamic_lookup";
     NIX_BUILD_CORES = "4";  # Limit parallel jobs
     CARGO_BUILD_JOBS = "4"; # Limit cargo parallelism

--- a/nix/ext/wrappers/default.nix
+++ b/nix/ext/wrappers/default.nix
@@ -12,7 +12,7 @@
 , git
 }:
 let
-  rustVersion = "1.81.0";
+  rustVersion = "1.84.0";
   cargo = rust-bin.stable.${rustVersion}.default;
 in
 buildPgrxExtension_0_12_9 rec {
@@ -50,7 +50,7 @@ buildPgrxExtension_0_12_9 rec {
     # - PostgreSQL 15.8 → 5435 + 0 + (15-15)*2 = 5435
     # - PostgreSQL 17_0 (OrioleDB) → 5435 + 1 + (17-15)*2 = 5440
     # - PostgreSQL 17.4 → 5435 + 0 + (17-15)*2 = 5439
-    PGPORT = toString (5435 + 
+    PGPORT = toString (5534 + 
       (if builtins.match ".*_.*" postgresql.version != null then 1 else 0) +  # +1 for OrioleDB
       ((builtins.fromJSON (builtins.substring 0 2 postgresql.version)) - 15) * 2);  # +2 for each major version
   };


### PR DESCRIPTION
## What kind of change does this PR introduce?

needed to run `nix flake update rust-overlay` to bring on the code that would make rust 1.84.0 available to the nix build (this command updated just that rust-overlay input for the `flake.lock` file.)

Then, due to port conflicts on extension that rely on rust for pgrx builds, updating the input triggered a rebuild of other pg extensions (although did not change their dependencies, but it will always rebuild if inputs change version in any way). This created port conflicts for the internal tests the extensions run. So I applied a port handling to pg_graphql as well to fix that issue. 