### PR TITLE
feat: enable GitHub merge queues

### DIFF
--- a/.github/workflows/check-shellscripts.yml
+++ b/.github/workflows/check-shellscripts.yml
@@ -1,15 +1,13 @@
 name: Check shell scripts
 
 on:
-  push:
-    branches:
-      - develop
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: Check merge requirements
 
 on:
   pull_request:
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -3,9 +3,9 @@ name: Nix CI
 on:
   push:
     branches:
-      - develop
       - release/*
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
GitHub [merge queues](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) prevent a family of breakage that [this schema stolen from Bors explains perfectly](https://bors.tech/essay/2017/02/02/pitch/).

It happens recently in this repo, when merging https://github.com/supabase/postgres/pull/1668, the PR tests were green, but [the exact same check failed when merged into `develop`](https://github.com/supabase/postgres/actions/runs/18328786045/job/52201792116#step:11:2766). Merge queues basically just invert those steps, running first the checks on merged code, and then updating the `develop` branch _(without then needing to rerun the tests afterward)_.

This PR adds the needed workflow event, but this requires also some admin steps: **Settings** => **Branches** => **Branch protection rules** (create or update one for `develop`); Check the "**Require merge queue**" box and (higher in the settings page) in "**Require status checks to pass before merging**" the workflow needed to pass before merging needs to be listed; save your changes.

**n.b.** I should mention that I'm personally more used to [Bors](https://graydon2.dreamwidth.org/1597.html) and would like to [dive a bit deeper into subtle differences in merge queues design](https://theunixzoo.co.uk/blog/2023-11-16-migrating-to-gh-merge-queues.html).
