### PR TITLE
fix: gandalf path name

### DIFF
--- a/ansible/manifest-playbook.yml
+++ b/ansible/manifest-playbook.yml
@@ -63,7 +63,7 @@
 
     - name: Download gandalf archive
       get_url:
-        url: "https://supabase-public-artifacts-bucket.s3.amazonaws.com/gandalf/v{{ gandalf_release }}/gandalf_{{ gandalf_release }}_linux_arm64.tar.gz"
+        url: "https://supabase-public-artifacts-bucket.s3.amazonaws.com/gandalf/v{{ gandalf_release }}/gandalf-{{ gandalf_release }}-linux-arm64.tar.gz"
         dest: "/tmp/gandalf.tar.gz"
         timeout: 90
 


### PR DESCRIPTION
Should use `-` instead of `_`

CI failure: https://github.com/supabase/postgres/actions/runs/15870216211/job/44744951792#step:14:58