### PR TITLE
feat: tighten gotrue.service deps and startup behavior

### DIFF
--- a/ansible/files/gotrue.service.j2
+++ b/ansible/files/gotrue.service.j2
@@ -1,53 +1,6 @@
 [Unit]
 Description=Gotrue
 
-# Avoid starting gotrue while cloud-init is running. It makes a lot of changes
-# and I would like to rule out side effects of it running concurrently along
-# side services.
-After=cloud-init.service
-Wants=cloud-init.target
-
-# I'm not certain waiting for this service will allow it to apply its changes
-# but I think it's prudent to do our best to let salt apply formula.
-After=supabase-admin-agent_salt.service
-
-# Given the fact that auth uses SO_REUSEADDR, I want to rule out capabilities
-# being modified between restarts early in boot. This plugs up the scenario that
-# EADDRINUSE errors originate from a previous gotrue process starting without
-# the SO_REUSEADDR flag (due to lacking capability at that point in boot proc)
-# so when the next gotrue starts it can't re-use a slow releasing socket.
-After=apparmor.service
-
-# We want sysctl's to be applied
-After=systemd-sysctl.service
-
-# UFW Is modified by cloud init, but started non-blocking, so configuration
-# could be in-flight while gotrue is starting. I want to ensure future rules
-# that are relied on for security posture are applied before gotrue runs.
-After=ufw.service
-
-# We need networking & resolution, auth uses the Go DNS resolver (not libc)
-# so it's possible `localhost` resolution could be unstable early in startup. We
-# care about this because SO_REUSEADDR eligibility checks the tuple
-# (proto, family, addr, port) meaning the AF_INET (ipv4, ipv6) could affect the
-# binding resulting in a second way for EADDRINUSE errors to surface.
-#
-# Note: We should consider removing localhost usage given `localhost` resolution
-# can often be racey early in boot, can be difficult to debug and offers no real
-# advantage in our infra. At the very least avoiding DNS resolved binding would
-# be a good idea.
-Wants=network-online.target systemd-resolved.service
-After=network-online.target systemd-resolved.service
-
-# Auth server can't start unless postgres is online, lets remove a lot of auth
-# server noise during slow starts by requiring it.
-Wants=postgresql.service
-After=postgresql.service
-
-# Lower start limit ival and burst to prevent the noisy flapping
-StartLimitIntervalSec=10
-StartLimitBurst=5
-
 [Service]
 Type=exec
 WorkingDirectory=/opt/gotrue

--- a/ansible/files/gotrue.service.j2
+++ b/ansible/files/gotrue.service.j2
@@ -1,6 +1,49 @@
 [Unit]
 Description=Gotrue
 
+# Avoid starting gotrue while cloud-init is running. It makes a lot of changes
+# and I would like to rule out side effects of it running concurrently along
+# side services.
+After=cloud-init.service
+Wants=cloud-init.target
+
+# Given the fact that auth uses SO_REUSEADDR, I want to rule out capabilities
+# being modified between restarts early in boot. This plugs up the scenario that
+# EADDRINUSE errors originate from a previous gotrue process starting without
+# the SO_REUSEADDR flag (due to lacking capability at that point in boot proc)
+# so when the next gotrue starts it can't re-use a slow releasing socket.
+After=apparmor.service
+
+# We want sysctl's to be applied
+After=systemd-sysctl.service
+
+# UFW Is modified by cloud init, but started non-blocking, so configuration
+# could be in-flight while gotrue is starting. I want to ensure future rules
+# that are relied on for security posture are applied before gotrue runs.
+After=ufw.service
+
+# We need networking & resolution, auth uses the Go DNS resolver (not libc)
+# so it's possible `localhost` resolution could be unstable early in startup. We
+# care about this because SO_REUSEADDR eligibility checks the tuple
+# (proto, family, addr, port) meaning the AF_INET (ipv4, ipv6) could affect the
+# binding resulting in a second way for EADDRINUSE errors to surface.
+#
+# Note: We should consider removing localhost usage given `localhost` resolution
+# can often be racey early in boot, can be difficult to debug and offers no real
+# advantage in our infra. At the very least avoiding DNS resolved binding would
+# be a good idea.
+Wants=network-online.target systemd-resolved.service
+After=network-online.target systemd-resolved.service
+
+# Auth server can't start unless postgres is online, lets remove a lot of auth
+# server noise during slow starts by requiring it.
+Wants=postgresql.service
+After=postgresql.service
+
+# Lower start limit ival and burst to prevent the noisy flapping
+StartLimitIntervalSec=10
+StartLimitBurst=5
+
 [Service]
 Type=exec
 WorkingDirectory=/opt/gotrue
