### PR TITLE
refactor(ansible): bring our ansible up to modern ansible-lint standards

### DIFF
--- a/ansible/tasks/setup-kong.yml
+++ b/ansible/tasks/setup-kong.yml
@@ -1,62 +1,64 @@
 - name: Kong - system user
-  user: name=kong
+  ansible.builtin.user:
+    name: 'kong'
+    state: 'present'
 
 # Kong installation steps from http://archive.vn/3HRQx
 - name: Kong - system dependencies
-  apt:
+  ansible.builtin.apt:
     pkg:
-      - openssl
       - libpcre3
-      - procps
+      - openssl
       - perl
+      - procps
 
 - name: Kong - download deb package
   get_url:
-    url: "https://packages.konghq.com/public/gateway-28/deb/ubuntu/pool/{{ kong_release_target }}/main/k/ko/kong_2.8.1/{{ kong_deb }}"
-    dest: /tmp/kong.deb
     checksum: "{{ kong_deb_checksum }}"
+    dest: '/tmp/kong.deb'
+    url: "https://packages.konghq.com/public/gateway-28/deb/ubuntu/pool/{{ kong_release_target }}/main/k/ko/kong_2.8.1/{{ kong_deb }}"
 
 - name: Kong - deb installation
-  apt: deb=file:///tmp/kong.deb
+  ansible.builtin.apt:
+    deb: '/tmp/kong.deb'
 
 - name: Kong - ensure it is NOT autoremoved
-  shell: |
-    set -e
-    apt-mark manual kong zlib1g*
+  ansible.builtin.command:
+    cmd: apt-mark manual kong zlib1g*
 
 - name: Kong - configuration
-  template:
-    src: files/kong_config/kong.conf.j2
-    dest: /etc/kong/kong.conf
+  ansible.builtin.template:
+    dest: '/etc/kong/kong.conf'
+    src: 'files/kong_config/kong.conf.j2'
 
 - name: Kong - hand over ownership of /usr/local/kong to user kong
-  file:
-    path: /usr/local/kong
-    recurse: yes
-    owner: kong
+  ansible.builtin.file:
+    owner: 'kong'
+    path: '/usr/local/kong'
+    recurse: true
 
 # [warn] ulimit is currently set to "1024". For better performance set it to at least
 # "4096" using "ulimit -n"
 - name: Kong - bump up ulimit
-  pam_limits:
-    limit_item: nofile
-    limit_type: soft
-    domain: kong
-    value: "4096"
+  community.general.pam_limits:
+    domain: 'kong'
+    limit_item: 'nofile'
+    limit_type: 'soft'
+    value: '4096'
 
 - name: Kong - create env file
-  template:
-    src: files/kong_config/kong.env.j2
-    dest: /etc/kong/kong.env
+  ansible.builtin.template:
+    dest: '/etc/kong/kong.env'
+    src: 'files/kong_config/kong.env.j2'
 
 - name: Kong - create service file
-  template:
-    src: files/kong_config/kong.service.j2
-    dest: /etc/systemd/system/kong.service
+  ansible.builtin.template:
+    dest: '/etc/systemd/system/kong.service'
+    src: 'files/kong_config/kong.service.j2'
 
 - name: Kong - disable service
-  systemd:
-    enabled: no
-    name: kong
-    state: stopped
-    daemon_reload: yes
+  ansible.builtin.systemd_service:
+    daemon_reload: true
+    enabled: false
+    name: 'kong'
+    state: 'stopped'


### PR DESCRIPTION
The 7th in a series of PRs, going file-by-file cleaning up and modernizing our Ansible to make current `ansible-lint` happy as well as following https://redhat-cop.github.io/automation-good-practices/