### PR TITLE
refactor(ansible): bring our ansible up to modern ansible-lint standards

### DIFF
--- a/ansible/tasks/setup-pgbouncer.yml
+++ b/ansible/tasks/setup-pgbouncer.yml
@@ -50,18 +50,18 @@
     shell: '/usr/sbin/nolign'
     state: 'present'
 
-- name: PgBouncer - create a directory if it does not exist
+- name: Create PgBouncer directories if they does not exist
   ansible.builtin.file:
     group: 'pgbouncer'
     mode: "{{ pgbouncer_dir_item['mode'] }}"
     owner: 'pgbouncer'
     path: "{{ pgbouncer_dir_item['dir'] }}"
     state: 'directory'
-  loop:
-    - "{ mode: '0700', dir: '/etc/pgbouncer'}"
-    - "{ mode: '0775', dir: '/etc/pgbouncer-custom'}"
   loop_control:
     loop_var: 'pgbouncer_dir_item'
+  with_items:
+    - "{ mode: '0700', dir: '/etc/pgbouncer' }"
+    - "{ mode: '0775', dir: '/etc/pgbouncer-custom' }"
 
 - name: create PgBouncer placeholder config files
   ansible.builtin.file:

--- a/ansible/tasks/setup-pgbouncer.yml
+++ b/ansible/tasks/setup-pgbouncer.yml
@@ -50,7 +50,7 @@
     shell: '/usr/sbin/nolign'
     state: 'present'
 
-- name: Create PgBouncer directories if they does not exist
+- name: Create PgBouncer directories if they do not exist
   ansible.builtin.file:
     group: 'pgbouncer'
     mode: "{{ pgbouncer_dir_item['mode'] }}"
@@ -60,8 +60,8 @@
   loop_control:
     loop_var: 'pgbouncer_dir_item'
   with_items:
-    - "{ mode: '0700', dir: '/etc/pgbouncer' }"
-    - "{ mode: '0775', dir: '/etc/pgbouncer-custom' }"
+    - { mode: '0700', dir: '/etc/pgbouncer' }
+    - { mode: '0775', dir: '/etc/pgbouncer-custom' }
 
 - name: create PgBouncer placeholder config files
   ansible.builtin.file:

--- a/ansible/tasks/setup-pgbouncer.yml
+++ b/ansible/tasks/setup-pgbouncer.yml
@@ -49,7 +49,7 @@
     state: 'present'
 
 - name: PgBouncer - create a directory if it does not exist
-  ansible.builtin,file:
+  ansible.builtin.file:
     group: 'pgbouncer'
     mode: "{{ pgbouncer_dir_item['mode'] }}"
     owner: 'pgbouncer'

--- a/ansible/tasks/setup-pgbouncer.yml
+++ b/ansible/tasks/setup-pgbouncer.yml
@@ -34,11 +34,13 @@
 - name: PgBouncer - build and install
   community.general.make:
     chdir: "/tmp/pgbouncer-{{ pgbouncer_release }}"
-    target: "{{ pgbouncer_mak_item }}"
+    target: "{{ pgbouncer_make_item }}"
   become: true
   loop:
     - 'all'
     - 'install'
+  loop_control:
+    loop_var: 'pgbouncer_make_item'
 
 - name: Create pgbouncer user
   ansible.builtin.user:

--- a/ansible/tasks/setup-pgbouncer.yml
+++ b/ansible/tasks/setup-pgbouncer.yml
@@ -1,135 +1,136 @@
 # PgBouncer
 - name: PgBouncer - download & install dependencies
-  apt:
+  ansible.builtin.apt:
     pkg:
       - build-essential
-      - libssl-dev
-      - pkg-config
       - libevent-dev
+      - libssl-dev
       - libsystemd-dev
-    update_cache: yes
+      - pkg-config
+    update_cache: true
     cache_valid_time: 3600
 
 - name: PgBouncer - download latest release
-  get_url:
-    url: "https://www.pgbouncer.org/downloads/files/{{ pgbouncer_release }}/pgbouncer-{{ pgbouncer_release }}.tar.gz"
-    dest: /tmp/pgbouncer-{{ pgbouncer_release }}.tar.gz
+  ansible.builtin.get_url:
     checksum: "{{ pgbouncer_release_checksum }}"
