### PR TITLE
fix: bump ami version

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -9,9 +9,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.0.1.103-orioledb"
-  postgres17: "17.4.1.053"
-  postgres15: "15.8.1.110"
+  postgresorioledb-17: "17.0.1.104-orioledb"
+  postgres17: "17.4.1.054"
+  postgres15: "15.8.1.111"
 
 # Non Postgres Extensions
 pgbouncer_release: "1.19.0"


### PR DESCRIPTION
* Includes changes made in https://github.com/supabase/postgres/pull/1697/files
* It only includes the above change as the previous AMI bump was made in #1695 