### PR TITLE
fix: changes to envoy external ip headers for use by auth rate limiting

### DIFF
--- a/ansible/files/envoy_config/lds.yaml
+++ b/ansible/files/envoy_config/lds.yaml
@@ -25,6 +25,9 @@ resources:
                     '@type': >-
                       type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
               generate_request_id: false
+              use_remote_address: true
+              xff_num_trusted_hops: 1
+              skip_xff_append: true
               http_filters:
                 - name: envoy.filters.http.cors
                   typed_config:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Added new external IP to envoy external IP. This is the IP before the last hop based on the x-forwarded-for header.

## What is the current behavior?

Currently Envoy acts transparently in regards to x-forwarded-for headers, does not add or delete. 

## What is the new behavior?

envoy will append a new x-envoy-external-address header that will only include the IP address of before that last hop (i.e. the client before the ALB)

## Additional context

Please see internal infra discussion on this vs at the auth layer