### PR TITLE
chore(docker): bump gosu to 1.19

### DIFF
--- a/Dockerfile-15
+++ b/Dockerfile-15
@@ -134,7 +134,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
    ca-certificates \
    && rm -rf /var/lib/apt/lists/*
 # Download binary
-ARG GOSU_VERSION=1.16
+ARG GOSU_VERSION=1.19
 ARG GOSU_GPG_KEY=B42F6819007F00F88E364FD4036A9C25BF357DD4
 ADD https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$TARGETARCH \
     /usr/local/bin/gosu

--- a/Dockerfile-17
+++ b/Dockerfile-17
@@ -138,7 +138,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
    ca-certificates \
    && rm -rf /var/lib/apt/lists/*
 # Download binary
-ARG GOSU_VERSION=1.16
+ARG GOSU_VERSION=1.19
 ARG GOSU_GPG_KEY=B42F6819007F00F88E364FD4036A9C25BF357DD4
 ADD https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$TARGETARCH \
     /usr/local/bin/gosu

--- a/Dockerfile-orioledb-17
+++ b/Dockerfile-orioledb-17
@@ -138,7 +138,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
    ca-certificates \
    && rm -rf /var/lib/apt/lists/*
 # Download binary
-ARG GOSU_VERSION=1.16
+ARG GOSU_VERSION=1.19
 ARG GOSU_GPG_KEY=B42F6819007F00F88E364FD4036A9C25BF357DD4
 ADD https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$TARGETARCH \
     /usr/local/bin/gosu


### PR DESCRIPTION
This pull request updates `gosu` from version `1.16`  to `1.19` in the following Dockerfiles:
- `Dockerfile-15`
- `Dockerfile-17`
- `Dockerfile-orioledb-17`

The official Docker Postgres image has already upgraded [5]  to gosu 1.19 [1], 
and this change keeps these images consistent with the upstream base.

Using the latest `gosu` release [2] also helps reduce potential security findings reported by image scanners. 
For example, a recent local Trivy scan [3] reported several medium to critical issues in the older `gosu` binary.

No functional changes beyond the version update.

### References

[1]  Upstream Postgres Dockerfile (gosu 1.19):    
https://github.com/docker-library/postgres/blob/master/Dockerfile-debian.template

[2]   gosu 1.19 release notes:   
https://github.com/tianon/gosu/releases/tag/1.19
Additional releases (1.17–1.19): https://github.com/tianon/gosu/releases

[3]  Trivy scan example (old gosu 1.16 binary):
```bash
$ trivy image --ignore-unfixed supabase/postgres:17.5.1.041-orioledb
...
usr/local/bin/gosu (gobinary)
Total: 69 (UNKNOWN: 0, LOW: 2, MEDIUM: 30, HIGH: 34, CRITICAL: 3)
```
[5] https://github.com/docker-library/postgres/commit/a2433755c76d294477c85945d68944f8cdb7cf4b
