### PR TITLE
chore: add cargo pgrx v0.14.3 for nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -75,6 +75,10 @@
                 cargo-pgrx = final.cargo-pgrx.cargo-pgrx_0_12_9;
               };
 
+              buildPgrxExtension_0_14_3 = prev.buildPgrxExtension.override {
+                cargo-pgrx = final.cargo-pgrx.cargo-pgrx_0_14_3;
+              };
+
             })
             (final: prev: {
               postgresql = final.callPackage ./nix/postgresql/default.nix {
@@ -417,6 +421,7 @@
             cargo-pgrx_0_11_3 = pkgs.cargo-pgrx.cargo-pgrx_0_11_3;
             cargo-pgrx_0_12_6 = pkgs.cargo-pgrx.cargo-pgrx_0_12_6;
             cargo-pgrx_0_12_9 = pkgs.cargo-pgrx.cargo-pgrx_0_12_9;
+            cargo-pgrx_0_14_3 = pkgs.cargo-pgrx.cargo-pgrx_0_14_3;
             # PostgreSQL versions.
             psql_15 = postgresVersions.psql_15;
             psql_17 = postgresVersions.psql_17;

--- a/nix/cargo-pgrx/default.nix
+++ b/nix/cargo-pgrx/default.nix
@@ -8,7 +8,7 @@
 , rust-bin
 }:
 let
-  rustVersion = "1.76.0";
+  rustVersion = "1.85.1";
   rustPlatform = makeRustPlatform {
     cargo = rust-bin.stable.${rustVersion}.default;
     rustc = rust-bin.stable.${rustVersion}.default;
@@ -19,6 +19,11 @@ let
     , cargoHash
     }:
     rustPlatform.buildRustPackage rec {
+      # rust-overlay uses 'cargo-auditable' wrapper for 'cargo' command, but it
+      # is using older version 0.18.1 of 'cargo_metadata' which doesn't support
+      # rust edition 2024, so we disable the 'cargo-auditable' just for now.
+      # ref: https://github.com/oxalica/rust-overlay/issues/153
+      auditable = false;
       pname = "cargo-pgrx";
       inherit version;
       src = fetchCrate {
@@ -70,6 +75,11 @@ in
     version = "0.12.9";
     hash = "sha256-aR3DZAjeEEAjLQfZ0ZxkjLqTVMIEbU0UiZ62T4BkQq8=";
     cargoHash = "sha256-53HKhvsKLTa2JCByLEcK3UzWXoM+LTatd98zvS1C9no=";
+  };
+  cargo-pgrx_0_14_3 = generic {
+    version = "0.14.3";
+    hash = "sha256-3TsNpEqNm3Uol5XPW1i0XEbP2fF2+RKB2d7lO6BDnvQ=";
+    cargoHash = "sha256-Ny7j56pwB+2eEK62X0nWfFKQy5fBz+Q1oyvecivxLkk=";
   };
   inherit rustPlatform;
 }

--- a/nix/cargo-pgrx/default.nix
+++ b/nix/cargo-pgrx/default.nix
@@ -74,7 +74,7 @@ in
   cargo-pgrx_0_12_9 = generic {
     version = "0.12.9";
     hash = "sha256-aR3DZAjeEEAjLQfZ0ZxkjLqTVMIEbU0UiZ62T4BkQq8=";
-    cargoHash = "sha256-53HKhvsKLTa2JCByLEcK3UzWXoM+LTatd98zvS1C9no=";
+    cargoHash = "sha256-KTKcol9qSNLQZGW32e6fBb6cPkUGItknyVpLdBYqrBY=";
   };
   cargo-pgrx_0_14_3 = generic {
     version = "0.14.3";


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add pgrx v0.14.3 build to Nix, which is required by Wrappers version >= 0.5.1

## What is the current behavior?

Current cargo pgrx build version is up to 0.12.9

## What is the new behavior?

Added a new package `cargo-pgrx_0_14_3`.

## Additional context

- Rust version is upgraded to 1.85.1
- `cargo-auditable` is disable as it doesn't support Rust edition 2024 yet