### PR TITLE
fix: use cachix nix installer with pinned nix version

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -63,18 +63,20 @@ jobs:
           EOF
           sudo chmod +x /etc/nix/upload-to-cache.sh
       - name: Install nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: cachix/install-nix-action@v27
         if: ${{ github.secret_source == 'Actions' }}
         with:
-          extra-conf: |
+          install_url: https://releases.nixos.org/nix/nix-2.29.1/install
+          extra_nix_config: |
             substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com
             trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=% cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
             post-build-hook = /etc/nix/upload-to-cache.sh
       - name: Install nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: cachix/install-nix-action@v27
         if: ${{ github.secret_source == 'None' }}
         with:
-          extra-conf: |
+          install_url: https://releases.nixos.org/nix/nix-2.29.1/install
+          extra_nix_config: |
             substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com
             trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=% cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
       - name: Aggressive disk cleanup for DuckDB build


### PR DESCRIPTION
## What kind of change does this PR introduce?

* https://nix.dev/manual/nix/2.30/release-notes/rl-2.30.html#backward-incompatible-changes-and-deprecations a breaking change in nix that changes where nix does builds
* I was using determinate systems nix-installer-action which doesn't have a way to pin the version of nix apparently, and so it just rolls forward.  I definitely do not want to do that.
* switched to cachix installer action, which does allow to specify a version of nix, builds working again
* trying latest before breaking change 2.29.1