### PR TITLE
Disable triggers when running after-create.sql hook of postgres_fdw

### DIFF
--- a/ansible/files/postgresql_extension_custom_scripts/postgres_fdw/after-create.sql
+++ b/ansible/files/postgresql_extension_custom_scripts/postgres_fdw/after-create.sql
@@ -10,6 +10,7 @@ begin
 
   -- Need to be superuser to own FDWs, so we temporarily make postgres superuser.
   if not is_super then
+    set session_replication_role = replica;
     alter role postgres superuser;
   end if;
 
@@ -17,5 +18,6 @@ begin
 
   if not is_super then
     alter role postgres nosuperuser;
+    reset session_replication_role;
   end if;
 end $$;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

## What is the new behavior?

`after-create.sql` hook disables event triggers temporarily during its execution.

## Additional context

Add any other context or screenshots.