### PR TITLE
fix  don't use PrivateTmp for SAA unit

### DIFF
--- a/ansible/files/supabase_admin_agent_config/supabase-admin-agent_salt.service
+++ b/ansible/files/supabase_admin_agent_config/supabase-admin-agent_salt.service
@@ -14,8 +14,5 @@ StandardError=journal
 StateDirectory=supabase-admin-agent
 CacheDirectory=supabase-admin-agent
 
-# Security hardening
-PrivateTmp=true
-
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#PrivateTmp=

```
This setting is useful to secure access to temporary files of the process, but makes sharing between processes via /tmp/ or /var/tmp/ impossible. 
```

Unfortunately using PrivateTmp doesn't allow sharing between processes and it seems that when using it here, it can cause tmp file issues between saa and salt.
