### PR TITLE
feat(pg): use concurrent index builds

### DIFF
--- a/migrations/db/init-scripts/00000000000001-auth-schema.sql
+++ b/migrations/db/init-scripts/00000000000001-auth-schema.sql
@@ -28,8 +28,8 @@ CREATE TABLE auth.users (
     updated_at timestamptz NULL,
     CONSTRAINT users_pkey PRIMARY KEY (id)
 );
-CREATE INDEX users_instance_id_email_idx ON auth.users USING btree (instance_id, email);
-CREATE INDEX users_instance_id_idx ON auth.users USING btree (instance_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS users_instance_id_email_idx ON auth.users USING btree (instance_id, email);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS users_instance_id_idx ON auth.users USING btree (instance_id);
 comment on table auth.users is 'Auth: Stores user login data within a secure schema.';
 
 -- auth.refresh_tokens definition
@@ -44,9 +44,9 @@ CREATE TABLE auth.refresh_tokens (
     updated_at timestamptz NULL,
     CONSTRAINT refresh_tokens_pkey PRIMARY KEY (id)
 );
-CREATE INDEX refresh_tokens_instance_id_idx ON auth.refresh_tokens USING btree (instance_id);
-CREATE INDEX refresh_tokens_instance_id_user_id_idx ON auth.refresh_tokens USING btree (instance_id, user_id);
-CREATE INDEX refresh_tokens_token_idx ON auth.refresh_tokens USING btree (token);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS refresh_tokens_instance_id_idx ON auth.refresh_tokens USING btree (instance_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS refresh_tokens_instance_id_user_id_idx ON auth.refresh_tokens USING btree (instance_id, user_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS refresh_tokens_token_idx ON auth.refresh_tokens USING btree (token);
 comment on table auth.refresh_tokens is 'Auth: Store of tokens used to refresh JWT tokens once they expire.';
 
 -- auth.instances definition
@@ -70,7 +70,7 @@ CREATE TABLE auth.audit_log_entries (
     created_at timestamptz NULL,
     CONSTRAINT audit_log_entries_pkey PRIMARY KEY (id)
 );
-CREATE INDEX audit_logs_instance_id_idx ON auth.audit_log_entries USING btree (instance_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS audit_logs_instance_id_idx ON auth.audit_log_entries USING btree (instance_id);
 comment on table auth.audit_log_entries is 'Auth: Audit trail for user actions.';
 
 -- auth.schema_migrations definition

--- a/migrations/db/init-scripts/00000000000002-storage-schema.sql
+++ b/migrations/db/init-scripts/00000000000002-storage-schema.sql
@@ -16,7 +16,7 @@ CREATE TABLE "storage"."buckets" (
     CONSTRAINT "buckets_owner_fkey" FOREIGN KEY ("owner") REFERENCES "auth"."users"("id"),
     PRIMARY KEY ("id")
 );
-CREATE UNIQUE INDEX "bname" ON "storage"."buckets" USING BTREE ("name");
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "bname" ON "storage"."buckets" USING BTREE ("name");
 
 CREATE TABLE "storage"."objects" (
     "id" uuid NOT NULL DEFAULT extensions.uuid_generate_v4(),
@@ -31,8 +31,8 @@ CREATE TABLE "storage"."objects" (
     CONSTRAINT "objects_owner_fkey" FOREIGN KEY ("owner") REFERENCES "auth"."users"("id"),
     PRIMARY KEY ("id")
 );
-CREATE UNIQUE INDEX "bucketid_objname" ON "storage"."objects" USING BTREE ("bucket_id","name");
-CREATE INDEX name_prefix_search ON storage.objects(name text_pattern_ops);
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "bucketid_objname" ON "storage"."objects" USING BTREE ("bucket_id","name");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS name_prefix_search ON storage.objects(name text_pattern_ops);
 
 ALTER TABLE storage.objects ENABLE ROW LEVEL SECURITY;
 

--- a/migrations/schema-15.sql
+++ b/migrations/schema-15.sql
@@ -847,63 +847,63 @@ ALTER TABLE ONLY storage.objects
 -- Name: audit_logs_instance_id_idx; Type: INDEX; Schema: auth; Owner: -
 --
 
-CREATE INDEX audit_logs_instance_id_idx ON auth.audit_log_entries USING btree (instance_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS audit_logs_instance_id_idx ON auth.audit_log_entries USING btree (instance_id);
 
 
 --
 -- Name: refresh_tokens_instance_id_idx; Type: INDEX; Schema: auth; Owner: -
 --
 
-CREATE INDEX refresh_tokens_instance_id_idx ON auth.refresh_tokens USING btree (instance_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS refresh_tokens_instance_id_idx ON auth.refresh_tokens USING btree (instance_id);
 
 
 --
 -- Name: refresh_tokens_instance_id_user_id_idx; Type: INDEX; Schema: auth; Owner: -
 --
 
-CREATE INDEX refresh_tokens_instance_id_user_id_idx ON auth.refresh_tokens USING btree (instance_id, user_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS refresh_tokens_instance_id_user_id_idx ON auth.refresh_tokens USING btree (instance_id, user_id);
 
 
 --
 -- Name: refresh_tokens_token_idx; Type: INDEX; Schema: auth; Owner: -
 --
 
-CREATE INDEX refresh_tokens_token_idx ON auth.refresh_tokens USING btree (token);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS refresh_tokens_token_idx ON auth.refresh_tokens USING btree (token);
 
 
 --
 -- Name: users_instance_id_email_idx; Type: INDEX; Schema: auth; Owner: -
 --
 
-CREATE INDEX users_instance_id_email_idx ON auth.users USING btree (instance_id, email);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS users_instance_id_email_idx ON auth.users USING btree (instance_id, email);
 
 
 --
 -- Name: users_instance_id_idx; Type: INDEX; Schema: auth; Owner: -
 --
 
-CREATE INDEX users_instance_id_idx ON auth.users USING btree (instance_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS users_instance_id_idx ON auth.users USING btree (instance_id);
 
 
 --
 -- Name: bname; Type: INDEX; Schema: storage; Owner: -
 --
 
-CREATE UNIQUE INDEX bname ON storage.buckets USING btree (name);
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS bname ON storage.buckets USING btree (name);
 
 
 --
 -- Name: bucketid_objname; Type: INDEX; Schema: storage; Owner: -
 --
 
-CREATE UNIQUE INDEX bucketid_objname ON storage.objects USING btree (bucket_id, name);
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS bucketid_objname ON storage.objects USING btree (bucket_id, name);
 
 
 --
 -- Name: name_prefix_search; Type: INDEX; Schema: storage; Owner: -
 --
 
-CREATE INDEX name_prefix_search ON storage.objects USING btree (name text_pattern_ops);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS name_prefix_search ON storage.objects USING btree (name text_pattern_ops);
 
 
 --

--- a/migrations/schema-17.sql
+++ b/migrations/schema-17.sql
@@ -848,63 +848,63 @@ ALTER TABLE ONLY storage.objects
 -- Name: audit_logs_instance_id_idx; Type: INDEX; Schema: auth; Owner: -
 --
 
-CREATE INDEX audit_logs_instance_id_idx ON auth.audit_log_entries USING btree (instance_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS audit_logs_instance_id_idx ON auth.audit_log_entries USING btree (instance_id);
 
 
 --
 -- Name: refresh_tokens_instance_id_idx; Type: INDEX; Schema: auth; Owner: -
 --
 
-CREATE INDEX refresh_tokens_instance_id_idx ON auth.refresh_tokens USING btree (instance_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS refresh_tokens_instance_id_idx ON auth.refresh_tokens USING btree (instance_id);
 
 
 --
 -- Name: refresh_tokens_instance_id_user_id_idx; Type: INDEX; Schema: auth; Owner: -
 --
 
-CREATE INDEX refresh_tokens_instance_id_user_id_idx ON auth.refresh_tokens USING btree (instance_id, user_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTINDEX CONCURRENTLY IF NOT EXISTS refresh_tokens_instance_id_user_id_idx ON auth.refresh_tokens USING btree (instance_id, user_id);
 
 
 --
 -- Name: refresh_tokens_token_idx; Type: INDEX; Schema: auth; Owner: -
 --
 
-CREATE INDEX refresh_tokens_token_idx ON auth.refresh_tokens USING btree (token);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS refresh_tokens_token_idx ON auth.refresh_tokens USING btree (token);
 
 
 --
 -- Name: users_instance_id_email_idx; Type: INDEX; Schema: auth; Owner: -
 --
 
-CREATE INDEX users_instance_id_email_idx ON auth.users USING btree (instance_id, email);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS users_instance_id_email_idx ON auth.users USING btree (instance_id, email);
 
 
 --
 -- Name: users_instance_id_idx; Type: INDEX; Schema: auth; Owner: -
 --
 
-CREATE INDEX users_instance_id_idx ON auth.users USING btree (instance_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS users_instance_id_idx ON auth.users USING btree (instance_id);
 
 
 --
 -- Name: bname; Type: INDEX; Schema: storage; Owner: -
 --
 
-CREATE UNIQUE INDEX bname ON storage.buckets USING btree (name);
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS bname ON storage.buckets USING btree (name);
 
 
 --
 -- Name: bucketid_objname; Type: INDEX; Schema: storage; Owner: -
 --
 
-CREATE UNIQUE INDEX bucketid_objname ON storage.objects USING btree (bucket_id, name);
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS bucketid_objname ON storage.objects USING btree (bucket_id, name);
 
 
 --
 -- Name: name_prefix_search; Type: INDEX; Schema: storage; Owner: -
 --
 
-CREATE INDEX name_prefix_search ON storage.objects USING btree (name text_pattern_ops);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS name_prefix_search ON storage.objects USING btree (name text_pattern_ops);
 
 
 --

--- a/migrations/schema-orioledb-17.sql
+++ b/migrations/schema-orioledb-17.sql
@@ -860,56 +860,56 @@ ALTER TABLE ONLY storage.objects
 -- Name: audit_logs_instance_id_idx; Type: INDEX; Schema: auth; Owner: -
 --
 
-CREATE INDEX audit_logs_instance_id_idx ON auth.audit_log_entries USING btree (instance_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS audit_logs_instance_id_idx ON auth.audit_log_entries USING btree (instance_id);
 
 
 --
 -- Name: refresh_tokens_instance_id_idx; Type: INDEX; Schema: auth; Owner: -
 --
 
-CREATE INDEX refresh_tokens_instance_id_idx ON auth.refresh_tokens USING btree (instance_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS refresh_tokens_instance_id_idx ON auth.refresh_tokens USING btree (instance_id);
 
 
 --
 -- Name: refresh_tokens_instance_id_user_id_idx; Type: INDEX; Schema: auth; Owner: -
 --
 
-CREATE INDEX refresh_tokens_instance_id_user_id_idx ON auth.refresh_tokens USING btree (instance_id, user_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS refresh_tokens_instance_id_user_id_idx ON auth.refresh_tokens USING btree (instance_id, user_id);
 
 
 --
 -- Name: refresh_tokens_token_idx; Type: INDEX; Schema: auth; Owner: -
 --
 
-CREATE INDEX refresh_tokens_token_idx ON auth.refresh_tokens USING btree (token);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS refresh_tokens_token_idx ON auth.refresh_tokens USING btree (token);
 
 
 --
 -- Name: users_instance_id_email_idx; Type: INDEX; Schema: auth; Owner: -
 --
 
-CREATE INDEX users_instance_id_email_idx ON auth.users USING btree (instance_id, email);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS users_instance_id_email_idx ON auth.users USING btree (instance_id, email);
 
 
 --
 -- Name: users_instance_id_idx; Type: INDEX; Schema: auth; Owner: -
 --
 
-CREATE INDEX users_instance_id_idx ON auth.users USING btree (instance_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS users_instance_id_idx ON auth.users USING btree (instance_id);
 
 
 --
 -- Name: bname; Type: INDEX; Schema: storage; Owner: -
 --
 
-CREATE UNIQUE INDEX bname ON storage.buckets USING btree (name);
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS bname ON storage.buckets USING btree (name);
 
 
 --
 -- Name: bucketid_objname; Type: INDEX; Schema: storage; Owner: -
 --
 
-CREATE UNIQUE INDEX bucketid_objname ON storage.objects USING btree (bucket_id, name);
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS bucketid_objname ON storage.objects USING btree (bucket_id, name);
 
 
 --

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -838,63 +838,63 @@ ALTER TABLE ONLY storage.objects
 -- Name: audit_logs_instance_id_idx; Type: INDEX; Schema: auth; Owner: -
 --
 
-CREATE INDEX audit_logs_instance_id_idx ON auth.audit_log_entries USING btree (instance_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS audit_logs_instance_id_idx ON auth.audit_log_entries USING btree (instance_id);
 
 
 --
 -- Name: refresh_tokens_instance_id_idx; Type: INDEX; Schema: auth; Owner: -
 --
 
-CREATE INDEX refresh_tokens_instance_id_idx ON auth.refresh_tokens USING btree (instance_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS refresh_tokens_instance_id_idx ON auth.refresh_tokens USING btree (instance_id);
 
 
 --
 -- Name: refresh_tokens_instance_id_user_id_idx; Type: INDEX; Schema: auth; Owner: -
 --
 
-CREATE INDEX refresh_tokens_instance_id_user_id_idx ON auth.refresh_tokens USING btree (instance_id, user_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS refresh_tokens_instance_id_user_id_idx ON auth.refresh_tokens USING btree (instance_id, user_id);
 
 
 --
 -- Name: refresh_tokens_token_idx; Type: INDEX; Schema: auth; Owner: -
 --
 
-CREATE INDEX refresh_tokens_token_idx ON auth.refresh_tokens USING btree (token);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS refresh_tokens_token_idx ON auth.refresh_tokens USING btree (token);
 
 
 --
 -- Name: users_instance_id_email_idx; Type: INDEX; Schema: auth; Owner: -
 --
 
-CREATE INDEX users_instance_id_email_idx ON auth.users USING btree (instance_id, email);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS users_instance_id_email_idx ON auth.users USING btree (instance_id, email);
 
 
 --
 -- Name: users_instance_id_idx; Type: INDEX; Schema: auth; Owner: -
 --
 
-CREATE INDEX users_instance_id_idx ON auth.users USING btree (instance_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS users_instance_id_idx ON auth.users USING btree (instance_id);
 
 
 --
 -- Name: bname; Type: INDEX; Schema: storage; Owner: -
 --
 
-CREATE UNIQUE INDEX bname ON storage.buckets USING btree (name);
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS bname ON storage.buckets USING btree (name);
 
 
 --
 -- Name: bucketid_objname; Type: INDEX; Schema: storage; Owner: -
 --
 
-CREATE UNIQUE INDEX bucketid_objname ON storage.objects USING btree (bucket_id, name);
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS bucketid_objname ON storage.objects USING btree (bucket_id, name);
 
 
 --
 -- Name: name_prefix_search; Type: INDEX; Schema: storage; Owner: -
 --
 
-CREATE INDEX name_prefix_search ON storage.objects USING btree (name text_pattern_ops);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS name_prefix_search ON storage.objects USING btree (name text_pattern_ops);
 
 
 --

--- a/nix/tests/expected/docs-full-text-search.out
+++ b/nix/tests/expected/docs-full-text-search.out
@@ -148,7 +148,7 @@ alter table
   books
 add column
   fts tsvector generated always as (to_tsvector('english', description || ' ' || title)) stored;
-create index books_fts on books using gin (fts);
+create index concurrently if not exists books_fts on books using gin (fts);
 select id, fts
 from books;
  id |                                                       fts                                                       

--- a/nix/tests/expected/docs-indexes.out
+++ b/nix/tests/expected/docs-indexes.out
@@ -14,9 +14,9 @@ select name from persons where age = 32;
  John Doe
 (1 row)
 
-create index idx_persons_age on persons (age);
-create index idx_living_persons_age on persons (age) where deceased is false;
-create index idx_persons_age_desc on persons (age desc nulls last);
+create index concurrently if not exists idx_persons_age on persons (age);
+create index concurrently if not exists idx_living_persons_age on persons (age) where deceased is false;
+create index concurrently if not exists idx_persons_age_desc on persons (age desc nulls last);
 reindex index concurrently idx_persons_age;
 reindex table concurrently persons;
 drop table persons cascade;

--- a/nix/tests/expected/hypopg.out
+++ b/nix/tests/expected/hypopg.out
@@ -3,7 +3,7 @@ create table v.samp(
   id int
 );
 select 1 from hypopg_create_index($$
-  create index on v.samp(id)
+  create index concurrently if not exists on v.samp(id)
 $$);
  ?column? 
 ----------

--- a/nix/tests/expected/index_advisor.out
+++ b/nix/tests/expected/index_advisor.out
@@ -9,7 +9,7 @@ from
   index_advisor('select id from v.book where title = $1');
                 index_statements                | errors 
 ------------------------------------------------+--------
- {"CREATE INDEX ON v.book USING btree (title)"} | {}
+ {"CREATE INDEX CONCURRENTLY IF NOT EXISTS ON v.book USING btree (title)"} | {}
 (1 row)
 
 drop schema v cascade;

--- a/nix/tests/expected/z_15_pgroonga.out
+++ b/nix/tests/expected/z_15_pgroonga.out
@@ -51,9 +51,9 @@ values
   ('This is a full-text search test'),
   ('PGroonga supports various languages');
 -- Create default index
-create index pgroonga_index on v.roon using pgroonga (content);
+create index concurrently if not exists pgroonga_index on v.roon using pgroonga (content);
 -- Create mecab tokenizer index since we had a bug with this one once
-create index pgroonga_index_mecab on v.roon using pgroonga (content) with (tokenizer='TokenMecab');
+create index concurrently if not exists pgroonga_index_mecab on v.roon using pgroonga (content) with (tokenizer='TokenMecab');
 -- Run some queries to test the index
 select * from v.roon where content &@~ 'Hello';
  id |   content   

--- a/nix/tests/expected/z_15_pgvector.out
+++ b/nix/tests/expected/z_15_pgvector.out
@@ -7,36 +7,36 @@ create table v.items(
   sparse_embedding sparsevec(3)
 );
 -- vector ops
-create index on v.items using hnsw (embedding vector_l2_ops);
-create index on v.items using hnsw (embedding vector_cosine_ops);
-create index on v.items using hnsw (embedding vector_l1_ops);
-create index on v.items using ivfflat (embedding vector_l2_ops);
+create index concurrently if not exists on v.items using hnsw (embedding vector_l2_ops);
+create index concurrently if not exists on v.items using hnsw (embedding vector_cosine_ops);
+create index concurrently if not exists on v.items using hnsw (embedding vector_l1_ops);
+create index concurrently if not exists on v.items using ivfflat (embedding vector_l2_ops);
 NOTICE:  ivfflat index created with little data
 DETAIL:  This will cause low recall.
 HINT:  Drop the index until the table has more data.
-create index on v.items using ivfflat (embedding vector_cosine_ops);
+create index concurrently if not exists on v.items using ivfflat (embedding vector_cosine_ops);
 NOTICE:  ivfflat index created with little data
 DETAIL:  This will cause low recall.
 HINT:  Drop the index until the table has more data.
 -- halfvec ops
-create index on v.items using hnsw (half_embedding halfvec_l2_ops);
-create index on v.items using hnsw (half_embedding halfvec_cosine_ops);
-create index on v.items using hnsw (half_embedding halfvec_l1_ops);
-create index on v.items using ivfflat (half_embedding halfvec_l2_ops);
+create index concurrently if not exists on v.items using hnsw (half_embedding halfvec_l2_ops);
+create index concurrently if not exists on v.items using hnsw (half_embedding halfvec_cosine_ops);
+create index concurrently if not exists on v.items using hnsw (half_embedding halfvec_l1_ops);
+create index concurrently if not exists on v.items using ivfflat (half_embedding halfvec_l2_ops);
 NOTICE:  ivfflat index created with little data
 DETAIL:  This will cause low recall.
 HINT:  Drop the index until the table has more data.
-create index on v.items using ivfflat (half_embedding halfvec_cosine_ops);
+create index concurrently if not exists on v.items using ivfflat (half_embedding halfvec_cosine_ops);
 NOTICE:  ivfflat index created with little data
 DETAIL:  This will cause low recall.
 HINT:  Drop the index until the table has more data.
 -- sparsevec
-create index on v.items using hnsw (sparse_embedding sparsevec_l2_ops);
-create index on v.items using hnsw (sparse_embedding sparsevec_cosine_ops);
-create index on v.items using hnsw (sparse_embedding sparsevec_l1_ops);
+create index concurrently if not exists on v.items using hnsw (sparse_embedding sparsevec_l2_ops);
+create index concurrently if not exists on v.items using hnsw (sparse_embedding sparsevec_cosine_ops);
+create index concurrently if not exists on v.items using hnsw (sparse_embedding sparsevec_l1_ops);
 -- bit ops
-create index on v.items using hnsw (bit_embedding bit_hamming_ops);
-create index on v.items using ivfflat (bit_embedding bit_hamming_ops);
+create index concurrently if not exists on v.items using hnsw (bit_embedding bit_hamming_ops);
+create index concurrently if not exists on v.items using ivfflat (bit_embedding bit_hamming_ops);
 NOTICE:  ivfflat index created with little data
 DETAIL:  This will cause low recall.
 HINT:  Drop the index until the table has more data.

--- a/nix/tests/expected/z_15_rum.out
+++ b/nix/tests/expected/z_15_rum.out
@@ -20,7 +20,7 @@ values
   ('the situation is most beautiful'),
   ('it is a beautiful'),
   ('it looks like a beautiful place');
-create index rumidx on v.test_rum using rum (a rum_tsvector_ops);
+create index concurrently if not exists rumidx on v.test_rum using rum (a rum_tsvector_ops);
 select
   t,
   round(a <=> to_tsquery('english', 'beautiful | place')) as rank

--- a/nix/tests/expected/z_17_rum.out
+++ b/nix/tests/expected/z_17_rum.out
@@ -20,7 +20,7 @@ values
   ('the situation is most beautiful'),
   ('it is a beautiful'),
   ('it looks like a beautiful place');
-create index rumidx on v.test_rum using rum (a rum_tsvector_ops);
+create index concurrently if not exists rumidx on v.test_rum using rum (a rum_tsvector_ops);
 select
   t,
   round(a <=> to_tsquery('english', 'beautiful | place')) as rank

--- a/nix/tests/smoke/0005-test_pgroonga_mecab.sql
+++ b/nix/tests/smoke/0005-test_pgroonga_mecab.sql
@@ -19,7 +19,7 @@ begin;
     -- Test 2: Check if the table was created
     SELECT has_table('public', 'notes', 'The notes table should exist.');    
     -- Create the PGroonga index
-    CREATE INDEX pgroonga_content_index
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS pgroonga_content_index
             ON notes
          USING pgroonga (content)
           WITH (tokenizer='TokenMecab');

--- a/nix/tests/sql/docs-full-text-search.sql
+++ b/nix/tests/sql/docs-full-text-search.sql
@@ -102,7 +102,7 @@ alter table
 add column
   fts tsvector generated always as (to_tsvector('english', description || ' ' || title)) stored;
 
-create index books_fts on books using gin (fts);
+create index concurrently if not exists books_fts on books using gin (fts);
 
 select id, fts
 from books;

--- a/nix/tests/sql/docs-indexes.sql
+++ b/nix/tests/sql/docs-indexes.sql
@@ -13,11 +13,11 @@ insert into persons (age, height, weight, name, deceased) values (32, 180, 70, '
 
 select name from persons where age = 32;
 
-create index idx_persons_age on persons (age);
+create index concurrently if not exists idx_persons_age on persons (age);
 
-create index idx_living_persons_age on persons (age) where deceased is false;
+create index concurrently if not exists idx_living_persons_age on persons (age) where deceased is false;
 
-create index idx_persons_age_desc on persons (age desc nulls last);
+create index concurrently if not exists idx_persons_age_desc on persons (age desc nulls last);
 
 reindex index concurrently idx_persons_age;
 

--- a/nix/tests/sql/hypopg.sql
+++ b/nix/tests/sql/hypopg.sql
@@ -5,7 +5,7 @@ create table v.samp(
 );
 
 select 1 from hypopg_create_index($$
-  create index on v.samp(id)
+  create index concurrently if not exists on v.samp(id)
 $$);
 
 drop schema v cascade;

--- a/nix/tests/sql/z_15_pgroonga.sql
+++ b/nix/tests/sql/z_15_pgroonga.sql
@@ -37,7 +37,7 @@ values
 create index pgroonga_index on v.roon using pgroonga (content);
 
 -- Create mecab tokenizer index since we had a bug with this one once
-create index pgroonga_index_mecab on v.roon using pgroonga (content) with (tokenizer='TokenMecab');
+create index concurrently if not exists pgroonga_index_mecab on v.roon using pgroonga (content) with (tokenizer='TokenMecab');
 
 -- Run some queries to test the index
 select * from v.roon where content &@~ 'Hello';

--- a/nix/tests/sql/z_15_pgvector.sql
+++ b/nix/tests/sql/z_15_pgvector.sql
@@ -9,27 +9,27 @@ create table v.items(
 );
 
 -- vector ops
-create index on v.items using hnsw (embedding vector_l2_ops);
-create index on v.items using hnsw (embedding vector_cosine_ops);
-create index on v.items using hnsw (embedding vector_l1_ops);
-create index on v.items using ivfflat (embedding vector_l2_ops);
-create index on v.items using ivfflat (embedding vector_cosine_ops);
+create index concurrently if not exists on v.items using hnsw (embedding vector_l2_ops);
+create index concurrently if not exists on v.items using hnsw (embedding vector_cosine_ops);
+create index concurrently if not exists on v.items using hnsw (embedding vector_l1_ops);
+create index concurrently if not exists on v.items using ivfflat (embedding vector_l2_ops);
+create index concurrently if not exists on v.items using ivfflat (embedding vector_cosine_ops);
 
 -- halfvec ops
-create index on v.items using hnsw (half_embedding halfvec_l2_ops);
-create index on v.items using hnsw (half_embedding halfvec_cosine_ops);
-create index on v.items using hnsw (half_embedding halfvec_l1_ops);
-create index on v.items using ivfflat (half_embedding halfvec_l2_ops);
-create index on v.items using ivfflat (half_embedding halfvec_cosine_ops);
+create index concurrently if not exists on v.items using hnsw (half_embedding halfvec_l2_ops);
+create index concurrently if not exists on v.items using hnsw (half_embedding halfvec_cosine_ops);
+create index concurrently if not exists on v.items using hnsw (half_embedding halfvec_l1_ops);
+create index concurrently if not exists on v.items using ivfflat (half_embedding halfvec_l2_ops);
+create index concurrently if not exists on v.items using ivfflat (half_embedding halfvec_cosine_ops);
 
 -- sparsevec
-create index on v.items using hnsw (sparse_embedding sparsevec_l2_ops);
-create index on v.items using hnsw (sparse_embedding sparsevec_cosine_ops);
-create index on v.items using hnsw (sparse_embedding sparsevec_l1_ops);
+create index concurrently if not exists on v.items using hnsw (sparse_embedding sparsevec_l2_ops);
+create index concurrently if not exists on v.items using hnsw (sparse_embedding sparsevec_cosine_ops);
+create index concurrently if not exists on v.items using hnsw (sparse_embedding sparsevec_l1_ops);
 
 -- bit ops
-create index on v.items using hnsw (bit_embedding bit_hamming_ops);
-create index on v.items using ivfflat (bit_embedding bit_hamming_ops);
+create index concurrently if not exists on v.items using hnsw (bit_embedding bit_hamming_ops);
+create index concurrently if not exists on v.items using ivfflat (bit_embedding bit_hamming_ops);
 
 -- Populate some records
 insert into v.items(

--- a/nix/tests/sql/z_15_rum.sql
+++ b/nix/tests/sql/z_15_rum.sql
@@ -24,7 +24,7 @@ values
   ('it is a beautiful'),
   ('it looks like a beautiful place');
 
-create index rumidx on v.test_rum using rum (a rum_tsvector_ops);
+create index concurrently if not exists rumidx on v.test_rum using rum (a rum_tsvector_ops);
 
 select
   t,

--- a/nix/tests/sql/z_17_rum.sql
+++ b/nix/tests/sql/z_17_rum.sql
@@ -24,7 +24,7 @@ values
   ('it is a beautiful'),
   ('it looks like a beautiful place');
 
-create index rumidx on v.test_rum using rum (a rum_tsvector_ops);
+create index concurrently if not exists rumidx on v.test_rum using rum (a rum_tsvector_ops);
 
 select
   t,


### PR DESCRIPTION
## What does this PR do

Updates existing `create index` calls to `create index concurrently`.

Additionally adds `if not exists` if it was missing.

This is part of PSQL-752