### PR TITLE
fix: make sure that docker image has full/correct groonga/pgroonga handling

### DIFF
--- a/Dockerfile-15
+++ b/Dockerfile-15
@@ -123,6 +123,20 @@ RUN nix profile install .#wal-g-3 && \
 RUN nix store gc
 
 WORKDIR /
+####################
+# setup-groonga
+####################
+FROM base as groonga
+
+WORKDIR /nixpg
+
+RUN nix profile install .#supabase-groonga && \
+    mkdir -p /tmp/groonga-plugins && \
+    cp -r /nix/var/nix/profiles/default/lib/groonga/plugins /tmp/groonga-plugins/
+
+RUN nix store gc
+
+WORKDIR /
 # ####################
 # # Download gosu for easy step-down from root
 # ####################
@@ -153,6 +167,7 @@ FROM gosu as production
 RUN id postgres || (echo "postgres user does not exist" && exit 1)
 # # Setup extensions
 COPY --from=walg /tmp/wal-g /usr/local/bin/
+COPY --from=groonga /tmp/groonga-plugins/plugins /usr/lib/groonga/plugins
 
 # # Initialise configs
 COPY --chown=postgres:postgres ansible/files/postgresql_config/postgresql.conf.j2 /etc/postgresql/postgresql.conf
@@ -216,4 +231,7 @@ ENV LOCALE_ARCHIVE /usr/lib/locale/locale-archive
 RUN mkdir -p /usr/share/postgresql/extension/ && \
     ln -s /usr/lib/postgresql/bin/pgsodium_getkey.sh /usr/share/postgresql/extension/pgsodium_getkey && \
     chmod +x /usr/lib/postgresql/bin/pgsodium_getkey.sh
+
+ENV GRN_PLUGINS_DIR=/usr/lib/groonga/plugins
+
 CMD ["postgres", "-D", "/etc/postgresql"]

--- a/Dockerfile-17
+++ b/Dockerfile-17
@@ -127,6 +127,20 @@ RUN nix profile install .#wal-g-3 && \
 RUN nix store gc
 
 WORKDIR /
+####################
+# setup-groonga
+####################
+FROM base as groonga
+
+WORKDIR /nixpg
+
+RUN nix profile install .#supabase-groonga && \
+    mkdir -p /tmp/groonga-plugins && \
+    cp -r /nix/var/nix/profiles/default/lib/groonga/plugins /tmp/groonga-plugins/
+
+RUN nix store gc
+
+WORKDIR /
 # ####################
 # # Download gosu for easy step-down from root
 # ####################
@@ -157,6 +171,7 @@ FROM gosu as production
 RUN id postgres || (echo "postgres user does not exist" && exit 1)
 # # Setup extensions
 COPY --from=walg /tmp/wal-g /usr/local/bin/
+COPY --from=groonga /tmp/groonga-plugins/plugins /usr/lib/groonga/plugins
 
 # # Initialise configs
 COPY --chown=postgres:postgres ansible/files/postgresql_config/postgresql.conf.j2 /etc/postgresql/postgresql.conf
@@ -229,4 +244,7 @@ ENV LOCALE_ARCHIVE /usr/lib/locale/locale-archive
 RUN mkdir -p /usr/share/postgresql/extension/ && \
     ln -s /usr/lib/postgresql/bin/pgsodium_getkey.sh /usr/share/postgresql/extension/pgsodium_getkey && \
     chmod +x /usr/lib/postgresql/bin/pgsodium_getkey.sh
+
+ENV GRN_PLUGINS_DIR=/usr/lib/groonga/plugins
+
 CMD ["postgres", "-D", "/etc/postgresql"]

--- a/Dockerfile-orioledb-17
+++ b/Dockerfile-orioledb-17
@@ -127,6 +127,20 @@ RUN nix profile install .#wal-g-3 && \
 RUN nix store gc
 
 WORKDIR /
+####################
+# setup-groonga
+####################
+FROM base as groonga
+
+WORKDIR /nixpg
+
+RUN nix profile install .#supabase-groonga && \
+    mkdir -p /tmp/groonga-plugins && \
+    cp -r /nix/var/nix/profiles/default/lib/groonga/plugins /tmp/groonga-plugins/
+
+RUN nix store gc
+
+WORKDIR /
 # ####################
 # # Download gosu for easy step-down from root
 # ####################
