### PR TITLE
fix: bump pg version for new admin mgr and admin api

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -9,9 +9,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.5.1.022-orioledb"
-  postgres17: "17.6.1.001"
-  postgres15: "15.14.1.001"
+  postgresorioledb-17: "17.5.1.023-orioledb"
+  postgres17: "17.6.1.002"
+  postgres15: "15.14.1.002"
 
 # Non Postgres Extensions
 pgbouncer_release: "1.19.0"
@@ -52,7 +52,7 @@ postgres_exporter_release_checksum:
   arm64: sha256:29ba62d538b92d39952afe12ee2e1f4401250d678ff4b354ff2752f4321c87a0
   amd64: sha256:cb89fc5bf4485fb554e0d640d9684fae143a4b2d5fa443009bd29c59f9129e84
 
-adminapi_release: 0.92.0
+adminapi_release: 0.92.1
 adminmgr_release: 0.32.1
 supabase_admin_agent_release: 1.4.38
 supabase_admin_agent_splay: 30


### PR DESCRIPTION
Bump PG version and `admin-api` to encompass fixes.