### PR TITLE
feat(nix): add our substituter config to flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,11 @@
 {
   description = "Prototype tooling for deploying PostgreSQL";
-
+  nixConfig = {
+    extra-substituters = [ "https://nix-postgres-artifacts.s3.amazonaws.com" ];
+    extra-trusted-public-keys = [
+      "nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI="
+    ];
+  };
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";


### PR DESCRIPTION
Configure our binary cache for anyone willing to use any output of the nix flake.