### PR TITLE
fix: drop pgbouncer from unit after

### DIFF
--- a/ansible/files/adminapi.service.j2
+++ b/ansible/files/adminapi.service.j2
@@ -1,7 +1,7 @@
 [Unit]
 Description=AdminAPI
 Requires=network-online.target
-After=network-online.target pgbouncer.service
+After=network-online.target
 
 # Move this to the Service section if on systemd >=250
 StartLimitIntervalSec=60

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -9,9 +9,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.0.1.081-orioledb"
-  postgres17: "17.4.1.031"
-  postgres15: "15.8.1.088"
+  postgresorioledb-17: "17.0.1.082-orioledb"
+  postgres17: "17.4.1.032"
+  postgres15: "15.8.1.089"
 
 # Non Postgres Extensions
 pgbouncer_release: "1.19.0"


### PR DESCRIPTION
## What kind of change does this PR introduce?
Drops `pgbouncer` from the `After` in the systemd unit file. Admin API handles this gracefully internally.