### PR TITLE
refactor(ansible): bring our ansible up to modern ansible-lint standards

### DIFF
--- a/ansible/tasks/setup-envoy.yml
+++ b/ansible/tasks/setup-envoy.yml
@@ -43,7 +43,7 @@
     dest: '/etc/envoy/'
     directory_mode: '0775'
     group: 'envoy'
-    mode: '0644'
+    mode: '0664'
     owner: 'envoy'
     src: 'files/envoy_config/'
 

--- a/ansible/tasks/setup-envoy.yml
+++ b/ansible/tasks/setup-envoy.yml
@@ -41,7 +41,7 @@
 - name: Envoy - create configuration files
   ansible.builtin.copy:
     dest: '/etc/envoy/'
-    directory_mode: '0755'
+    directory_mode: '0775'
     group: 'envoy'
     mode: '0644'
     owner: 'envoy'

--- a/ansible/tasks/setup-envoy.yml
+++ b/ansible/tasks/setup-envoy.yml
@@ -1,60 +1,61 @@
 - name: Envoy - system user
   ansible.builtin.user:
-    name: envoy
+    name: 'envoy'
+    state: 'present'
 
 - name: Envoy - download binary
   ansible.builtin.get_url:
     checksum: "{{ envoy_release_checksum }}"
-    dest: /opt/envoy
-    group: envoy
-    mode: u+x
-    owner: envoy
+    dest: '/opt/envoy'
+    group: 'envoy'
+    mode: '0700'
+    owner: 'envoy'
     # yamllint disable-line rule:line-length
     url: "https://github.com/envoyproxy/envoy/releases/download/v{{ envoy_release }}/envoy-{{ envoy_release }}-linux-aarch_64"
 
 - name: Envoy - download hot restarter script
   ansible.builtin.get_url:
     checksum: "{{ envoy_hot_restarter_release_checksum }}"
-    dest: /opt/envoy-hot-restarter.py
-    group: envoy
-    mode: u+x
-    owner: envoy
+    dest: '/opt/envoy-hot-restarter.py'
+    group: 'envoy'
+    mode: '0700'
+    owner: 'envoy'
     # yamllint disable-line rule:line-length
-    url: https://raw.githubusercontent.com/envoyproxy/envoy/v{{ envoy_release }}/restarter/hot-restarter.py
+    url: "https://raw.githubusercontent.com/envoyproxy/envoy/v{{ envoy_release }}/restarter/hot-restarter.py"
 
 - name: Envoy - bump up ulimit
   community.general.pam_limits:
-    domain: envoy
-    limit_item: nofile
-    limit_type: soft
-    value: 4096
+    domain: 'envoy'
+    limit_item: 'nofile'
+    limit_type: 'soft'
+    value: '4096'
 
 - name: Envoy - create script to start envoy
   ansible.builtin.copy:
-    dest: /opt/start-envoy.sh
-    group: envoy
-    mode: u+x
-    owner: envoy
-    src: files/start-envoy.sh
+    dest: '/opt/start-envoy.sh'
+    group: 'envoy'
+    mode: '0700'
+    owner: 'envoy'
+    src: 'files/start-envoy.sh'
 
 - name: Envoy - create configuration files
   ansible.builtin.copy:
-    dest: /etc/envoy/
-    directory_mode: u=rwx,g=rwx,o=rx
-    group: envoy
-    mode: u=rw,g=rw,o=r
-    owner: envoy
-    src: files/envoy_config/
+    dest: '/etc/envoy/'
+    directory_mode: '0755'
+    group: 'envoy'
+    mode: '0644'
+    owner: 'envoy'
+    src: 'files/envoy_config/'
 
 - name: Envoy - create service file
   ansible.builtin.copy:
-    dest: /etc/systemd/system/envoy.service
-    mode: u=rw,g=r,o=r
-    src: files/envoy.service
+    dest: '/etc/systemd/system/envoy.service'
+    mode: '0644'
+    src: 'files/envoy.service'
 
 - name: Envoy - disable service
-  ansible.builtin.systemd:
+  ansible.builtin.systemd_service:
     daemon_reload: true
     enabled: false
-    name: envoy
-    state: stopped
+    name: 'envoy'
+    state: 'stopped'


### PR DESCRIPTION
The 4th in a series of PRs, going file-by-file cleaning up and modernizing our Ansible to make current `ansible-lint` happy as well as following https://redhat-cop.github.io/automation-good-practices/