### PR TITLE
feat: disable default database collector for postgres_exporter

### DIFF
--- a/ansible/files/postgres_exporter.service.j2
+++ b/ansible/files/postgres_exporter.service.j2
@@ -3,7 +3,7 @@ Description=Postgres Exporter
 
 [Service]
 Type=simple
-ExecStart=/opt/postgres_exporter/postgres_exporter --disable-settings-metrics --extend.query-path="/opt/postgres_exporter/queries.yml" --disable-default-metrics --no-collector.locks --no-collector.replication --no-collector.replication_slot --no-collector.stat_bgwriter --no-collector.stat_database --no-collector.stat_user_tables --no-collector.statio_user_tables --no-collector.wal
+ExecStart=/opt/postgres_exporter/postgres_exporter --disable-settings-metrics --extend.query-path="/opt/postgres_exporter/queries.yml" --disable-default-metrics --no-collector.locks --no-collector.replication --no-collector.replication_slot --no-collector.stat_bgwriter --no-collector.stat_database --no-collector.stat_user_tables --no-collector.statio_user_tables --no-collector.wal {% if qemu_mode is defined and qemu_mode %}--no-collector.database {% endif %}
 User=postgres
 Group=postgres
 Restart=always

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -9,9 +9,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.5.1.001-orioledb"
-  postgres17: "17.4.1.058"
-  postgres15: "15.8.1.115"
+  postgresorioledb-17: "17.5.1.002-orioledb"
+  postgres17: "17.4.1.059"
+  postgres15: "15.8.1.116"
 
 # Non Postgres Extensions
 pgbouncer_release: "1.19.0"


### PR DESCRIPTION
The database collector emits a metric for the size of each database by
default. We emit a metric that represents the sum of all database,
which suffices for our purposes. This change removes the redundant
per-database metric.