### PR TITLE
fix: admin-agent timer file is a template

### DIFF
--- a/ansible/files/supabase_admin_agent_config/supabase-admin-agent_salt.timer.j2
+++ b/ansible/files/supabase_admin_agent_config/supabase-admin-agent_salt.timer.j2
@@ -4,8 +4,8 @@ Requires=supabase-admin-agent_salt.service
 
 [Timer]
 OnCalendar=*:0/10
-# Random delay up to {{ splay }} seconds splay
-RandomizedDelaySec={{ splay }}
+# Random delay up to {{ supabase_admin_agent_splay }} seconds splay
+RandomizedDelaySec={{ supabase_admin_agent_splay }}
 AccuracySec=1s
 Persistent=true
 

--- a/ansible/tasks/internal/supabase-admin-agent.yml
+++ b/ansible/tasks/internal/supabase-admin-agent.yml
@@ -67,7 +67,7 @@
 
 - name: supabase-admin-agent - create salt systemd timer file
   template:
-    src: files/supabase_admin_agent_config/supabase-admin-agent_salt.timer
+    src: files/supabase_admin_agent_config/supabase-admin-agent_salt.timer.j2
     dest: /etc/systemd/system/supabase-admin-agent_salt.timer
 
 - name: supabase-admin-agent - create salt service file

--- a/ansible/tasks/internal/supabase-admin-agent.yml
+++ b/ansible/tasks/internal/supabase-admin-agent.yml
@@ -66,7 +66,7 @@
     force: yes
 
 - name: supabase-admin-agent - create salt systemd timer file
-  copy:
+  template:
     src: files/supabase_admin_agent_config/supabase-admin-agent_salt.timer
     dest: /etc/systemd/system/supabase-admin-agent_salt.timer
 

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -9,9 +9,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.5.1.005-orioledb"
-  postgres17: "17.4.1.062"
-  postgres15: "15.8.1.119"
+  postgresorioledb-17: "17.5.1.006-orioledb"
+  postgres17: "17.4.1.063"
+  postgres15: "15.8.1.120"
 
 # Non Postgres Extensions
 pgbouncer_release: "1.19.0"

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -9,9 +9,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.5.1.006-orioledb"
-  postgres17: "17.4.1.063"
-  postgres15: "15.8.1.120"
+  postgresorioledb-17: "17.5.1.007-orioledb"
+  postgres17: "17.4.1.064"
+  postgres15: "15.8.1.121"
 
 # Non Postgres Extensions
 pgbouncer_release: "1.19.0"

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -54,6 +54,7 @@ postgres_exporter_release_checksum:
 adminapi_release: 0.84.1
 adminmgr_release: 0.25.1
 supabase_admin_agent_release: 1.4.37
+supabase_admin_agent_splay: 30
 
 vector_x86_deb: "https://packages.timber.io/vector/0.48.X/vector_0.48.0-1_amd64.deb"
 vector_arm_deb: "https://packages.timber.io/vector/0.48.X/vector_0.48.0-1_arm64.deb"


### PR DESCRIPTION
/etc/systemd/system/supabase-admin-agent_salt.timer:8: Failed to parse sec value, ignoring: {{ splay }}

