### PR TITLE
ci: build pg17 + pg17-oriole for qemu vm

### DIFF
--- a/.github/workflows/qemu-image-build.yml
+++ b/.github/workflows/qemu-image-build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set PostgreSQL versions - only builds pg17 atm
         id: set-versions
         run: |
-          VERSIONS=$(nix run nixpkgs#yq --  '.postgres_major[2]' ansible/vars.yml | nix run nixpkgs#jq -- -R -s -c 'split("\n")[:-1]')
+          VERSIONS=$(nix run nixpkgs#yq --  '.postgres_major[1,2]' ansible/vars.yml | nix run nixpkgs#jq -- -R -s -c 'split("\n")[:-1]')
           echo "postgres_versions=$VERSIONS" >> $GITHUB_OUTPUT
 
   build:


### PR DESCRIPTION
## What kind of change does this PR introduce?

ci 

## What is the current behavior?

Qemu artifact only builds pg17-oriole. 

## What is the new behavior?

Qemu artifact builds both pg17-oriole and standard pg17

## Additional context

n/a