### PR TITLE
fix: path to vars.yml for mirror postgrest job

### DIFF
--- a/.github/workflows/mirror-postgrest.yml
+++ b/.github/workflows/mirror-postgrest.yml
@@ -6,7 +6,7 @@ on:
       - develop
     paths:
       - ".github/workflows/mirror-postgrest.yml"
-      - "common.vars*"
+      - "ansible/vars.yml"
 
 permissions:
   contents: read


### PR DESCRIPTION
## What kind of change does this PR introduce?

ci

## What is the new behavior?

Continue to mirror postgrest images on version bump.

## Additional context

Add any other context or screenshots.