@@ -34,9 +77,14 @@ Environment=GOTRUE_RELOADING_POLLER_ENABLED=false
 # ensures only 1 reload operation occurs during a burst of config updates.
 Environment=GOTRUE_RELOADING_GRACE_PERIOD_INTERVAL=2s
 
-# v3 does not use filesystem notifications for config reloads.
 {% if qemu_mode is defined and qemu_mode %}
+# v3 does not use filesystem notifications for config reloads.
 Environment=GOTRUE_RELOADING_NOTIFY_ENABLED=false
+{% else %}
+# v2 currently relies on notify support, so we will enable it until both v2 / v3
+# have migrated to strictly use signals across all projects. The default is true
+# in gotrue but we will set it defensively here.
+Environment=GOTRUE_RELOADING_NOTIFY_ENABLED=true
 {% endif %}
 
 Slice=services.slice

--- a/ansible/files/gotrue.service.j2
+++ b/ansible/files/gotrue.service.j2
@@ -72,3 +72,4 @@ Slice=services.slice
 
 [Install]
 WantedBy=multi-user.target
+

--- a/ansible/files/gotrue.service.j2
+++ b/ansible/files/gotrue.service.j2
@@ -51,11 +51,10 @@ StartLimitBurst=5
 [Service]
 Type=exec
 WorkingDirectory=/opt/gotrue
-{% if qemu_mode is defined and qemu_mode %}
-ExecStart=/opt/gotrue/gotrue
-{% else %}
+
+# Both v2 & v3 need a config-dir for reloading support.
 ExecStart=/opt/gotrue/gotrue --config-dir /etc/auth.d
-{% endif %}
+ExecReload=/bin/kill -10 $MAINPID
 
 User=gotrue
 Restart=always
@@ -64,9 +63,28 @@ RestartSec=3
 MemoryAccounting=true
 MemoryMax=50%
 
+# These are the historical location of env files. The /etc/auth.d dir will
+# override them when present.
 EnvironmentFile=-/etc/gotrue.generated.env
 EnvironmentFile=/etc/gotrue.env
 EnvironmentFile=-/etc/gotrue.overrides.env
+
+# Both v2 & v3 support reloading via signals, on linux this is SIGUSR1.
+Environment=GOTRUE_RELOADING_SIGNAL_ENABLED=true
+Environment=GOTRUE_RELOADING_SIGNAL_NUMBER=10
+
+# Both v2 & v3 disable the poller. While gotrue sets it to off by default we
+# defensively set it to false here.
+Environment=GOTRUE_RELOADING_POLLER_ENABLED=false
+
+# Determines how much idle time must pass before triggering a reload. This
+# ensures only 1 reload operation occurs during a burst of config updates.
+Environment=GOTRUE_RELOADING_GRACE_PERIOD_INTERVAL=2s
+
+# v3 does not use filesystem notifications for config reloads.
+{% if qemu_mode is defined and qemu_mode %}
+Environment=GOTRUE_RELOADING_NOTIFY_ENABLED=false
+{% endif %}
 
 Slice=services.slice
 

--- a/ansible/files/gotrue.service.j2
+++ b/ansible/files/gotrue.service.j2
@@ -1,8 +1,55 @@
 [Unit]
 Description=Gotrue
 
