### PR TITLE
feat: add pldebugger v1.9 extension for PL/pgSQL debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ This is the same PostgreSQL build that powers [Supabase](https://supabase.io), b
 | [pgrouting](https://github.com/pgRouting/pgrouting/archive/v3.4.1.tar.gz) | [3.4.1](https://github.com/pgRouting/pgrouting/archive/v3.4.1.tar.gz) | A PostgreSQL/PostGIS extension that provides geospatial routing functionality |
 | [pgsodium]() | [3.1.8]() |  |
 | [pgtap](https://github.com/theory/pgtap/archive/v1.2.0.tar.gz) | [1.2.0](https://github.com/theory/pgtap/archive/v1.2.0.tar.gz) | A unit testing framework for PostgreSQL |
+| [pldebugger](https://github.com/EnterpriseDB/pldebugger) | [1.9](https://github.com/EnterpriseDB/pldebugger/releases/tag/v1.9) | PL/pgSQL debugger API for PostgreSQL |
 | [plpgsql-check](https://github.com/okbob/plpgsql_check/archive/v2.7.11.tar.gz) | [2.7.11](https://github.com/okbob/plpgsql_check/archive/v2.7.11.tar.gz) | Linter tool for language PL/pgSQL |
 | [plv8](https://github.com/plv8/plv8/archive/v3.1.10.tar.gz) | [3.1.10](https://github.com/plv8/plv8/archive/v3.1.10.tar.gz) | V8 Engine Javascript Procedural Language add-on for PostgreSQL |
 | [postgis](https://download.osgeo.org/postgis/source/postgis-3.3.7.tar.gz) | [3.3.7](https://download.osgeo.org/postgis/source/postgis-3.3.7.tar.gz) | Geographic Objects for PostgreSQL |

--- a/nix/ext/pldebugger.nix
+++ b/nix/ext/pldebugger.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  libkrb5,
+  openssl,
+  postgresql,
+  postgresqlTestHook,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pldebugger";
+  version = "1.9";
+
+  src = fetchFromGitHub {
+    owner = "EnterpriseDB";
+    repo = "pldebugger";
+    rev = "v${version}";
+    hash = "sha256-1q/kAn0i6KdWJNcIsE2HJp9m6/TMANWXZkUMWVgpKz8=";
+  };
+
+  buildInputs = [
+    libkrb5
+    openssl
+    postgresql
+  ];
+
+  makeFlags = [ "USE_PGXS=1" ];
+
+  installPhase = ''
+    install -D -t $out/lib plugin_debugger${postgresql.dlSuffix}
+    install -D -t $out/share/postgresql/extension *.sql
+    install -D -t $out/share/postgresql/extension *.control
+  '';
+
+  passthru.tests.extension = stdenv.mkDerivation {
+    name = "pldebugger-test";
+    dontUnpack = true;
+    doCheck = true;
+    buildInputs = [ postgresqlTestHook ];
+    nativeCheckInputs = [ (postgresql.withPackages (ps: [ ps.pldebugger ])) ];
+    postgresqlTestUserOptions = "LOGIN SUPERUSER";
+    failureHook = "postgresqlStop";
+    checkPhase = ''
+      runHook preCheck
+      psql -a -v ON_ERROR_STOP=1 -c "CREATE EXTENSION pldbgapi;"
+      psql -a -v ON_ERROR_STOP=1 -c "SELECT extname, extversion FROM pg_extension WHERE extname = 'pldbgapi';"
+      runHook postCheck
+    '';
+    installPhase = "touch $out";
+  };
+
+  meta = with lib; {
+    description = "PL/pgSQL debugger API for PostgreSQL";
+    homepage = "https://github.com/EnterpriseDB/pldebugger";
+    changelog = "https://github.com/EnterpriseDB/pldebugger/releases/tag/v${version}";
+    platforms = postgresql.meta.platforms;
+    license = licenses.artistic2;
+    maintainers = [ ];
+  };
+}

--- a/nix/packages/postgres.nix
+++ b/nix/packages/postgres.nix
@@ -26,6 +26,7 @@
         ../ext/pg_repack.nix
         ../ext/pg-safeupdate.nix
         ../ext/plpgsql-check.nix
+        ../ext/pldebugger.nix
         ../ext/pgjwt.nix
         ../ext/pgaudit.nix
         ../ext/postgis.nix


### PR DESCRIPTION
- Add pldebugger v1.9 Nix package with proper dependencies (libkrb5, openssl)
- Integrate pldebugger into PostgreSQL nix build system
- Update README.md with pldebugger documentation

Extension provides server-side debugging API for PL/pgSQL functions
Compatible with pgAdmin and other PostgreSQL debugging tools

Resolves GitHub issue supabase/supabase#11143

**pgAdmin4:**

<img width="1251" height="740" alt="image" src="https://github.com/user-attachments/assets/0c0a9c13-664f-4723-84b5-157d2c8b4636" />

**Jetbrains DataGrip:**

<img width="1147" height="746" alt="image" src="https://github.com/user-attachments/assets/5405679a-cea4-4816-80ab-3025efa1d67f" />
