### PR TITLE
refactor(ansible): bring our ansible up to modern ansible-lint standards

### DIFF
--- a/ansible/tasks/setup-wal-g.yml
+++ b/ansible/tasks/setup-wal-g.yml
@@ -29,16 +29,14 @@
     - stage2_nix
   block:
     - name: Install wal-g 2 from nix binary cache
-      ansible.builtin.command:
-        cmd: "nix profile install github:supabase/postgres/{{ git_commit_sha }}#wal-g-2"
+      ansible.builtin.shell:
+        cmd: sudo -u wal-g bash -c ". /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh && nix profile install github:supabase/postgres/{{ git_commit_sha }}#wal-g-2"
       become: true
-      become_user: 'wal-g'
 
     - name: Install wal-g 3 from nix binary cache
-      ansible.builtin.command:
-        cmd: "nix profile install github:supabase/postgres/{{ git_commit_sha }}#wal-g-3"
+      ansible.builtin.shell:
+        cmd: sudo -u wal-g bash -c ". /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh && nix profile install github:supabase/postgres/{{ git_commit_sha }}#wal-g-3"
       become: true
-      become_user: 'wal-g'
 
     - name: Create symlink for wal-g-3 from Nix profile to /usr/local/bin
       ansible.builtin.file:

--- a/ansible/tasks/setup-wal-g.yml
+++ b/ansible/tasks/setup-wal-g.yml
@@ -1,95 +1,95 @@
-- name: Create wal-g group
-  group:
-    name: wal-g
-    state: present
-  when: nixpkg_mode
+- name: Execute wal-g things when nixpkg_mode
+  when:
+    - nixpkg_mode
+  block:
+    - name: Create wal-g group
+      ansible.builtin.group:
+        name: 'wal-g'
+        state: 'present'
 
-- name: Create wal-g user
-  user:
-    name: wal-g
-    shell: /bin/false
-    comment: WAL-G user
-    group: wal-g
-    groups: wal-g, postgres
-  when: nixpkg_mode
-- name: Create a config directory owned by wal-g
-  file:
-    path: /etc/wal-g
-    state: directory
-    owner: wal-g
-    group: wal-g
-    mode: '0770'
-  when: nixpkg_mode
+    - name: Create wal-g user
+      ansible.builtin.user:
+        comment: 'WAL-G user'
+        group: 'wal-g'
+        groups: 'wal-g, postgres'
+        name: 'wal-g'
+        shell: '/usr/bin/nologin'
+        system: true
 
-- name: Install wal-g 2 from nix binary cache
-  become: yes
-  shell: |
-    sudo -u wal-g bash -c ". /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh && nix profile install github:supabase/postgres/{{ git_commit_sha }}#wal-g-2"
-  when: stage2_nix
+    - name: Create a config directory owned by wal-g
+      ansible.builtin.file:
+        group: 'wal-g'
+        mode: '0770'
+        owner: 'wal-g'
+        path: '/etc/wal-g'
+        state: 'directory'
 
-- name: Install wal-g 3 from nix binary cache
-  become: yes
-  shell: |
-    sudo -u wal-g bash -c ". /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh && nix profile install github:supabase/postgres/{{ git_commit_sha }}#wal-g-3"
-  when: stage2_nix
+- name: Execute wal-g things when stage2_nix
+  when:
+    - stage2_nix
+  block:
+    - name: Install wal-g 2 from nix binary cache
+      ansible.builtin.command:
+        cmd: "nix profile install github:supabase/postgres/{{ git_commit_sha }}#wal-g-2"
+      become: true
+      become_user: 'wal-g'
 
-- name: Create symlink for wal-g-3 from Nix profile to /usr/local/bin
-  ansible.builtin.file:
-    src: /home/wal-g/.nix-profile/bin/wal-g-3
-    dest: /usr/local/bin/wal-g-v3
-    state: link
-    force: yes  # This will replace existing file/symlink if it exists
-  become: yes   # Need sudo to write to /usr/local/bin
-  when: stage2_nix
+    - name: Install wal-g 3 from nix binary cache
+      ansible.builtin.command:
+        cmd: "nix profile install github:supabase/postgres/{{ git_commit_sha }}#wal-g-3"
+      become: true
+      become_user: 'wal-g'
 
