### PR TITLE
Use nix-fast-build to build all checks

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -18,11 +18,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: larger-runner-4cpu
+          - runner: large-linux-x86
             arch: amd64
-          - runner: arm-runner
+          - runner: large-linux-arm
             arch: arm64
-          - runner: macos-latest
+          - runner: macos-latest-xlarge
             arch: arm64
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 180

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -70,8 +70,10 @@ jobs:
             substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com
             trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=% cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
       - name: Build psql bundle
-        run: |
-          ./docker/nix/build_nix.sh
+        run: >
+            nix run "github:Mic92/nix-fast-build?rev=b1dae483ab7d4139a6297e02b6de9e5d30e43d48" 
+            -- --skip-cached --no-nom 
+            --flake ".#checks.$(nix eval --raw --impure --expr 'builtins.currentSystem')"
         env:
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -43,37 +43,36 @@ jobs:
           python -c "import os; file = open('nix-secret-key', 'w'); file.write(os.environ['NIX_SIGN_SECRET_KEY']); file.close()"
         env:
           NIX_SIGN_SECRET_KEY: ${{ secrets.NIX_SIGN_SECRET_KEY }}
-      - name: Log in to Docker Hub
-        if: matrix.runner != 'macos-latest' && matrix.runner != 'macos-13' && github.secret_source == 'Actions'
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Build psql bundle with nix
-        if: matrix.runner != 'macos-latest' && matrix.runner != 'macos-13'
-        run: docker build -t base_nix -f docker/nix/Dockerfile .
-      - name: Run build psql bundle
-        if: matrix.runner != 'macos-latest' && matrix.runner != 'macos-13'
-        run:  |
-          docker run -e AWS_ACCESS_KEY_ID=${{ env.AWS_ACCESS_KEY_ID }} \
-                    -e AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }} \
-                    -e AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }} \
-                    base_nix bash -c "./workspace/docker/nix/build_nix.sh"
-      - name: Build psql bundle on macos
-        if: matrix.runner == 'macos-latest' || matrix.runner == 'macos-13'
+      - name: Setup cache script
+        if: ${{ github.secret_source == 'Actions' }}
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --no-confirm \
-          --extra-conf "substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com" \
-          --extra-conf "trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=% cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
-          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-          cp ./docker/nix/build_nix.sh ./build_nix.sh
-          sed -i '' '1s|^#!/bin/env bash|#!/usr/bin/env bash|' ./build_nix.sh
-          chmod +x ./build_nix.sh
-          ./build_nix.sh
+          mkdir -p /etc/nix
+          cat << 'EOF' | sudo tee /etc/nix/upload-to-cache.sh > /dev/null
+          #!/usr/bin/env bash
+          set -eouf
+          export IFS=' '
+          echo /nix/var/nix/profiles/default/bin/nix copy --to 's3://nix-postgres-artifacts?secret-key=nix-secret-key' \$OUT_PATHS
+          EOF
+          chmod +x /etc/nix/upload-to-cache.sh
+      - name: Install nix
+        uses: DeterminateSystems/nix-installer-action@main
+        if: ${{ github.secret_source == 'Actions' }}
+        with:
+          extra-conf: |
+            substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com
+            trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=% cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+            post-build-hook = /etc/nix/upload-to-cache.sh
+      - name: Install nix
+        uses: DeterminateSystems/nix-installer-action@main
+        if: ${{ github.secret_source == 'None' }}
+        with:
+          extra-conf: |
+            substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com
+            trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=% cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+      - name: Build psql bundle
+        run: |
+          ./docker/nix/build_nix.sh
         env:
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
           AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
-
-    name: build psql bundle on ${{ matrix.arch }}
-    

--- a/docker/nix/build_nix.sh
+++ b/docker/nix/build_nix.sh
@@ -6,40 +6,4 @@ if [ -d "/workspace" ]; then
     cd /workspace
 fi
 
