### PR TITLE
feat: covering ranges for upgrades

### DIFF
--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
@@ -430,8 +430,8 @@ $(cat /etc/postgresql/pg_hba.conf)" > /etc/postgresql/pg_hba.conf
        # Add the setting if not found
     echo "max_slot_wal_keep_size = -1" >> "$TMP_CONFIG"
 
-    # Remove db_user_namespace if upgrading from PG15 or lower
-    if [[ "${OLD_PGVERSION%%.*}" -le 15 && "$PGVERSION" =~ ^17.* ]]; then
+    # Remove db_user_namespace if upgrading from PG15 or lower to PG16+
+    if [[ "${OLD_PGVERSION%%.*}" -le 15 && "${PGVERSION%%.*}" -ge 16 ]]; then
         sed -i '/^db_user_namespace/d' "$TMP_CONFIG"
     fi
 

--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
@@ -430,8 +430,8 @@ $(cat /etc/postgresql/pg_hba.conf)" > /etc/postgresql/pg_hba.conf
        # Add the setting if not found
     echo "max_slot_wal_keep_size = -1" >> "$TMP_CONFIG"
 
-    # Remove db_user_namespace if upgrading from PG15
-    if [[ "$OLD_PGVERSION" =~ ^15.* && "$PGVERSION" =~ ^17.* ]]; then
+    # Remove db_user_namespace if upgrading from PG15 or lower
+    if [[ "${OLD_PGVERSION%%.*}" -le 15 && "$PGVERSION" =~ ^17.* ]]; then
         sed -i '/^db_user_namespace/d' "$TMP_CONFIG"
     fi
 

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -9,9 +9,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.0.1.085-orioledb"
-  postgres17: "17.4.1.035"
-  postgres15: "15.8.1.092"
+  postgresorioledb-17: "17.0.1.086-orioledb"
+  postgres17: "17.4.1.036"
+  postgres15: "15.8.1.093"
 
 # Non Postgres Extensions
 pgbouncer_release: "1.19.0"

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -9,9 +9,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.0.1.086-orioledb"
-  postgres17: "17.4.1.036"
-  postgres15: "15.8.1.093"
+  postgresorioledb-17: "17.0.1.086-orioledb-up-1"
+  postgres17: "17.4.1.036-up-1"
+  postgres15: "15.8.1.093-up-1"
 
 # Non Postgres Extensions
 pgbouncer_release: "1.19.0"

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -9,9 +9,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.0.1.086-orioledb-up-1"
-  postgres17: "17.4.1.036-up-1"
-  postgres15: "15.8.1.093-up-1"
+  postgresorioledb-17: "17.0.1.086-orioledb"
+  postgres17: "17.4.1.036"
+  postgres15: "15.8.1.093"
 
 # Non Postgres Extensions
 pgbouncer_release: "1.19.0"


### PR DESCRIPTION
In this PR we are expanding the coverage to pg major version equal to or less than 15, to cover pg 14 instances, for config adjustments that need to happen to upgrade postgres. Need to cover ranges for differences between 15 and lower, or 16 and higher (instead of specific version) for various operations. 