### PR TITLE
fix(pgmq): add missing helper function in migration script

### DIFF
--- a/nix/ext/pgmq.nix
+++ b/nix/ext/pgmq.nix
@@ -60,6 +60,19 @@ let
             echo "default_version = '${version}'"
             cat $out/share/postgresql/extension/${pname}--${version}.control
           } > $out/share/postgresql/extension/${pname}.control
+          cat >> sql/pgmq--1.5.0--1.5.1.sql <<EOF
+
+        CREATE FUNCTION pgmq._extension_exists(extension_name TEXT)
+        RETURNS BOOLEAN
+        LANGUAGE SQL
+        AS \$\$
+        SELECT EXISTS (
+            SELECT 1
+            FROM pg_extension
+            WHERE extname = extension_name
+        )
+        \$\$;
+        EOF
           cp sql/*.sql $out/share/postgresql/extension
         fi
 


### PR DESCRIPTION
pg_regress tests are failing on the pgmq extension because the helper function pgmq._extension_exists() is missing in the 1.5.0 to 1.5.1 migration script.
This change adds the missing function to the migration script.