### PR TITLE
feat(systemd): configure the systemd pager to make debugging via journalctl easier

### DIFF
--- a/ansible/tasks/setup-system.yml
+++ b/ansible/tasks/setup-system.yml
@@ -146,6 +146,16 @@
     group: root
   when: debpkg_mode or nixpkg_mode
 
+- name: configure systemd's pager
+  copy:
+    content: |
+      export SYSTEMD_LESS=FRXMK
+    dest: /etc/profile.d/10-systemd-pager.sh
+    mode: 0644
+    owner: root
+    group: root
+  when: debpkg_mode or nixpkg_mode
+
 - name: set hosts file
   copy:
     content: |


### PR DESCRIPTION
## What kind of change does this PR introduce?

QoL 'feature' in the OS to configure the pager used by systemd/journalctl so that log lines are not truncated

## What is the current behavior?
```
Sep 09 17:15:49 db-ymtelzpzutuirtrtcboq gotrue[178607]: {"level":"fatal","msg":"running db migrations: error executing m>
```

## What is the new behavior?

```
Sep 09 17:15:49 db-ymtelzpzutuirtrtcboq gotrue[178607]: {"level":"fatal","msg":"running db migrations: error executing migrations/20221208132122_backfill_email_last_sign_in_at.up.sql, sql: -- previous backfill migration left last_sign_in_at to be null, which broke some projects\n\ndo $$\nbegin\nupdate auth.identities\n  set last_sign_in_at = '2022-11-25'\n  where\n    last_sign_in_at is null and\n    created_at = '2022-11-25' and\n    updated_at = '2022-11-25' and\n    provider = 'email' and\n    id = user_id::text;\nend $$;\n: ERROR: operator does not exist: uuid = text (SQLSTATE 42883)","time":"2025-09-09T17:15:49Z"}
```

## Additional context

N/A