### PR TITLE
fix: update Dockerfiles for changes to postgis multiversion

### DIFF
--- a/Dockerfile-15
+++ b/Dockerfile-15
@@ -90,10 +90,6 @@ RUN ln -s /nix/var/nix/profiles/default/share/postgresql/* /usr/lib/postgresql/s
 RUN ln -s /nix/var/nix/profiles/default/share/postgresql/* /usr/share/postgresql/
 RUN chown -R postgres:postgres /usr/lib/postgresql/share/postgresql/
 RUN chown -R postgres:postgres /usr/share/postgresql/ 
-# Create symbolic links for contrib directory
-RUN mkdir -p /usr/lib/postgresql/share/postgresql/contrib \
-    && find /nix/var/nix/profiles/default/share/postgresql/contrib/ -mindepth 1 -type d -exec sh -c 'for dir do ln -s "$dir" "/usr/lib/postgresql/share/postgresql/contrib/$(basename "$dir")"; done' sh {} + \
-    && chown -R postgres:postgres /usr/lib/postgresql/share/postgresql/contrib/
 
 RUN chown -R postgres:postgres /usr/lib/postgresql
 

--- a/Dockerfile-17
+++ b/Dockerfile-17
@@ -91,7 +91,7 @@ RUN ln -s /nix/var/nix/profiles/default/share/postgresql/* /usr/lib/postgresql/s
 RUN ln -s /nix/var/nix/profiles/default/share/postgresql/* /usr/share/postgresql/
 RUN chown -R postgres:postgres /usr/lib/postgresql/share/postgresql/
 RUN chown -R postgres:postgres /usr/share/postgresql/ 
-# Create symbolic links for contrib directory
+
 RUN tree /nix > /tmp/tree.txt && cat /tmp/tree.txt && cat /tmp/tree.txt >&2
 
 RUN chown -R postgres:postgres /usr/lib/postgresql

--- a/Dockerfile-orioledb-17
+++ b/Dockerfile-orioledb-17
@@ -91,7 +91,7 @@ RUN ln -s /nix/var/nix/profiles/default/share/postgresql/* /usr/lib/postgresql/s
 RUN ln -s /nix/var/nix/profiles/default/share/postgresql/* /usr/share/postgresql/
 RUN chown -R postgres:postgres /usr/lib/postgresql/share/postgresql/
 RUN chown -R postgres:postgres /usr/share/postgresql/ 
-# Create symbolic links for contrib directory
+
 RUN tree /nix > /tmp/tree.txt && cat /tmp/tree.txt && cat /tmp/tree.txt >&2
 
 RUN chown -R postgres:postgres /usr/lib/postgresql


### PR DESCRIPTION
We eliminated legacy `/usr/lib/postgresql/share/postgresql/contrib` and so it no longer needs to be aliased or used in Dockerfile image builds