### PR TITLE
fix: update adminapi systemd unit file to wait for the network

### DIFF
--- a/ansible/files/adminapi.service.j2
+++ b/ansible/files/adminapi.service.j2
@@ -2,7 +2,6 @@
 Description=AdminAPI
 Requires=network-online.target
 After=network-online.target pgbouncer.service
-Wants=pgbouncer.service
 
 # Move this to the Service section if on systemd >=250
 StartLimitIntervalSec=60

--- a/ansible/files/adminapi.service.j2
+++ b/ansible/files/adminapi.service.j2
@@ -1,5 +1,12 @@
 [Unit]
 Description=AdminAPI
+Requires=network-online.target
+After=network-online.target pgbouncer.service
+Wants=pgbouncer.service
+
+# Move this to the Service section if on systemd >=250
+StartLimitIntervalSec=60
+StartLimitBurst=10
 
 [Service]
 Type=simple
@@ -7,10 +14,13 @@ ExecStart=/opt/supabase-admin-api
 User=adminapi
 Restart=always
 RestartSec=3
+TimeoutStopSec=10
 Environment="AWS_USE_DUALSTACK_ENDPOINT=true"
 {% if qemu_mode is defined and qemu_mode %}
 Environment="AWS_SDK_LOAD_CONFIG=true"
 {% endif %}
+StandardOutput=journal
+StandardError=journal
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This PR updates the `admin-api` systemd unit file to wait on the network to become active before trying to start. We are seeing errors quite often in logs for failed starts and we should ensure the best possible conditions for a clean start.