### PR TITLE
feat: update various git-hosted runners with blacksmith runners

### DIFF
--- a/.github/workflows/ami-release-nix.yml
+++ b/.github/workflows/ami-release-nix.yml
@@ -44,7 +44,7 @@ jobs:
       matrix:
         postgres_version: ${{ fromJson(needs.prepare.outputs.postgres_versions) }}
         include:
-          - runner: blacksmith-32vcpu-ubuntu-2404-arm
+          - runner: blacksmith-2vcpu-ubuntu-2404-arm
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 150
 

--- a/.github/workflows/ami-release-nix.yml
+++ b/.github/workflows/ami-release-nix.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   prepare:
-    runs-on: large-linux-x86
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     outputs:
       postgres_versions: ${{ steps.set-versions.outputs.postgres_versions }}
     steps:
@@ -44,7 +44,7 @@ jobs:
       matrix:
         postgres_version: ${{ fromJson(needs.prepare.outputs.postgres_versions) }}
         include:
-          - runner: large-linux-arm
+          - runner: blacksmith-32vcpu-ubuntu-2404-arm
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 150
 

--- a/.github/workflows/dockerhub-release-matrix.yml
+++ b/.github/workflows/dockerhub-release-matrix.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   prepare:
-    runs-on: large-linux-x86
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     outputs:
       matrix_config: ${{ steps.set-matrix.outputs.matrix_config }}
     steps:

--- a/.github/workflows/manual-docker-release.yml
+++ b/.github/workflows/manual-docker-release.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   prepare:
-    runs-on: large-linux-x86
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     outputs:
       matrix_config: ${{ steps.set-matrix.outputs.matrix_config }}
     steps:
@@ -46,7 +46,7 @@ jobs:
     needs: prepare
     strategy:
       matrix: ${{ fromJson(needs.prepare.outputs.matrix_config) }}
-    runs-on: large-linux-x86
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     outputs:
       build_args: ${{ steps.args.outputs.result }}
     steps:
@@ -72,7 +72,7 @@ jobs:
       matrix:
         postgres: ${{ fromJson(needs.prepare.outputs.matrix_config).include }}
         arch: [amd64, arm64]
-    runs-on: ${{ matrix.arch == 'amd64' && 'large-linux-x86' || 'large-linux-arm' }}
+    runs-on: ${{ matrix.arch == 'amd64' && 'blacksmith-8vcpu-ubuntu-2404' || 'large-linux-arm' }}
     timeout-minutes: 180
     steps:
       - name: Checkout Repo
@@ -141,7 +141,7 @@ jobs:
     strategy:
       matrix:
         include: ${{ fromJson(needs.prepare.outputs.matrix_config).include }}
-    runs-on: large-linux-x86
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     steps:
       - name: Checkout Repo
         uses: supabase/postgres/.github/actions/shared-checkout@HEAD
@@ -185,7 +185,7 @@ jobs:
           ${{ steps.get_version.outputs.pg_version }}_arm64
   combine_results:
     needs: [prepare, merge_manifest]
-    runs-on: large-linux-x86
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     steps:
       - name: Checkout Repo
         uses: supabase/postgres/.github/actions/shared-checkout@HEAD

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -20,9 +20,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: large-linux-x86
+          - runner: blacksmith-32vcpu-ubuntu-2404	
             arch: amd64
-          - runner: large-linux-arm
+          - runner: blacksmith-32vcpu-ubuntu-2404-arm
             arch: arm64
           - runner: macos-latest-xlarge
             arch: arm64

--- a/.github/workflows/publish-migrations-prod.yml
+++ b/.github/workflows/publish-migrations-prod.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: large-linux-arm
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     timeout-minutes: 15
     permissions:
       id-token: write

--- a/.github/workflows/publish-migrations-prod.yml
+++ b/.github/workflows/publish-migrations-prod.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 15
     permissions:
       id-token: write

--- a/.github/workflows/publish-migrations-staging.yml
+++ b/.github/workflows/publish-migrations-staging.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     timeout-minutes: 15
     permissions:
       id-token: write

--- a/.github/workflows/publish-migrations-staging.yml
+++ b/.github/workflows/publish-migrations-staging.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: large-linux-arm
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     timeout-minutes: 15
     permissions:
       id-token: write

--- a/.github/workflows/publish-nix-pgupgrade-bin-flake-version.yml
+++ b/.github/workflows/publish-nix-pgupgrade-bin-flake-version.yml
@@ -12,7 +12,7 @@ permissions:
     
 jobs:
   prepare:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     outputs:
       postgres_versions: ${{ steps.set-versions.outputs.postgres_versions }}
     steps:

--- a/.github/workflows/publish-nix-pgupgrade-bin-flake-version.yml
+++ b/.github/workflows/publish-nix-pgupgrade-bin-flake-version.yml
@@ -12,7 +12,7 @@ permissions:
     
 jobs:
   prepare:
-    runs-on: large-linux-x86
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     outputs:
       postgres_versions: ${{ steps.set-versions.outputs.postgres_versions }}
     steps:

--- a/.github/workflows/publish-nix-pgupgrade-scripts.yml
+++ b/.github/workflows/publish-nix-pgupgrade-scripts.yml
@@ -19,7 +19,7 @@ permissions:
     
 jobs:
   prepare:
-    runs-on: large-linux-x86
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     outputs:
       postgres_versions: ${{ steps.set-versions.outputs.postgres_versions }}
     steps:

--- a/.github/workflows/publish-nix-pgupgrade-scripts.yml
+++ b/.github/workflows/publish-nix-pgupgrade-scripts.yml
@@ -19,7 +19,7 @@ permissions:
     
 jobs:
   prepare:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     outputs:
       postgres_versions: ${{ steps.set-versions.outputs.postgres_versions }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   prepare:
-    runs-on: large-linux-x86
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     outputs:
       postgres_versions: ${{ steps.set-versions.outputs.postgres_versions }}
     steps:

--- a/.github/workflows/testinfra-ami-build.yml
+++ b/.github/workflows/testinfra-ami-build.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   prepare:
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     outputs:
       postgres_versions: ${{ steps.set-versions.outputs.postgres_versions }}
     steps:
@@ -42,7 +42,7 @@ jobs:
       matrix:
         postgres_version: ${{ fromJson(needs.prepare.outputs.postgres_versions) }}
         include:
-          - runner: blacksmith-8vcpu-ubuntu-2404-arm
+          - runner: blacksmith-2vcpu-ubuntu-2404-arm
             arch: arm64
             ubuntu_release: noble
             ubuntu_version: 24.04

--- a/.github/workflows/testinfra-ami-build.yml
+++ b/.github/workflows/testinfra-ami-build.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   prepare:
-    runs-on: large-linux-x86
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     outputs:
       postgres_versions: ${{ steps.set-versions.outputs.postgres_versions }}
     steps:
@@ -42,7 +42,7 @@ jobs:
       matrix:
         postgres_version: ${{ fromJson(needs.prepare.outputs.postgres_versions) }}
         include:
-          - runner: large-linux-arm
+          - runner: blacksmith-8vcpu-ubuntu-2404-arm
             arch: arm64
             ubuntu_release: noble
             ubuntu_version: 24.04


### PR DESCRIPTION
Many github action workflows were failing that were using github hosted runners.

Across the rest of the org we had good luck with https://docs.blacksmith.sh/blacksmith-runners/overview#runner-tags runners, and so this PR attempts to swap those in and also tweak the size used for various jobs.

We did receive a response from a support ticket to github on the hosted action failures. They suggested we recreate the stalled runners. However, we will try this blacksmith approach first as the runners are overall faster for the same resource size.