### PR TITLE
fix: permissions fix for correct sudoers

### DIFF
--- a/ansible/tasks/internal/admin-api.yml
+++ b/ansible/tasks/internal/admin-api.yml
@@ -21,7 +21,7 @@
   copy:
     src: files/adminapi.sudoers.conf
     dest: /etc/sudoers.d/adminapi
-    mode: "0644"
+    mode: "0440"
 
 - name: perms for adminapi
   shell: |

--- a/ansible/tasks/internal/supabase-admin-agent.yml
+++ b/ansible/tasks/internal/supabase-admin-agent.yml
@@ -29,7 +29,7 @@
   copy:
     src: files/supabase_admin_agent_config/supabase-admin-agent.sudoers.conf
     dest: /etc/sudoers.d/supabase-admin-agent
-    mode: "0644"
+    mode: "0440"
 
 - name: Setting arch (x86)
   set_fact:


### PR DESCRIPTION
Fixing warning presented by `visudo -c`
