### PR TITLE
fix: fine tune protection rules to unblock wal-g functionality

### DIFF
--- a/ansible/files/postgresql_config/postgresql.service.j2
+++ b/ansible/files/postgresql_config/postgresql.service.j2
@@ -22,9 +22,8 @@ OOMScoreAdjust=-1000
 EnvironmentFile=-/etc/environment.d/postgresql.env
 LimitNOFILE=16384
 {% if supabase_internal is defined %}
-ProtectHome=yes
-ReadOnlyPaths=/etc /opt
-InaccessiblePaths=-/var/lib/supabase -/var/lib/supabase-admin-agent -/var/lib/cloud -/var/cache/supabase-admin-agent -/opt/saltstack -/etc/salt
+ReadOnlyPaths=/etc
+InaccessiblePaths=/root -/var/lib/supabase -/var/lib/supabase-admin-agent -/var/cache/supabase-admin-agent -/opt/saltstack -/etc/salt
 {% endif %}
 [Install]
 WantedBy=multi-user.target

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.5.1.044-orioledb"
-  postgres17: "17.6.1.023"
-  postgres15: "15.14.1.023"
+  postgresorioledb-17: "17.5.1.044-orioledb-rules-1"
+  postgres17: "17.6.1.023-rules-1"
+  postgres15: "15.14.1.023-rules-1"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.19.0

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.5.1.044-orioledb-rules-1"
-  postgres17: "17.6.1.023-rules-1"
-  postgres15: "15.14.1.023-rules-1"
+  postgresorioledb-17: "17.5.1.044-orioledb-rules-2"
+  postgres17: "17.6.1.023-rules-2"
+  postgres15: "15.14.1.023-rules-2"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.19.0

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.5.1.044-orioledb-rules-2"
-  postgres17: "17.6.1.023-rules-2"
-  postgres15: "15.14.1.023-rules-2"
+  postgresorioledb-17: "17.5.1.045-orioledb"
+  postgres17: "17.6.1.024"
+  postgres15: "15.14.1.024"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.19.0


### PR DESCRIPTION
maintains security hardening on sensitive paths (/var/lib/supabase, /var/lib/supabase-admin-agent, /opt/saltstack,
/etc/salt) while allowing the infrastructure to manage pause/resume operations properly.