### PR TITLE
fix: accurately determine disk mount for upgrade disk xvdp

### DIFF
--- a/ansible/tasks/setup-supabase-internal.yml
+++ b/ansible/tasks/setup-supabase-internal.yml
@@ -29,6 +29,12 @@
   shell: "/tmp/aws/install --update"
   become: true
 
+- name: install utilities to manage Amazon EC2 instance storage
+  become: true
+  apt:
+    pkg:
+      - amazon-ec2-utils
+
 - name: AWS CLI - configure ipv6 support for s3
   shell: |
     aws configure set default.s3.use_dualstack_endpoint true


### PR DESCRIPTION
- **chore: install amazon-ec2-utils for ebs nvme mapping tool**
- **fix: accurately determine disk mount for upgrade disk xvdp**

During an upgrade, the future data disk is mounted for the data upgrade. 
It's observed that since upgrading the base image to ubuntu 24.04 there are occurrences
where the disks are available earlier and assigned inconsistent block device names

Here we install amazon-ec2-utils to give us the ebsnvme-id utility that reads the nvme block devices
and determines their ec2 device name that maps to the nvme device name.

* xvda -> root disk
* xvdh -> data disk
* xvdp -> upgrade data disk

Fallback to current implementation when ebsnvme-id is not correctly installed
