### PR TITLE
feat: bump auth to v2.174.0

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -9,9 +9,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.0.1.086-orioledb"
-  postgres17: "17.4.1.036"
-  postgres15: "15.8.1.093"
+  postgresorioledb-17: "17.0.1.087-orioledb"
+  postgres17: "17.4.1.037"
+  postgres15: "15.8.1.094"
 
 # Non Postgres Extensions
 pgbouncer_release: "1.19.0"
@@ -24,8 +24,8 @@ postgrest_release: "12.2.3"
 postgrest_arm_release_checksum: sha1:fbfd6613d711ce1afa25c42d5df8f1b017f396f9
 postgrest_x86_release_checksum: sha1:61c513f91a8931be4062587b9d4a18b42acf5c05
 
-gotrue_release: 2.173.0
-gotrue_release_checksum: sha1:8ec5e9396f3b30cb867d32bdbe39fcfdd78f1f59
+gotrue_release: 2.174.0
+gotrue_release_checksum: sha1:d9ac9bb209a5e0b383ab96e05d05409eaebdbaac
 
 aws_cli_release: "2.23.11"
 


### PR DESCRIPTION
bump auth to v2.174.0 for postgres AMIs