+# Avoid starting gotrue while cloud-init is running. It makes a lot of changes
+# and I would like to rule out side effects of it running concurrently along
+# side services.
+After=cloud-init.service
+Wants=cloud-init.target
+
+# I'm not certain waiting for this service will allow it to apply its changes
+# but I think it's prudent to do our best to let salt apply formula.
+After=supabase-admin-agent_salt.service
+
+# Given the fact that auth uses SO_REUSEADDR, I want to rule out capabilities
+# being modified between restarts early in boot. This plugs up the scenario that
+# EADDRINUSE errors originate from a previous gotrue process starting without
+# the SO_REUSEADDR flag (due to lacking capability at that point in boot proc)
+# so when the next gotrue starts it can't re-use a slow releasing socket.
+After=apparmor.service
+
+# We want sysctl's to be applied
+After=systemd-sysctl.service
+
+# UFW Is modified by cloud init, but started non-blocking, so configuration
+# could be in-flight while gotrue is starting. I want to ensure future rules
+# that are relied on for security posture are applied before gotrue runs.
+After=ufw.service
+
+# We need networking & resolution, auth uses the Go DNS resolver (not libc)
+# so it's possible `localhost` resolution could be unstable early in startup. We
+# care about this because SO_REUSEADDR eligibility checks the tuple
+# (proto, family, addr, port) meaning the AF_INET (ipv4, ipv6) could affect the
+# binding resulting in a second way for EADDRINUSE errors to surface.
+#
+# Note: We should consider removing localhost usage given `localhost` resolution
+# can often be racey early in boot, can be difficult to debug and offers no real
+# advantage in our infra. At the very least avoiding DNS resolved binding would
+# be a good idea.
+Wants=network-online.target systemd-resolved.service
+After=network-online.target systemd-resolved.service
+
+# Auth server can't start unless postgres is online, lets remove a lot of auth
+# server noise during slow starts by requiring it.
+Wants=postgresql.service
+After=postgresql.service
+
+# Lower start limit ival and burst to prevent the noisy flapping
+StartLimitIntervalSec=10
+StartLimitBurst=5
+
 [Service]
-Type=simple
+Type=exec
 WorkingDirectory=/opt/gotrue
 {% if qemu_mode is defined and qemu_mode %}
 ExecStart=/opt/gotrue/gotrue

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -9,9 +9,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.5.1.025-orioledb"
-  postgres17: "17.6.1.004"
-  postgres15: "15.14.1.004"
+  postgresorioledb-17: "17.5.1.024-orioledb-authsysd-1"
+  postgres17: "17.6.1.003-authsysd-1"
+  postgres15: "15.14.1.003-authsysd-1"
 
 # Non Postgres Extensions
 pgbouncer_release: "1.19.0"

--- a/testinfra/test_ami_nix.py
+++ b/testinfra/test_ami_nix.py
@@ -353,47 +353,39 @@ users:
 
     def is_healthy(ssh) -> bool:
         health_checks = [
-            (
-                "postgres",
-                "sudo -u postgres /usr/bin/pg_isready -U postgres",
-                "journalctl -b -u postgres -n 10 -r --no-pager",
-            ),
+            ("postgres", "sudo -u postgres /usr/bin/pg_isready -U postgres"),
             (
                 "adminapi",
                 f"curl -sf -k --connect-timeout 30 --max-time 60 https://localhost:8085/health -H 'apikey: {supabase_admin_key}'",
-                "journalctl -b -u adminapi -n 10 -r --no-pager",
             ),
             (
                 "postgrest",
                 "curl -sf --connect-timeout 30 --max-time 60 http://localhost:3001/ready",
-                "journalctl -b -u postgrest -n 10 -r --no-pager",
             ),
             (
                 "gotrue",
                 "curl -sf --connect-timeout 30 --max-time 60 http://localhost:8081/health",
-                "journalctl -b -u gotrue -n 10 -r --no-pager",
             ),
-            ("kong", "sudo kong health", ""),
-            ("fail2ban", "sudo fail2ban-client status", ""),
+            ("kong", "sudo kong health"),
+            ("fail2ban", "sudo fail2ban-client status"),
         ]
 
-        for service, command, info_command in health_checks:
+        for service, command in health_checks:
             try:
                 result = run_ssh_command(ssh, command)
-                if result["succeeded"]:
-                    continue
-
-                info_text = ""
-                if info_command is not "":
+                if not result["succeeded"]:
+                    info_text = ""
+                    info_command = f"sudo journalctl -b -u {service} -n 10 -r --no-pager"
                     info_result = run_ssh_command(ssh, info_command)
                     if info_result["succeeded"]:
                         info_text=info_result["stdout"].strip()
-                logger.warning(f"{service} not ready{info_text}")
-                return False
+
+                    logger.warning(f"{service} not ready{info_text}")
+                    return False
+
             except Exception:
                 logger.warning(f"Connection failed during {service} check")
                 return False
-
         return True
 
     while True:

--- a/testinfra/test_ami_nix.py
+++ b/testinfra/test_ami_nix.py
@@ -375,10 +375,12 @@ users:
                 result = run_ssh_command(ssh, command)
                 if not result["succeeded"]:
                     info_text = ""
-                    info_command = f"sudo journalctl -b -u {service} -n 10 -r --no-pager"
+                    info_command = (
+                        f"sudo journalctl -b -u {service} -n 10 -r --no-pager"
+                    )
                     info_result = run_ssh_command(ssh, info_command)
                     if info_result["succeeded"]:
