### PR TITLE
feat: add retry policy for auth service routes

### DIFF
--- a/ansible/files/envoy_config/lds.supabase.yaml
+++ b/ansible/files/envoy_config/lds.supabase.yaml
@@ -235,7 +235,7 @@ resources:
                             google_re2:
                               max_program_size: 150
                             regex: >-
-                              /auth/v1/(verify|callback|authorize|sso/saml/(acs|metadata|slo)|\.well-known/(openid-configuration|jwks\.json))
+                              /auth/v1/(verify|callback|authorize|sso/saml/(acs|metadata|slo))
                         request_headers_to_remove:
                           - apikey
                           - sb-opk
@@ -259,6 +259,12 @@ resources:
                           cluster: gotrue
                           prefix_rewrite: /
                           timeout: 35s
+                          retry_policy:
+                            retry_on: "connect-failure,refused-stream,gateway-error"
+                            num_retries: 3
+                            retry_back_off:
+                              base_interval: 1s
+                              max_interval: 3s
                       - match:
                           prefix: /rest/v1/
                           query_parameters:

--- a/ansible/files/envoy_config/lds.supabase.yaml
+++ b/ansible/files/envoy_config/lds.supabase.yaml
@@ -235,7 +235,7 @@ resources:
                             google_re2:
                               max_program_size: 150
                             regex: >-
-                              /auth/v1/(verify|callback|authorize|sso/saml/(acs|metadata|slo))
+                              /auth/v1/(verify|callback|authorize|sso/saml/(acs|metadata|slo)|\.well-known/(openid-configuration|jwks\.json))
                         request_headers_to_remove:
                           - apikey
                           - sb-opk

--- a/ansible/files/envoy_config/lds.yaml
+++ b/ansible/files/envoy_config/lds.yaml
@@ -261,7 +261,7 @@ resources:
                             google_re2:
                               max_program_size: 150
                             regex: >-
-                              /auth/v1/(verify|callback|authorize|sso/saml/(acs|metadata|slo)|\.well-known/(openid-configuration|jwks\.json))
+                              /auth/v1/(verify|callback|authorize|sso/saml/(acs|metadata|slo))
                         request_headers_to_remove:
                           - apikey
                           - sb-opk
@@ -285,6 +285,12 @@ resources:
                           cluster: gotrue
                           prefix_rewrite: /
                           timeout: 35s
+                          retry_policy:
+                            retry_on: "connect-failure,refused-stream,gateway-error"
+                            num_retries: 3
+                            retry_back_off:
+                              base_interval: 1s
+                              max_interval: 3s
                       - match:
                           prefix: /rest/v1/
                           query_parameters:

--- a/ansible/files/envoy_config/lds.yaml
+++ b/ansible/files/envoy_config/lds.yaml
@@ -261,7 +261,7 @@ resources:
                             google_re2:
                               max_program_size: 150
                             regex: >-
-                              /auth/v1/(verify|callback|authorize|sso/saml/(acs|metadata|slo))
+                              /auth/v1/(verify|callback|authorize|sso/saml/(acs|metadata|slo)|\.well-known/(openid-configuration|jwks\.json))
                         request_headers_to_remove:
                           - apikey
                           - sb-opk


### PR DESCRIPTION
## Summary
  - Implements Envoy retry policy for auth service routes to reduce 503 errors during service restarts
  - Adds retry configuration with exponential backoff (1s base, 3s max) for up to 3 attempts
  - Added `retry_on: gateway-error` as it was being inherited from the virtual host definition:

https://github.com/supabase/postgres/blob/cemal/feat-add-auth-retry-policy-for-connect-failure/ansible/files/envoy_config/lds.yaml#L419-L424