-SYSTEM=$(nix-instantiate --eval -E builtins.currentSystem | tr -d '"')
-
-nix build .#checks.$SYSTEM.psql_15 -L --no-link
-nix build .#checks.$SYSTEM.psql_orioledb-17 -L --no-link
-nix build .#checks.$SYSTEM.psql_17 -L --no-link
-nix build .#psql_15/bin -o psql_15 -L
-nix build .#psql_orioledb-17/bin -o psql_orioledb_17 -L
-nix build .#psql_17/bin -o psql_17 -L
-nix build .#wal-g-2 -o wal-g-2 -L
-nix build .#wal-g-3 -o wal-g-3 -L
-
-# Copy to S3
-if [[ -n "${AWS_ACCESS_KEY_ID-}" && -n "${AWS_SECRET_ACCESS_KEY-}" ]]; then
-    nix copy --to s3://nix-postgres-artifacts?secret-key=nix-secret-key ./wal-g-2
-    nix copy --to s3://nix-postgres-artifacts?secret-key=nix-secret-key ./wal-g-3
-    nix copy --to s3://nix-postgres-artifacts?secret-key=nix-secret-key ./psql_15
-    nix copy --to s3://nix-postgres-artifacts?secret-key=nix-secret-key ./psql_orioledb_17
-    nix copy --to s3://nix-postgres-artifacts?secret-key=nix-secret-key ./psql_17
-fi
-
-if [ "$SYSTEM" = "aarch64-linux" ]; then
-    nix build .#postgresql_15_debug -o ./postgresql_15_debug
-    nix build .#postgresql_15_src -o ./postgresql_15_src
-    nix build .#postgresql_orioledb-17_debug -o ./postgresql_orioledb-17_debug
-    nix build .#postgresql_orioledb-17_src -o ./postgresql_orioledb-17_src
-    nix build .#postgresql_17_debug -o ./postgresql_17_debug
-    nix build .#postgresql_17_src -o ./postgresql_17_src
-
-    if [[ -n "${AWS_ACCESS_KEY_ID-}" && -n "${AWS_SECRET_ACCESS_KEY-}" ]]; then
-        nix copy --to s3://nix-postgres-artifacts?secret-key=nix-secret-key ./postgresql_15_debug-debug
-        nix copy --to s3://nix-postgres-artifacts?secret-key=nix-secret-key  ./postgresql_15_src
-        nix copy --to s3://nix-postgres-artifacts?secret-key=nix-secret-key ./postgresql_orioledb-17_debug-debug
-        nix copy --to s3://nix-postgres-artifacts?secret-key=nix-secret-key  ./postgresql_orioledb-17_src
-        nix copy --to s3://nix-postgres-artifacts?secret-key=nix-secret-key ./postgresql_17_debug-debug
-        nix copy --to s3://nix-postgres-artifacts?secret-key=nix-secret-key  ./postgresql_17_src
-    fi
-fi
+nix run "github:Mic92/nix-fast-build?rev=b1dae483ab7d4139a6297e02b6de9e5d30e43d48" -- --skip-cached --no-nom --flake ".#checks"

--- a/flake.nix
+++ b/flake.nix
@@ -1125,11 +1125,7 @@
 
                 TMPDIR_BASE=$(mktemp -d)
 
-                if [[ "$(uname)" == "Darwin" ]]; then
-                  KEY_DIR="/private/tmp/pgsodium"
-                else
-                  KEY_DIR="''${PGSODIUM_KEY_DIR:-$TMPDIR_BASE/pgsodium}"
-                fi
+                KEY_DIR="''${PGSODIUM_KEY_DIR:-$TMPDIR_BASE/pgsodium}"
                 KEY_FILE="$KEY_DIR/pgsodium.key"
 
                 if ! mkdir -p "$KEY_DIR" 2>/dev/null; then
@@ -1165,6 +1161,7 @@
               name = "start-postgres-server-test";
               extraSubstitutions = {
                 PGSODIUM_GETKEY = "${getkey-script}/bin/pgsodium-getkey";
+                PGSQL_DEFAULT_PORT = pgPort;
               };
             };
 