+    dest: "/tmp/pgbouncer-{{ pgbouncer_release }}.tar.gz"
     timeout: 60
+    url: "https://www.pgbouncer.org/downloads/files/{{ pgbouncer_release }}/pgbouncer-{{ pgbouncer_release }}.tar.gz"
 
 - name: PgBouncer - unpack archive
-  unarchive:
-    remote_src: yes
-    src: /tmp/pgbouncer-{{ pgbouncer_release }}.tar.gz
-    dest: /tmp
-  become: yes
+  ansible.builtin.unarchive:
+    dest: '/tmp'
+    remote_src: true
+    src: "/tmp/pgbouncer-{{ pgbouncer_release }}.tar.gz"
+  become: true
 
 - name: PgBouncer - configure
-  shell:
-    cmd: "./configure --prefix=/usr/local --with-systemd"
-    chdir: /tmp/pgbouncer-{{ pgbouncer_release }}
-  become: yes
+  ansible.builtin.command:
+    cmd: './configure --prefix=/usr/local --with-systemd'
+  args:
+    chdir: "/tmp/pgbouncer-{{ pgbouncer_release }}"
+  become: true
 
-- name: PgBouncer - build
-  make:
-    chdir: /tmp/pgbouncer-{{ pgbouncer_release }}
-  become: yes
-
-- name: PgBouncer - install
-  make:
-    chdir: /tmp/pgbouncer-{{ pgbouncer_release }}
-    target: install
-  become: yes
+- name: PgBouncer - build and install
+  community.general.make:
+    chdir: "/tmp/pgbouncer-{{ pgbouncer_release }}"
+    target: "{{ pgbouncer_mak_item }}"
+  become: true
+  loop:
+    - 'all'
+    - 'install'
 
 - name: Create pgbouncer user
-  user:
-    name: pgbouncer
-    shell: /bin/false
-    comment: PgBouncer user
-    groups: postgres,ssl-cert
+  ansible.builtin.user:
+    comment: 'PgBouncer user'
+    groups: 'postgres,ssl-cert'
+    name: 'pgbouncer'
+    shell: '/usr/sbin/nolign'
+    state: 'present'
 
 - name: PgBouncer - create a directory if it does not exist
-  file:
-    path: /etc/pgbouncer
-    state: directory
-    owner: pgbouncer
-    group: pgbouncer
-    mode: '0700'
+  ansible.builtin,file:
+    group: 'pgbouncer'
+    mode: "{{ pgbouncer_dir_item['mode'] }}"
+    owner: 'pgbouncer'
+    path: "{{ pgbouncer_dir_item['dir'] }}"
+    state: 'directory'
+  loop:
+    - "{ mode: '0700', dir: '/etc/pgbouncer'}"
+    - "{ mode: '0775', dir: '/etc/pgbouncer-custom'}"
+  loop_control:
+    loop_var: 'pgbouncer_dir_item'
 
-- name: PgBouncer - create a directory if it does not exist
-  file:
-    state: directory
-    owner: pgbouncer
-    group: pgbouncer
-    path: '{{ item }}'
-    mode: '0775'
+- name: create PgBouncer placeholder config files
+  ansible.builtin.file:
+    group: 'pgbouncer'
+    mode: '0664'
+    owner: 'pgbouncer'
+    path: "/etc/pgbouncer-custom/{{ pgbouncer_config_item }}"
+    state: 'touch'
+  loop_control:
+    loop_var: 'pgbouncer_config_item'
   with_items:
-    - '/etc/pgbouncer-custom'
-
-- name: create placeholder config files
-  file:
-    path: '/etc/pgbouncer-custom/{{ item }}'
-    state: touch
-    owner: pgbouncer
-    group: pgbouncer
-    mode: 0664
-  with_items:
-    - 'generated-optimizations.ini'
     - 'custom-overrides.ini'
+    - 'generated-optimizations.ini'
     - 'ssl-config.ini'
 
 - name: PgBouncer - adjust pgbouncer.ini
