### PR TITLE
chore: bump service versions for internal testing

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -9,9 +9,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.5.1.021-orioledb"
-  postgres17: "17.4.1.078"
-  postgres15: "15.8.1.135"
+  postgresorioledb-17: "17.5.1.022-orioledb"
+  postgres17: "17.4.1.079"
+  postgres15: "15.8.1.136"
 
 # Non Postgres Extensions
 pgbouncer_release: "1.19.0"
@@ -52,8 +52,8 @@ postgres_exporter_release_checksum:
   arm64: sha256:29ba62d538b92d39952afe12ee2e1f4401250d678ff4b354ff2752f4321c87a0
   amd64: sha256:cb89fc5bf4485fb554e0d640d9684fae143a4b2d5fa443009bd29c59f9129e84
 
-adminapi_release: 0.84.1
-adminmgr_release: 0.25.1
+adminapi_release: 0.92.0
+adminmgr_release: 0.32.1
 supabase_admin_agent_release: 1.4.38
 supabase_admin_agent_splay: 30
 


### PR DESCRIPTION
Bump `admin-mgr` and `admin-api` versions to test restore updates.