### PR TITLE
fix: hardcode the salt gpg keys path as it never changes

### DIFF
--- a/ansible/files/supabase_admin_agent_config/supabase-admin-agent.sudoers.conf
+++ b/ansible/files/supabase_admin_agent_config/supabase-admin-agent.sudoers.conf
@@ -1,2 +1,2 @@
 %supabase-admin-agent ALL= NOPASSWD: /usr/bin/salt-call
-%supabase-admin-agent ALL= NOPASSWD: /usr/bin/gpg --homedir {{ gpgdir }} --import, /usr/bin/gpg --homedir {{ gpgdir }} --list-secret-keys *
+%supabase-admin-agent ALL= NOPASSWD: /usr/bin/gpg --homedir /etc/salt/gpgkeys --import, /usr/bin/gpg --homedir /etc/salt/gpgkeys --list-secret-keys *


### PR DESCRIPTION
## What kind of change does this PR introduce?
This PR updates the `sudoers` file for the `supabase-admin-agent` to be able to execute commands using `sudo`. We are adding the Salt gpg keys path as a hardcoded value as it never changes.