### PR TITLE
fix: continue to use previous way to read old pg version in upgrade script

### DIFF
--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
@@ -41,7 +41,7 @@ LOG_FILE="/var/log/pg-upgrade-initiate.log"
 
 POST_UPGRADE_EXTENSION_SCRIPT="/tmp/pg_upgrade/pg_upgrade_extensions.sql"
 POST_UPGRADE_POSTGRES_PERMS_SCRIPT="/tmp/pg_upgrade/pg_upgrade_postgres_perms.sql"
-OLD_PGVERSION=$(pg_config --version | sed 's/PostgreSQL \([0-9]*\.[0-9]*\).*/\1/')
+OLD_PGVERSION=$(run_sql -A -t -c "SHOW server_version;")
 
 # Skip locale settings if both versions are PostgreSQL 17+
 if ! [[ "$OLD_PGVERSION" =~ ^17.* && "$PGVERSION" =~ ^17.* ]]; then

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -9,9 +9,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.0.1.084-orioledb"
-  postgres17: "17.4.1.034"
-  postgres15: "15.8.1.091"
+  postgresorioledb-17: "17.0.1.085-orioledb"
+  postgres17: "17.4.1.035"
+  postgres15: "15.8.1.092"
 
 # Non Postgres Extensions
 pgbouncer_release: "1.19.0"


### PR DESCRIPTION
Some very old versions of pg may have a mismatch on installed binary versions, which could break upgrade. Therefore we'll revert back to this method to detect version to avoid that failure. 