### PR TITLE
pg_stat_monitor with a logging backend

### DIFF
--- a/ansible/files/postgresql_config/postgresql.conf.j2
+++ b/ansible/files/postgresql_config/postgresql.conf.j2
@@ -688,7 +688,7 @@ default_text_search_config = 'pg_catalog.english'
 #local_preload_libraries = ''
 #session_preload_libraries = ''
 
-shared_preload_libraries = 'pg_stat_statements, pg_stat_monitor, pgaudit, plpgsql, plpgsql_check, pg_cron, pg_net, pgsodium, timescaledb, auto_explain, pg_tle, plan_filter, supabase_vault, pg_stat_monitor'	# (change requires restart)
+shared_preload_libraries = 'pg_stat_statements, pgaudit, plpgsql, plpgsql_check, pg_cron, pg_net, pgsodium, timescaledb, auto_explain, pg_tle, plan_filter, supabase_vault, pg_stat_monitor'	# (change requires restart)
 jit_provider = 'llvmjit'		# JIT library to use
 
 # - Other Defaults -

--- a/ansible/files/postgresql_config/postgresql.conf.j2
+++ b/ansible/files/postgresql_config/postgresql.conf.j2
@@ -776,5 +776,9 @@ include = '/etc/postgresql-custom/read-replica.conf'
 # Add settings for extensions here
 auto_explain.log_min_duration = 10s
 cron.database_name = 'postgres'
-pg_stat_monitor.pgsm_bucket_time = 300
-pg_stat_monitor.pgsm_max_buckets = 2016
+pg_stat_monitor.pgsm_max = 256
+pg_stat_monitor.pgsm_query_shared_buffer = 20
+pg_stat_monitor.pgsm_bucket_time = 3600
+pg_stat_monitor.pgsm_max_buckets = 12
+pg_stat_monitor.pgsm_enable_overflow = false
+pg_stat_monitor.pgsm_query_max_len = 1024

--- a/ansible/files/postgresql_config/postgresql.conf.j2
+++ b/ansible/files/postgresql_config/postgresql.conf.j2
@@ -776,9 +776,11 @@ include = '/etc/postgresql-custom/read-replica.conf'
 # Add settings for extensions here
 auto_explain.log_min_duration = 10s
 cron.database_name = 'postgres'
-pg_stat_monitor.pgsm_max = 256
-pg_stat_monitor.pgsm_query_shared_buffer = 20
+# pg_stat_monitor configuration with JSON logging and minimal memory usage
+pg_stat_monitor.pgsm_enable_json_log = true
+pg_stat_monitor.pgsm_max_buckets = 2
 pg_stat_monitor.pgsm_bucket_time = 3600
-pg_stat_monitor.pgsm_max_buckets = 12
+pg_stat_monitor.pgsm_max = 3
+pg_stat_monitor.pgsm_query_shared_buffer = 2
 pg_stat_monitor.pgsm_enable_overflow = false
-pg_stat_monitor.pgsm_query_max_len = 1024
+pg_stat_monitor.pgsm_query_max_len = 1200

--- a/ansible/files/postgresql_config/postgresql.conf.j2
+++ b/ansible/files/postgresql_config/postgresql.conf.j2
@@ -688,7 +688,7 @@ default_text_search_config = 'pg_catalog.english'
 #local_preload_libraries = ''
 #session_preload_libraries = ''
 
-shared_preload_libraries = 'pg_stat_statements, pgaudit, plpgsql, plpgsql_check, pg_cron, pg_net, pgsodium, timescaledb, auto_explain, pg_tle, plan_filter, supabase_vault'	# (change requires restart)
+shared_preload_libraries = 'pg_stat_statements, pg_stat_monitor, pgaudit, plpgsql, plpgsql_check, pg_cron, pg_net, pgsodium, timescaledb, auto_explain, pg_tle, plan_filter, supabase_vault, pg_stat_monitor'	# (change requires restart)
 jit_provider = 'llvmjit'		# JIT library to use
 
 # - Other Defaults -
@@ -776,3 +776,5 @@ include = '/etc/postgresql-custom/read-replica.conf'
 # Add settings for extensions here
 auto_explain.log_min_duration = 10s
 cron.database_name = 'postgres'
+pg_stat_monitor.pgsm_bucket_time = 300
+pg_stat_monitor.pgsm_max_buckets = 2016

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -9,9 +9,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.5.1.021-orioledb"
-  postgres17: "17.4.1.078"
-  postgres15: "15.8.1.135"
+  postgresorioledb-17: "17.5.1.019-orioledb-psm-1"
+  postgres17: "17.4.1.076-psm-1"
+  postgres15: "15.8.1.133-psm-1"
 
 # Non Postgres Extensions
 pgbouncer_release: "1.19.0"

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -9,9 +9,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.5.1.019-orioledb-psm-1"
-  postgres17: "17.4.1.076-psm-1"
-  postgres15: "15.8.1.133-psm-1"
+  postgresorioledb-17: "17.5.1.019-orioledb-psml-1"
+  postgres17: "17.4.1.076-psml-1"
+  postgres15: "15.8.1.133-psml-1"
 
 # Non Postgres Extensions
 pgbouncer_release: "1.19.0"

--- a/nix/ext/pg_stat_monitor.nix
+++ b/nix/ext/pg_stat_monitor.nix
@@ -12,10 +12,10 @@ stdenv.mkDerivation rec {
   buildInputs = [ postgresql ];
 
   src = fetchFromGitHub {
-    owner = "percona";
+    owner = "olirice";
     repo = pname;
-    rev = "refs/tags/${version}";
-    hash = "sha256-STJVvvrLVLe1JevNu6u6EftzAWv+X+J8lu66su7Or2s=";
+    rev = "or/logs2";
+    hash = "sha256-9vCtDseZ783pVXo/Grvi4rygVxnDZXavw9+zuHXr+0A=";
   };
 
   makeFlags = [ "USE_PGXS=1" ];


### PR DESCRIPTION
Adds a low memory configuration for pg_stat_monitor + a logging backend to durably drive query insights.

this PR is to cut a staging image for experimentation. its in draft

Note that `supabase/infrastructure` specifically strip pg_stat_monitor from shared preloads due to a previous issue, so to test you need to manually ssh in to the staging instance, update postgresql.conf, and then restart postgres