### PR TITLE
feat: bump auth to v2.179.0

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -24,8 +24,8 @@ postgrest_release: "13.0.5"
 postgrest_arm_release_checksum: sha256:7b4eafdaf76bc43b57f603109d460a838f89f949adccd02f452ca339f9a0a0d4
 postgrest_x86_release_checksum: sha256:05be2bd48abee6c1691fc7c5d005023466c6989e41a4fc7d1302b8212adb88b5
 
-gotrue_release: 2.178.0
-gotrue_release_checksum: sha1:56c5cf913eebf701ab5805e529375483933a0476
+gotrue_release: 2.179.0
+gotrue_release_checksum: sha1:e985fce00b2720b747e6a04420910015c4967121
 
 aws_cli_release: "2.23.11"
 


### PR DESCRIPTION
Bump Auth to v2.179.0. It's already rolling out with Salt v2 but this for completeness.