-  copy:
-    src: files/pgbouncer_config/pgbouncer.ini.j2
-    dest: /etc/pgbouncer/pgbouncer.ini
-    owner: pgbouncer
+  ansible.builtin.copy:
+    dest: '/etc/pgbouncer/pgbouncer.ini'
     mode: '0700'
+    owner: 'pgbouncer'
+    src: 'files/pgbouncer_config/pgbouncer.ini.j2'
 
-- name: PgBouncer - create a directory if it does not exist
-  file:
-    path: /etc/pgbouncer/userlist.txt
-    state: touch
-    owner: pgbouncer
+- name: PgBouncer - create a userlist file if it does not exist
+  ansible.builtin.file:
     mode: '0700'
+    owner: 'pgbouncer'
+    path: '/etc/pgbouncer/userlist.txt'
+    state: 'touch'
       
 - name: import /etc/tmpfiles.d/pgbouncer.conf
-  template:
-    src: files/pgbouncer_config/tmpfiles.d-pgbouncer.conf.j2
-    dest: /etc/tmpfiles.d/pgbouncer.conf
-  become: yes
+  ansible.builtin.template:
+    dest: '/etc/tmpfiles.d/pgbouncer.conf'
+    src: 'files/pgbouncer_config/tmpfiles.d-pgbouncer.conf.j2'
+  become: true
 
 - name: PgBouncer - By default allow ssl connections.
-  become: yes
-  copy:
-    dest: /etc/pgbouncer-custom/ssl-config.ini
-    content: |
-      client_tls_sslmode = allow
+  ansible.builtin.lineinfile:
+    line: 'client_tls_sslmode = allow'
+    path: '/etc/pgbouncer-custom/ssl-config.ini'
+  become: true
 
 - name: Grant pg_hba and pgbouncer grp perm for adminapi updates
-  shell: |
-     chmod g+w /etc/postgresql/pg_hba.conf
-     chmod g+w /etc/pgbouncer-custom/ssl-config.ini
+  ansible.builtin.file:
+    mode: '0664'
+    path: "{{ pgbouncer_group_item }}"
+  loop:
+    - /etc/pgbouncer-custom/ssl-config.ini
+    - /etc/postgresql/pg_hba.conf
+  loop_control:
+    loop_var: 'pgbouncer_group_item'
 
 # Add fail2ban filter
 - name: import jail.d/pgbouncer.conf
-  template:
-    src: files/fail2ban_config/jail-pgbouncer.conf.j2
-    dest: /etc/fail2ban/jail.d/pgbouncer.conf
-  become: yes
+  ansible.builtin.template:
+    dest: '/etc/fail2ban/jail.d/pgbouncer.conf'
+    src: 'files/fail2ban_config/jail-pgbouncer.conf.j2'
+  become: true
 
 - name: import filter.d/pgbouncer.conf
-  template:
-    src: files/fail2ban_config/filter-pgbouncer.conf.j2
-    dest: /etc/fail2ban/filter.d/pgbouncer.conf
-  become: yes
+  ansible.builtin.template:
+    dest: '/etc/fail2ban/filter.d/pgbouncer.conf'
+    src: 'files/fail2ban_config/filter-pgbouncer.conf.j2'
+  become: true
 
 # Add systemd file for PgBouncer
-- name: PgBouncer - import postgresql.service
-  template:
-    src: files/pgbouncer_config/pgbouncer.service.j2
-    dest: /etc/systemd/system/pgbouncer.service
-  become: yes
+- name: PgBouncer - import pgbouncer.service
+  ansible.builtin.template:
+    dest: '/etc/systemd/system/pgbouncer.service'
+    src: 'files/pgbouncer_config/pgbouncer.service.j2'
+  become: true
 
 - name: PgBouncer - reload systemd
-  systemd:
-    daemon_reload: yes
+  ansible.builtin.systemd_service:
+    daemon_reload: true


### PR DESCRIPTION
The 10th (of 17) in a series of PRs, going file-by-file cleaning up and modernizing our Ansible to make current `ansible-lint` happy as well as following https://redhat-cop.github.io/automation-good-practices/