### PR TITLE
feat: update nix build ci to checkout fork if workflow approved

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -31,9 +31,11 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
           fetch-tags: true
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: aws-creds
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -80,4 +82,3 @@ jobs:
           AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
 
     name: build psql bundle on ${{ matrix.arch }}
-    


### PR DESCRIPTION
## What kind of change does this PR introduce?

When someone outside of the supabase organization submits a PR, and if their running of workflows is approved by a supabase maintainer after thorough review, then the gh action workflow needs to be able to checkout the code from the submitting repo.

This PR addresses the issue for Nix CI build, and may also include changes after testing for other workflows. 