### PR TITLE
chore: bump suffix to test in local infra

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: 17.5.1.037-orioledb
-  postgres17: 17.6.1.016
-  postgres15: 15.14.1.016
+  postgresorioledb-17: 17.5.1.037-orioledb-pgmqfix-1
+  postgres17: 17.6.1.016-pgmqfix-1
+  postgres15: 15.14.1.016-pgmqfix-1
 
 # Non Postgres Extensions
 pgbouncer_release: 1.19.0


### PR DESCRIPTION
We patched migration for pgmq to fix upgrade issues. This PR will test and release the patch into production as an AMI version