### PR TITLE
feat: run pg_regress during extension tests

### DIFF
--- a/nix/ext/pgvector.nix
+++ b/nix/ext/pgvector.nix
@@ -88,5 +88,6 @@ pkgs.buildEnv {
     pname = "${pname}-all";
     version =
       "multi-" + lib.concatStringsSep "-" (map (v: lib.replaceStrings [ "." ] [ "-" ] v) versions);
+    pgRegressTestName = "pgvector";
   };
 }

--- a/nix/ext/tests/timescaledb.nix
+++ b/nix/ext/tests/timescaledb.nix
@@ -66,8 +66,9 @@ self.inputs.nixpkgs.lib.nixos.runTest {
       }
       extension_name = "${pname}"
       support_upgrade = True
+      sql_test_directory = Path("${../../tests}")
 
-      test = PostgresExtensionTest(server, extension_name, versions, support_upgrade)
+      test = PostgresExtensionTest(server, extension_name, versions, sql_test_directory, support_upgrade)
 
       with subtest("Check upgrade path with postgresql 15"):
         test.check_upgrade_path("15")


### PR DESCRIPTION
While testing the upgrade of our PostgreSQL extensions, we also want to run the pg_regress tests that come with the extension. This ensures that the extension is functioning correctly after installation and upgrades.