@@ -1217,6 +1214,12 @@
             # Filter SQL test files
             filteredSqlTests = filterTestFiles majorVersion ./nix/tests/sql;
 
+            pgPort = if (majorVersion == "17") then
+                "5535"
+                else if (majorVersion == "15") then
+                "5536"
+                else "5537";
+
             # Convert filtered tests to a sorted list of basenames (without extension)
             testList = pkgs.lib.mapAttrsToList
               (name: _:
@@ -1251,7 +1254,7 @@
             substitute ${./nix/tests/postgresql.conf.in} "$PGTAP_CLUSTER"/postgresql.conf \
               --subst-var-by PGSODIUM_GETKEY_SCRIPT "${getkey-script}/bin/pgsodium-getkey"
             echo "listen_addresses = '*'" >> "$PGTAP_CLUSTER"/postgresql.conf
-            echo "port = ${pgsqlDefaultPort}" >> "$PGTAP_CLUSTER"/postgresql.conf
+            echo "port = ${pgPort}" >> "$PGTAP_CLUSTER"/postgresql.conf
             echo "host all all 127.0.0.1/32 trust" >> $PGTAP_CLUSTER/pg_hba.conf
             echo "Checking shared_preload_libraries setting:"
             grep -rn "shared_preload_libraries" "$PGTAP_CLUSTER"/postgresql.conf
@@ -1272,10 +1275,10 @@
 
             # PostgreSQL startup
             if [[ "$(uname)" == "Darwin" ]]; then
-            pg_ctl -D "$PGTAP_CLUSTER" -l "$PGTAP_CLUSTER"/postgresql.log -o "-k "$PGTAP_CLUSTER" -p ${pgsqlDefaultPort} -d 5" start 2>&1
+            pg_ctl -D "$PGTAP_CLUSTER" -l "$PGTAP_CLUSTER"/postgresql.log -o "-k "$PGTAP_CLUSTER" -p ${pgPort} -d 5" start 2>&1
             else
             mkdir -p "$PGTAP_CLUSTER/sockets"
-            pg_ctl -D "$PGTAP_CLUSTER" -l "$PGTAP_CLUSTER"/postgresql.log -o "-k $PGTAP_CLUSTER/sockets -p ${pgsqlDefaultPort} -d 5" start 2>&1
+            pg_ctl -D "$PGTAP_CLUSTER" -l "$PGTAP_CLUSTER"/postgresql.log -o "-k $PGTAP_CLUSTER/sockets -p ${pgPort} -d 5" start 2>&1
             fi || {
             echo "pg_ctl failed to start PostgreSQL"
             echo "Contents of postgresql.log:"
@@ -1283,7 +1286,7 @@
             exit 1
             }
             for i in {1..60}; do
-              if pg_isready -h ${pgsqlDefaultHost} -p ${pgsqlDefaultPort}; then
+              if pg_isready -h ${pgsqlDefaultHost} -p ${pgPort}; then
                 echo "PostgreSQL is ready"
                 break
               fi
@@ -1297,8 +1300,8 @@
                 exit 1
               fi
             done
-            createdb -p ${pgsqlDefaultPort} -h ${pgsqlDefaultHost} --username=supabase_admin testing
-            if ! psql -p ${pgsqlDefaultPort} -h ${pgsqlDefaultHost} --username=supabase_admin -d testing -v ON_ERROR_STOP=1 -Xaf ${./nix/tests/prime.sql}; then
+            createdb -p ${pgPort} -h ${pgsqlDefaultHost} --username=supabase_admin testing
+            if ! psql -p ${pgPort} -h ${pgsqlDefaultHost} --username=supabase_admin -d testing -v ON_ERROR_STOP=1 -Xf ${./nix/tests/prime.sql}; then
               echo "Error executing SQL file. PostgreSQL log content:"
               cat "$PGTAP_CLUSTER"/postgresql.log
               pg_ctl -D "$PGTAP_CLUSTER" stop
@@ -1306,7 +1309,7 @@
             fi
             SORTED_DIR=$(mktemp -d)
             for t in $(printf "%s\n" ${builtins.concatStringsSep " " sortedTestList}); do
-              psql -p ${pgsqlDefaultPort} -h ${pgsqlDefaultHost} --username=supabase_admin -d testing -f "${./nix/tests/sql}/$t.sql" || true
+              psql -p ${pgPort} -h ${pgsqlDefaultHost} --username=supabase_admin -d testing -f "${./nix/tests/sql}/$t.sql" || true
             done
             rm -rf "$SORTED_DIR"
             pg_ctl -D "$PGTAP_CLUSTER" stop
@@ -1317,16 +1320,11 @@
             # which is start by the start-postgres-server-bin script
             # start-postgres-server-bin script closely matches our AMI setup, configurations and migrations
 
-            # Ensure pgsodium key directory exists with proper permissions
-            if [[ "$(uname)" == "Darwin" ]]; then
-              mkdir -p /private/tmp/pgsodium
-              chmod 1777 /private/tmp/pgsodium
-            fi
             unset GRN_PLUGINS_DIR
             ${start-postgres-server-bin}/bin/start-postgres-server ${getVersionArg pgpkg} --daemonize
 
             for i in {1..60}; do
-                if pg_isready -h ${pgsqlDefaultHost} -p ${pgsqlDefaultPort} -U supabase_admin -q; then
+                if pg_isready -h ${pgsqlDefaultHost} -p ${pgPort} -U supabase_admin -q; then
                     echo "PostgreSQL is ready"
                     break
                 fi
@@ -1337,7 +1335,7 @@
                 fi
             done
 
-            if ! psql -p ${pgsqlDefaultPort} -h ${pgsqlDefaultHost} --no-password --username=supabase_admin -d postgres -v ON_ERROR_STOP=1 -Xaf ${./nix/tests/prime.sql}; then
+            if ! psql -p ${pgPort} -h ${pgsqlDefaultHost} --no-password --username=supabase_admin -d postgres -v ON_ERROR_STOP=1 -Xf ${./nix/tests/prime.sql}; then
               echo "Error executing SQL file"
               exit 1
             fi
@@ -1349,7 +1347,7 @@
               --inputdir=${./nix/tests} \
               --outputdir=$out/regression_output \
               --host=${pgsqlDefaultHost} \
-              --port=${pgsqlDefaultPort} \
+              --port=${pgPort} \
               --user=supabase_admin \
               ${builtins.concatStringsSep " " sortedTestList}; then
               echo "pg_regress tests failed"
@@ -1358,7 +1356,7 @@
             fi
 
             echo "Running migrations tests"
-            pg_prove -p ${pgsqlDefaultPort} -U supabase_admin -h ${pgsqlDefaultHost} -d postgres -v ${./migrations/tests}/test.sql
+            pg_prove -p ${pgPort} -U supabase_admin -h ${pgsqlDefaultHost} -d postgres -v ${./migrations/tests}/test.sql
 
             # Copy logs to output
             for logfile in $(find /tmp -name postgresql.log -type f); do

--- a/flake.nix
+++ b/flake.nix
@@ -1382,6 +1382,9 @@
           psql_15 = makeCheckHarness basePackages.psql_15.bin;
           psql_17 = makeCheckHarness basePackages.psql_17.bin;
           psql_orioledb-17 = makeCheckHarness basePackages.psql_orioledb-17.bin;
+          inherit (basePackages) wal-g-2 wal-g-3;
+        } // pkgs.lib.optionalAttrs (system == "aarch64-linux") {
+          inherit (basePackages) postgresql_15_debug postgresql_15_src postgresql_orioledb-17_debug postgresql_orioledb-17_src postgresql_17_debug postgresql_17_src;
         };
 
         # Apps is a list of names of things that can be executed with 'nix run';


### PR DESCRIPTION
CI build the required nix packages defined in flake checks. We use the
`nix-fast-build` tool to speed up the evaluation and build process.

We now use the same GitHub action to install nix.

We upload the build results to the cache using a post build hook.
