### PR TITLE
fix: needed a release to rollout fixes that address pgmq issues

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -9,9 +9,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.0.1.099-orioledb"
-  postgres17: "17.4.1.049"
-  postgres15: "15.8.1.106"
+  postgresorioledb-17: "17.0.1.100-orioledb"
+  postgres17: "17.4.1.050"
+  postgres15: "15.8.1.107"
 
 # Non Postgres Extensions
 pgbouncer_release: "1.19.0"


### PR DESCRIPTION
related to https://github.com/supabase/postgres/pull/1471

To roll out new upgrade scripts for a new Postgres version, you must update the relevant version in ansible/vars.yml. The workflow will use whatever is defined there as the source of truth for Postgres versions and release strings.
you can see in https://github.com/supabase/postgres/blob/develop/.github/workflows/publish-nix-pgupgrade-bin-flake-version.yml and https://github.com/supabase/postgres/blob/develop/.github/workflows/publish-nix-pgupgrade-scripts.yml
The workflow explicitly reads versions from ansible/vars.yml:
In the prepare job, it runs: VERSIONS=$(nix run nixpkgs#yq -- '.postgres_major[]' ansible/vars.yml | nix run nixpkgs#jq -- -R -s -c 'split("\n")[:-1]') This extracts the list of Postgres major versions directly from the .postgres_major array in ansible/vars.yml.
It looks up exact release strings from ansible/vars.yml for each version: In both publish-staging and publish-prod jobs, it runs: VERSION=(nix{{ matrix.postgres_version }}'"]' ansible/vars.yml)
This uses the major version (from the previous step) to look up the corresponding release string in .postgres_release in ansible/vars.yml.
The workflow uses these values for publishing: The workflow matrix cycles through each version found in ansible/vars.yml. All script uploads, tarball creation, and artifact naming are based on these values.
Unless you explicitly override the version via workflow_dispatch input, these values are always sourced from ansible/vars.yml.
.github/workflows/publish-nix-pgupgrade-scripts.yml is also tied to the version and release info in ansible/vars.yml. To roll out upgrade scripts for new Postgres versions, you must update ansible/vars.yml with the new version and release string.