-                        info_text=info_result["stdout"].strip()
+                        info_text = info_result["stdout"].strip()
 
                     logger.warning(f"{service} not ready{info_text}")
                     return False

--- a/testinfra/test_ami_nix.py
+++ b/testinfra/test_ami_nix.py
@@ -353,29 +353,43 @@ users:
 
     def is_healthy(ssh) -> bool:
         health_checks = [
-            ("postgres", "sudo -u postgres /usr/bin/pg_isready -U postgres"),
+            (
+                "postgres",
+                "sudo -u postgres /usr/bin/pg_isready -U postgres",
+                "journalctl -b -u postgres -n 10 -r --no-pager",
+            ),
             (
                 "adminapi",
                 f"curl -sf -k --connect-timeout 30 --max-time 60 https://localhost:8085/health -H 'apikey: {supabase_admin_key}'",
+                "journalctl -b -u adminapi -n 10 -r --no-pager",
             ),
             (
                 "postgrest",
                 "curl -sf --connect-timeout 30 --max-time 60 http://localhost:3001/ready",
+                "journalctl -b -u postgrest -n 10 -r --no-pager",
             ),
             (
                 "gotrue",
                 "curl -sf --connect-timeout 30 --max-time 60 http://localhost:8081/health",
+                "journalctl -b -u gotrue -n 10 -r --no-pager",
             ),
-            ("kong", "sudo kong health"),
-            ("fail2ban", "sudo fail2ban-client status"),
+            ("kong", "sudo kong health", ""),
+            ("fail2ban", "sudo fail2ban-client status", ""),
         ]
 
-        for service, command in health_checks:
+        for service, command, info_command in health_checks:
             try:
                 result = run_ssh_command(ssh, command)
-                if not result["succeeded"]:
-                    logger.warning(f"{service} not ready")
-                    return False
+                if result["succeeded"]:
+                    continue
+
+                info_text = ""
+                if info_command is not "":
+                    info_result = run_ssh_command(ssh, info_command)
+                    if info_result["succeeded"]:
+                        info_text=info_result["stdout"].strip()
+                logger.warning(f"{service} not ready{info_text}")
+                return False
             except Exception:
                 logger.warning(f"Connection failed during {service} check")
                 return False

--- a/testinfra/test_ami_nix.py
+++ b/testinfra/test_ami_nix.py
@@ -376,11 +376,11 @@ users:
                 if not result["succeeded"]:
                     info_text = ""
                     info_command = (
-                        f"sudo journalctl -b -u {service} -n 10 -r --no-pager"
+                        f"sudo journalctl -b -u {service} -n 20 --no-pager"
                     )
                     info_result = run_ssh_command(ssh, info_command)
                     if info_result["succeeded"]:
-                        info_text = info_result["stdout"].strip()
+                        info_text = "\n" + info_result["stdout"].strip()
 
                     logger.warning(f"{service} not ready{info_text}")
                     return False

--- a/testinfra/test_ami_nix.py
+++ b/testinfra/test_ami_nix.py
@@ -375,9 +375,7 @@ users:
                 result = run_ssh_command(ssh, command)
                 if not result["succeeded"]:
                     info_text = ""
-                    info_command = (
-                        f"sudo journalctl -b -u {service} -n 20 --no-pager"
-                    )
+                    info_command = f"sudo journalctl -b -u {service} -n 20 --no-pager"
                     info_result = run_ssh_command(ssh, info_command)
                     if info_result["succeeded"]:
                         info_text = "\n" + info_result["stdout"].strip()


### PR DESCRIPTION
Add stronger ordering and dependency constraints to reduce startup race conditions and noisy flapping:

- Wait for `cloud-init`, `supabase-admin-agent_salt`, `apparmor`, `systemd-sysctl`, and ufw` to complete before starting.
- Require `network-online.target` and `systemd-resolved` for stable DNS resolution; note Go's resolver can race with early boot DNS.
- Ensure `postgresql.service` is online before starting auth to avoid misleading error noise during slow boots.
- Lower `StartLimitIntervalSec` and `StartLimitBurst` to reduce repeated restarts in failure scenarios.
- Switch service type to `exec` instead of `simple`. This removes the tiny window in which systemd is supervising the wrapper process instead of the Go binary.

These changes aim to rule out capability changes, socket reuse races, and incomplete firewall/network config as causes of EADDRINUSE errors and unstable startup.