### PR TITLE
feat: add an action that handles git checkouts for all workflows

### DIFF
--- a/.github/actions/shared-checkout/action.yml
+++ b/.github/actions/shared-checkout/action.yml
@@ -1,0 +1,12 @@
+name: Checkout
+description: Checkout repository for pull requests and branches
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
+        fetch-depth: 0
+        fetch-tags: true


### PR DESCRIPTION
## What kind of change does this PR introduce?

Merging an action for shared checkout of both branches of this repo, or fork of this repo if workflow approved. Needed to unblock pull requests from external orgs where workflow approved by supabase organization member. 