### PR TITLE
fix: ensure amazon-ec2-utils is installed before 24.04 upgrade

### DIFF
--- a/ansible/files/admin_api_scripts/grow_fs.sh
+++ b/ansible/files/admin_api_scripts/grow_fs.sh
@@ -13,7 +13,7 @@ if pgrep resizefs; then
 fi
 
 # install amazon disk utilities if not present on 24.04
-if [ "${UBUNTU_VERSION}" = "24.04" ] && ! dpkg -l | grep -q amazon-ec2-utils; then
+if [ "${UBUNTU_VERSION}" = "24.04" ] && ! /usr/bin/dpkg-query -W amazon-ec2-utils >/dev/null 2>&1; then
     apt-get update
     apt-get install -y amazon-ec2-utils || true
 fi
@@ -26,7 +26,7 @@ fi
 XVDA_DEVICE="/dev/nvme0n1"
 XVDH_DEVICE="/dev/nvme1n1"
 # Map AWS devices to NVMe for ubuntu 24.04 and later
-if [ "${UBUNTU_VERSION}" = "24.04" ] && dpkg -l | grep -q amazon-ec2-utils; then
+if [ "${UBUNTU_VERSION}" = "24.04" ] && /usr/bin/dpkg-query -W amazon-ec2-utils >/dev/null 2>&1; then
     for nvme_dev in $(lsblk -dprno name,type | grep disk | awk '{print $1}'); do
         if [ -b "$nvme_dev" ]; then
             mapping=$(ebsnvme-id -b "$nvme_dev" 2>/dev/null)

--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
@@ -350,6 +350,13 @@ function initiate_upgrade {
     if [ -z "$IS_CI" ] && [ -z "$IS_LOCAL_UPGRADE" ]; then
         # DATABASE_UPGRADE_DATA_MIGRATION_DEVICE_NAME = '/dev/xvdp' can be derived from the worker mount
         echo "5. Determining block device to mount"
+        # lsb release
+        UBUNTU_VERSION=$(lsb_release -rs)
+        # install amazon disk utilities if not present on 24.04
+        if [ "${UBUNTU_VERSION}" = "24.04" ] && ! dpkg -l | grep -q amazon-ec2-utils; then
+            apt-get update
+            apt-get install -y amazon-ec2-utils || true
+        fi
         if command -v ebsnvme-id >/dev/null 2>&1 && dpkg -l | grep -q amazon-ec2-utils; then
             for nvme_dev in $(lsblk -dprno name,size,mountpoint,type | grep disk | awk '{print $1}'); do
                 if [ -b "$nvme_dev" ]; then

--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
@@ -353,11 +353,11 @@ function initiate_upgrade {
         # lsb release
         UBUNTU_VERSION=$(lsb_release -rs)
         # install amazon disk utilities if not present on 24.04
-        if [ "${UBUNTU_VERSION}" = "24.04" ] && ! dpkg -l | grep -q amazon-ec2-utils; then
+        if [ "${UBUNTU_VERSION}" = "24.04" ] && ! /usr/bin/dpkg-query -W amazon-ec2-utils >/dev/null 2>&1; then
             apt-get update
             apt-get install -y amazon-ec2-utils || true
         fi
-        if command -v ebsnvme-id >/dev/null 2>&1 && dpkg -l | grep -q amazon-ec2-utils; then
+        if command -v ebsnvme-id >/dev/null 2>&1 && /usr/bin/dpkg-query -W amazon-ec2-utils >/dev/null 2>&1; then
             for nvme_dev in $(lsblk -dprno name,size,mountpoint,type | grep disk | awk '{print $1}'); do
                 if [ -b "$nvme_dev" ]; then
                     mapping=$(ebsnvme-id -b "$nvme_dev" 2>/dev/null)


### PR DESCRIPTION
Although this should be installed on the ami, some projects exist without.
Initiate is pulled at upgrade time
