### PR TITLE
ci: fix workflow dependencies

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -9,8 +9,10 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
   id-token: write
+  # required by testinfra-ami-build dependent workflows
+  contents: write
+  packages: write
 
 jobs:
   build-run-image:
@@ -84,3 +86,13 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
           AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
+  
+  run-testinfra:
+    needs: build-run-image
+    if: ${{ success() }}
+    uses: ./.github/workflows/testinfra-ami-build.yml
+    
+  run-tests:
+    needs: build-run-image
+    if: ${{ success() }}
+    uses: ./.github/workflows/test.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,7 @@
 name: Test Database
 on:
-  # Trigger this workflow when the "Nix CI" workflow completes
-  workflow_run:
-    workflows: ["Nix CI"]
-    types:
-      - completed
   workflow_dispatch:
+  workflow_call:
 
 permissions:
   contents: read
@@ -13,7 +9,6 @@ permissions:
 
 jobs:
   prepare:
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: large-linux-x86
     outputs:
       postgres_versions: ${{ steps.set-versions.outputs.postgres_versions }}
@@ -31,7 +26,6 @@ jobs:
           VERSIONS=$(nix run nixpkgs#yq -- '.postgres_major[]' ansible/vars.yml | nix run nixpkgs#jq -- -R -s -c "split(\"\n\")[:-1]")
           echo "postgres_versions=$VERSIONS" >> $GITHUB_OUTPUT
   build:
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     needs: prepare
     strategy:
       matrix:

--- a/.github/workflows/testinfra-ami-build.yml
+++ b/.github/workflows/testinfra-ami-build.yml
@@ -1,12 +1,8 @@
 name: Testinfra Integration Tests Nix
 
 on:
-  # Trigger this workflow when the "Nix CI" workflow completes
-  workflow_run:
-    workflows: ["Nix CI"]
-    types:
-      - completed
   workflow_dispatch:
+  workflow_call:
 
 permissions:
   contents: read
@@ -14,7 +10,6 @@ permissions:
 
 jobs:
   prepare:
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: large-linux-x86
     outputs:
       postgres_versions: ${{ steps.set-versions.outputs.postgres_versions }}
@@ -31,7 +26,6 @@ jobs:
           echo "postgres_versions=$VERSIONS" >> $GITHUB_OUTPUT
 
   test-ami-nix:
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     needs: prepare
     strategy:
       fail-fast: false


### PR DESCRIPTION
We want to run test.yaml and testinfra-ami-build.yaml after nix-build.yaml. We start using reusable workflow instead of relying on workflow_run which doesn't work well with pull requests.