### PR TITLE
chore: bump to PostgREST v12.2.12

### DIFF
--- a/ansible/manifest-playbook.yml
+++ b/ansible/manifest-playbook.yml
@@ -24,7 +24,7 @@
 
     - name: PostgREST - download ubuntu binary archive (arm)
       get_url:
-        url: "https://github.com/PostgREST/postgrest/releases/download/v{{ postgrest_release }}/postgrest-v{{ postgrest_release }}-ubuntu-aarch64.tar.xz"
+        url: "https://github.com/PostgREST/postgrest/releases/download/v{{ postgrest_release }}/postgrest-v{{ postgrest_release }}-ubuntu-20.04-aarch64.tar.xz"
         dest: /tmp/postgrest-{{ postgrest_release }}-arm64.tar.xz
         checksum: "{{ postgrest_arm_release_checksum }}"
         timeout: 60

--- a/ansible/tasks/setup-postgrest.yml
+++ b/ansible/tasks/setup-postgrest.yml
@@ -48,7 +48,7 @@
 
 - name: PostgREST - download ubuntu binary archive (arm)
   get_url:
-    url: "https://github.com/PostgREST/postgrest/releases/download/v{{ postgrest_release }}/postgrest-v{{ postgrest_release }}-ubuntu-aarch64.tar.xz"
+    url: "https://github.com/PostgREST/postgrest/releases/download/v{{ postgrest_release }}/postgrest-v{{ postgrest_release }}-ubuntu-20.04-aarch64.tar.xz"
     dest: /tmp/postgrest.tar.xz
     checksum: "{{ postgrest_arm_release_checksum }}"
     timeout: 60
@@ -56,7 +56,7 @@
 
 - name: PostgREST - download ubuntu binary archive (x86)
   get_url:
-    url: "https://github.com/PostgREST/postgrest/releases/download/v{{ postgrest_release }}/postgrest-v{{ postgrest_release }}-linux-static-x64.tar.xz"
+    url: "https://github.com/PostgREST/postgrest/releases/download/v{{ postgrest_release }}/postgrest-v{{ postgrest_release }}-linux-static-x86-64.tar.xz"
     dest: /tmp/postgrest.tar.xz
     checksum: "{{ postgrest_x86_release_checksum }}"
     timeout: 60    

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -9,20 +9,19 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.0.1.104-orioledb"
-  postgres17: "17.4.1.054"
-  postgres15: "15.8.1.111"
+  postgresorioledb-17: "17.0.1.105-orioledb"
+  postgres17: "17.4.1.055"
+  postgres15: "15.8.1.112"
 
 # Non Postgres Extensions
 pgbouncer_release: "1.19.0"
 pgbouncer_release_checksum: sha256:af0b05e97d0e1fd9ad45fe00ea6d2a934c63075f67f7e2ccef2ca59e3d8ce682
 
-# to get these use
-# wget https://github.com/PostgREST/postgrest/releases/download/v12.2.3/postgrest-v12.2.3-ubuntu-aarch64.tar.xz -q -O- | sha1sum
-# wget https://github.com/PostgREST/postgrest/releases/download/v12.2.3/postgrest-v12.2.3-linux-static-x64.tar.xz -q -O- | sha1sum
-postgrest_release: "12.2.3"
-postgrest_arm_release_checksum: sha1:fbfd6613d711ce1afa25c42d5df8f1b017f396f9
-postgrest_x86_release_checksum: sha1:61c513f91a8931be4062587b9d4a18b42acf5c05
+# The checksum can be found under "Assets", in the GitHub release page for each version:
+# https://github.com/PostgREST/postgrest/releases
+postgrest_release: "12.2.12"
+postgrest_arm_release_checksum: sha256:6b2eaa5759329e024df76f79d93f6bb3d87a93de11433acc5d66aa6c96f81f90
+postgrest_x86_release_checksum: sha256:5de4092f1719da3353c40bf96c8dec6913f2254a7cd0b61cc05f233153b557d5
 
 gotrue_release: 2.177.0
 gotrue_release_checksum: sha1:664a26237618c4bfb1e33e4f03a540c3cef3e3c8


### PR DESCRIPTION
Updates the v12 to the latest patch release.