### PR TITLE
chore: disable auth config reloading within qemu artifact

### DIFF
--- a/ansible/files/gotrue.service.j2
+++ b/ansible/files/gotrue.service.j2
@@ -4,7 +4,12 @@ Description=Gotrue
 [Service]
 Type=simple
 WorkingDirectory=/opt/gotrue
+{% if qemu_mode is defined and qemu_mode %}
+ExecStart=/opt/gotrue/gotrue
+{% else %}
 ExecStart=/opt/gotrue/gotrue --config-dir /etc/auth.d
+{% endif %}
+
 User=gotrue
 Restart=always
 RestartSec=3


### PR DESCRIPTION
The QEMU artifact is not running with a filesystem that supports the
inotify API, resulting in spurious error messages, and broken config
reloading.