-- name: Create symlink to make wal-g-v2 the default wal-g
-  ansible.builtin.file:
-    src: /home/wal-g/.nix-profile/bin/wal-g-2
-    dest: /usr/local/bin/wal-g
-    state: link
-    force: yes
-  become: yes
-  when: stage2_nix
+    - name: Create symlink for wal-g-3 from Nix profile to /usr/local/bin
+      ansible.builtin.file:
+        dest: '/usr/local/bin/wal-g-v3'
+        force: true
+        src: '/home/wal-g/.nix-profile/bin/wal-g-3'
+        state: 'link'
+      become: true
 
-- name: Create /etc/wal-g/config.json
-  file:
-    path: /etc/wal-g/config.json
-    state: touch
-    owner: wal-g
-    group: wal-g
-    mode: '0664'
-  when: stage2_nix
+    - name: Create symlink to make wal-g-v2 the default wal-g
+      ansible.builtin.file:
+        dest: '/usr/local/bin/wal-g'
+        force: true
+        src: '/home/wal-g/.nix-profile/bin/wal-g-2'
+        state: 'link'
+      become: true
 
-- name: Move custom wal-g.conf file to /etc/postgresql-custom/wal-g.conf
-  template:
-    src: "files/postgresql_config/custom_walg.conf.j2"
-    dest: /etc/postgresql-custom/wal-g.conf
-    mode: 0664
-    owner: postgres
-    group: postgres
-  when: stage2_nix
+    - name: Create /etc/wal-g/config.json
+      ansible.builtin.file:
+        group: 'wal-g'
+        mode: '0664'
+        owner: 'wal-g'
+        path: '/etc/wal-g/config.json'
+        state: 'touch'
 
-- name: Add script to be run for restore_command
-  template:
-    src: "files/walg_helper_scripts/wal_fetch.sh"
-    dest: /home/postgres/wal_fetch.sh
-    mode: 0500
-    owner: postgres
-    group: postgres
-  when: stage2_nix
+    - name: Move custom wal-g.conf file to /etc/postgresql-custom/wal-g.conf
+      ansible.builtin.template:
+        dest: '/etc/postgresql-custom/wal-g.conf'
+        group: 'postgres'
+        mode: '0664'
+        owner: 'postgres'
+        src: 'files/postgresql_config/custom_walg.conf.j2'
 
-- name: Add helper script for wal_fetch.sh
-  template:
-    src: "files/walg_helper_scripts/wal_change_ownership.sh"
-    dest: /root/wal_change_ownership.sh
-    mode: 0700
-    owner: root
-  when: stage2_nix
+    - name: Add script to be run for restore_command
+      ansible.builtin.template:
+        dest: '/home/postgres/wal_fetch.sh'
+        group: 'postgres'
+        mode: '0500'
+        owner: 'postgres'
+        src: 'files/walg_helper_scripts/wal_fetch.sh'
 
-- name: Include /etc/postgresql-custom/wal-g.conf in postgresql.conf
-  become: yes
-  replace:
-    path: /etc/postgresql/postgresql.conf
-    regexp: "#include = '/etc/postgresql-custom/wal-g.conf'"
-    replace: "include = '/etc/postgresql-custom/wal-g.conf'"
-  when: stage2_nix
+    - name: Add helper script for wal_fetch.sh
+      ansible.builtin.template:
+        dest: '/root/wal_change_ownership.sh'
+        mode: '0700'
+        owner: 'root'
+        src: 'files/walg_helper_scripts/wal_change_ownership.sh'
+
+    - name: Include /etc/postgresql-custom/wal-g.conf in postgresql.conf
+      ansible.builtin.replace:
+        path: '/etc/postgresql/postgresql.conf'
+        regexp: "#include = '/etc/postgresql-custom/wal-g.conf'"
+        replace: "include = '/etc/postgresql-custom/wal-g.conf'"
+      become: true


### PR DESCRIPTION
The 15th (of 17) in a series of PRs, going file-by-file cleaning up and modernizing our Ansible to make current `ansible-lint` happy as well as following https://redhat-cop.github.io/automation-good-practices/