@@ -157,6 +171,7 @@ FROM gosu as production
 RUN id postgres || (echo "postgres user does not exist" && exit 1)
 # # Setup extensions
 COPY --from=walg /tmp/wal-g /usr/local/bin/
+COPY --from=groonga /tmp/groonga-plugins/plugins /usr/lib/groonga/plugins
 
 # # Initialise configs
 COPY --chown=postgres:postgres ansible/files/postgresql_config/postgresql.conf.j2 /etc/postgresql/postgresql.conf
@@ -234,5 +249,7 @@ ENV LOCALE_ARCHIVE /usr/lib/locale/locale-archive
 RUN mkdir -p /usr/share/postgresql/extension/ && \
     ln -s /usr/lib/postgresql/bin/pgsodium_getkey.sh /usr/share/postgresql/extension/pgsodium_getkey && \
     chmod +x /usr/lib/postgresql/bin/pgsodium_getkey.sh
+
+ENV GRN_PLUGINS_DIR=/usr/lib/groonga/plugins
 
 CMD ["postgres", "-D", "/etc/postgresql"]

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.5.1.049-orioledb"
-  postgres17: "17.6.1.028"
-  postgres15: "15.14.1.028"
+  postgresorioledb-17: "17.5.1.050-orioledb"
+  postgres17: "17.6.1.030"
+  postgres15: "15.14.1.030"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.19.0


### PR DESCRIPTION
# Fix Groonga/PGroonga Installation in Dockerfiles

## Summary

This Draft PR aligns the groonga/pgroonga installation approach in Dockerfiles with the Ansible deployment method, ensuring consistent behavior across different deployment strategies.

## Problem

There was an inconsistency in how groonga and pgroonga packages were being installed between Ansible-based deployments and Docker-based deployments:

### Ansible Approach (Correct)
- Installed `supabase-groonga` as a **separate Nix package**
- Explicitly set the `GRN_PLUGINS_DIR` environment variable pointing to `/var/lib/postgresql/.nix-profile/lib/groonga/plugins`
- This modular approach ensured groonga plugins were properly located

### Dockerfile Approach (Incorrect)
- Relied on groonga/pgroonga being bundled within the main postgres Nix package
- **Did not set** the `GRN_PLUGINS_DIR` environment variable
- This could lead to runtime issues where pgroonga extension cannot locate groonga plugins

## Changes

### Files Modified
- `Dockerfile-15`
- `Dockerfile-17`
- `Dockerfile-orioledb-17`

### What Was Changed

For each Dockerfile:

1. **Added dedicated groonga build stage** (after the `walg` stage):
   ```dockerfile
   ####################
   # setup-groonga
   ####################
   FROM base as groonga

   WORKDIR /nixpg

   RUN nix profile install .#supabase-groonga && \
       mkdir -p /tmp/groonga-plugins && \
       cp -r /nix/var/nix/profiles/default/lib/groonga/plugins /tmp/groonga-plugins/

   RUN nix store gc

   WORKDIR /
   ```

2. **Copy groonga plugins to production image**:
   ```dockerfile
   COPY --from=groonga /tmp/groonga-plugins/plugins /usr/lib/groonga/plugins
   ```

3. **Set GRN_PLUGINS_DIR environment variable**:
   ```dockerfile
   ENV GRN_PLUGINS_DIR=/usr/lib/groonga/plugins
   ```


## Testing Recommendations

- [ ] Build all three Dockerfiles successfully
- [ ] Verify pgroonga extension loads without errors
- [ ] Test creating pgroonga indexes
- [ ] Verify `GRN_PLUGINS_DIR` environment variable is set correctly in running containers
- [ ] Ensure groonga plugins are accessible at `/usr/lib/groonga/plugins`

## Related

This fix ensures that the pgroonga extension (configured in `ansible/files/postgresql_config/supautils.conf.j2`) will work correctly in Docker-based deployments, matching the behavior of Ansible-based deployments.