### PR TITLE
fix: bump postgres versions for auth v2.179.0

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -9,9 +9,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.5.1.020-orioledb"
-  postgres17: "17.4.1.077"
-  postgres15: "15.8.1.134"
+  postgresorioledb-17: "17.5.1.021-orioledb"
+  postgres17: "17.4.1.078"
+  postgres15: "15.8.1.135"
 
 # Non Postgres Extensions
 pgbouncer_release: "1.19.0"


### PR DESCRIPTION
Forgot to bump these in #1776.