### PR TITLE
Enable Orioledb rewind GUCs

### DIFF
--- a/Dockerfile-orioledb-17
+++ b/Dockerfile-orioledb-17
@@ -195,10 +195,11 @@ RUN echo "default_table_access_method = 'orioledb'" >> "/etc/postgresql/postgres
 
 # OrioleDB rewind configuration
 # Enables time-based rewind capability for up to 20 minutes (1200 seconds)
+# Buffer size: 1280 buffers * 8KB = 10MB for transaction retention
 RUN echo "orioledb.enable_rewind = true" >> "/etc/postgresql/postgresql.conf" && \
     echo "orioledb.rewind_max_time = 1200" >> "/etc/postgresql/postgresql.conf" && \
     echo "orioledb.rewind_max_transactions = 100000" >> "/etc/postgresql/postgresql.conf" && \
-    echo "orioledb.rewind_buffers = 13" >> "/etc/postgresql/postgresql.conf" 
+    echo "orioledb.rewind_buffers = 1280" >> "/etc/postgresql/postgresql.conf" 
 
 
 

--- a/Dockerfile-orioledb-17
+++ b/Dockerfile-orioledb-17
@@ -189,9 +189,16 @@ RUN sed -i \
 RUN sed -i 's/ timescaledb,//g;' "/etc/postgresql/postgresql.conf" 
     #as of pg 16.4 + this db_user_namespace totally deprecated and will break the server if setting is present
 RUN sed -i 's/db_user_namespace = off/#db_user_namespace = off/g;' "/etc/postgresql/postgresql.conf" 
-RUN sed -i 's/ timescaledb,//g; s/ plv8,//g; s/ postgis,//g; s/ pgrouting,//g' "/etc/postgresql-custom/supautils.conf" 
-RUN sed -i 's/\(shared_preload_libraries.*\)'\''\(.*\)$/\1, orioledb'\''\2/' "/etc/postgresql/postgresql.conf" 
-RUN echo "default_table_access_method = 'orioledb'" >> "/etc/postgresql/postgresql.conf" 
+RUN sed -i 's/ timescaledb,//g; s/ plv8,//g; s/ postgis,//g; s/ pgrouting,//g' "/etc/postgresql-custom/supautils.conf"
+RUN sed -i 's/\(shared_preload_libraries.*\)'\''\(.*\)$/\1, orioledb'\''\2/' "/etc/postgresql/postgresql.conf"
+RUN echo "default_table_access_method = 'orioledb'" >> "/etc/postgresql/postgresql.conf"
+
+# OrioleDB rewind configuration
+# Enables time-based rewind capability for up to 20 minutes (1200 seconds)
+RUN echo "orioledb.enable_rewind = true" >> "/etc/postgresql/postgresql.conf" && \
+    echo "orioledb.rewind_max_time = 1200" >> "/etc/postgresql/postgresql.conf" && \
+    echo "orioledb.rewind_max_transactions = 100000" >> "/etc/postgresql/postgresql.conf" && \
+    echo "orioledb.rewind_buffers = 13" >> "/etc/postgresql/postgresql.conf" 
 
 
 

--- a/ansible/tasks/stage2-setup-postgres.yml
+++ b/ansible/tasks/stage2-setup-postgres.yml
@@ -82,10 +82,10 @@
       when: is_psql_oriole and stage2_nix
       become: yes
 
-    - name: Set OrioleDB rewind buffers
+    - name: Set OrioleDB rewind buffers (1280 buffers = 10MB)
       ansible.builtin.lineinfile:
         path: /etc/postgresql/postgresql.conf
-        line: "orioledb.rewind_buffers = 13"
+        line: "orioledb.rewind_buffers = 1280"
         state: present
       when: is_psql_oriole and stage2_nix
       become: yes

--- a/ansible/tasks/stage2-setup-postgres.yml
+++ b/ansible/tasks/stage2-setup-postgres.yml
@@ -57,7 +57,39 @@
         state: present
       when: is_psql_oriole and stage2_nix
       become: yes
-    
+
+    - name: Enable OrioleDB rewind feature
+      ansible.builtin.lineinfile:
+        path: /etc/postgresql/postgresql.conf
+        line: "orioledb.enable_rewind = true"
+        state: present
+      when: is_psql_oriole and stage2_nix
+      become: yes
+
+    - name: Set OrioleDB rewind max time (20 minutes)
+      ansible.builtin.lineinfile:
+        path: /etc/postgresql/postgresql.conf
+        line: "orioledb.rewind_max_time = 1200"
+        state: present
+      when: is_psql_oriole and stage2_nix
+      become: yes
+
+    - name: Set OrioleDB rewind max transactions
+      ansible.builtin.lineinfile:
+        path: /etc/postgresql/postgresql.conf
+        line: "orioledb.rewind_max_transactions = 100000"
+        state: present
+      when: is_psql_oriole and stage2_nix
+      become: yes
+
+    - name: Set OrioleDB rewind buffers
+      ansible.builtin.lineinfile:
+        path: /etc/postgresql/postgresql.conf
+        line: "orioledb.rewind_buffers = 13"
+        state: present
+      when: is_psql_oriole and stage2_nix
+      become: yes
+
     - name: Add ORIOLEDB_ENABLED environment variable
       ansible.builtin.lineinfile:
         path: /etc/environment

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,7 +10,7 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.5.1.055-orioledb-rewind"
+  postgresorioledb-17: "17.5.1.056-orioledb-rewind"
   postgres17: "17.6.1.028"
   postgres15: "15.14.1.028"
 

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,7 +10,7 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.5.1.051-orioledb-rewind"
+  postgresorioledb-17: "17.5.1.053-orioledb-rewind"
   postgres17: "17.6.1.028"
   postgres15: "15.14.1.028"
 

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,7 +10,7 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.5.1.056-orioledb-rewind"
+  postgresorioledb-17: "17.5.1.057-orioledb-rewind"
   postgres17: "17.6.1.028"
   postgres15: "15.14.1.028"
 

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -4,13 +4,13 @@ ebssurrogate_mode: true
 async_mode: true
 
 postgres_major:
-  - "15"
-  - "17"
+  # - "15"  # only building orioledb-17 for rewind feature
+  # - "17"  # only building orioledb-17 for rewind feature
   - orioledb-17
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.5.1.049-orioledb"
+  postgresorioledb-17: "17.5.1.051-orioledb-rewind"
   postgres17: "17.6.1.028"
   postgres15: "15.14.1.028"
 

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,7 +10,7 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.5.1.057-orioledb-rewind"
+  postgresorioledb-17: "17.5.1.058-orioledb-rewind"
   postgres17: "17.6.1.028"
   postgres15: "15.14.1.028"
 

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,7 +10,7 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.5.1.054-orioledb-rewind"
+  postgresorioledb-17: "17.5.1.055-orioledb-rewind"
   postgres17: "17.6.1.028"
   postgres15: "15.14.1.028"
 

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,7 +10,7 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.5.1.053-orioledb-rewind"
+  postgresorioledb-17: "17.5.1.054-orioledb-rewind"
   postgres17: "17.6.1.028"
   postgres15: "15.14.1.028"
 

--- a/nix/ext/orioledb.nix
+++ b/nix/ext/orioledb.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     python3
     openssl
   ];
-  buildPhase = "make USE_PGXS=1 ORIOLEDB_PATCHSET_VERSION=11";
+  buildPhase = "make USE_PGXS=1 ORIOLEDB_PATCHSET_VERSION=11 IS_DEV=1";
   installPhase = ''
     runHook preInstall
 

--- a/nix/ext/orioledb.nix
+++ b/nix/ext/orioledb.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     python3
     openssl
   ];
-  buildPhase = "make USE_PGXS=1 ORIOLEDB_PATCHSET_VERSION=11 IS_DEV=1";
+  buildPhase = "make USE_PGXS=1 ORIOLEDB_PATCHSET_VERSION=11";
   installPhase = ''
     runHook preInstall
 

--- a/nix/tools/run-server.sh.in
+++ b/nix/tools/run-server.sh.in
@@ -248,11 +248,11 @@ orioledb_config_items() {
         sed -i 's/ timescaledb,//g; s/ plv8,//g; s/ pgjwt,//g;' "$DATDIR/supautils.conf"
         sed -i 's/\(shared_preload_libraries.*\)'\''\(.*\)$/\1, orioledb'\''\2/' "$DATDIR/postgresql.conf"
         echo "default_table_access_method = 'orioledb'" >> "$DATDIR/postgresql.conf"
-        # OrioleDB rewind configuration (20 minute window)
+        # OrioleDB rewind configuration (20 minute window, 10MB buffer)
         echo "orioledb.enable_rewind = true" >> "$DATDIR/postgresql.conf"
         echo "orioledb.rewind_max_time = 1200" >> "$DATDIR/postgresql.conf"
         echo "orioledb.rewind_max_transactions = 100000" >> "$DATDIR/postgresql.conf"
-        echo "orioledb.rewind_buffers = 13" >> "$DATDIR/postgresql.conf"
+        echo "orioledb.rewind_buffers = 1280" >> "$DATDIR/postgresql.conf"
     elif [[ "$1" = "orioledb-17" && "$CURRENT_SYSTEM" = "aarch64-darwin" ]]; then
         # macOS specific configuration
         echo "macOS detected, applying macOS specific configuration"
@@ -268,11 +268,11 @@ orioledb_config_items() {
         perl -pi -e 's/(shared_preload_libraries\s*=\s*'\''.*?)'\''/\1, orioledb'\''/' "$DATDIR/postgresql.conf"
 
         echo "default_table_access_method = 'orioledb'" >> "$DATDIR/postgresql.conf"
-        # OrioleDB rewind configuration (20 minute window)
+        # OrioleDB rewind configuration (20 minute window, 10MB buffer)
         echo "orioledb.enable_rewind = true" >> "$DATDIR/postgresql.conf"
         echo "orioledb.rewind_max_time = 1200" >> "$DATDIR/postgresql.conf"
         echo "orioledb.rewind_max_transactions = 100000" >> "$DATDIR/postgresql.conf"
-        echo "orioledb.rewind_buffers = 13" >> "$DATDIR/postgresql.conf"
+        echo "orioledb.rewind_buffers = 1280" >> "$DATDIR/postgresql.conf"
     elif [[ "$VERSION" == "17" && "$CURRENT_SYSTEM" != "aarch64-darwin" ]]; then
         echo "non-macos pg 17 conf"
         sed -i 's/ timescaledb,//g;' "$DATDIR/postgresql.conf"

--- a/nix/tools/run-server.sh.in
+++ b/nix/tools/run-server.sh.in
@@ -248,6 +248,11 @@ orioledb_config_items() {
         sed -i 's/ timescaledb,//g; s/ plv8,//g; s/ pgjwt,//g;' "$DATDIR/supautils.conf"
         sed -i 's/\(shared_preload_libraries.*\)'\''\(.*\)$/\1, orioledb'\''\2/' "$DATDIR/postgresql.conf"
         echo "default_table_access_method = 'orioledb'" >> "$DATDIR/postgresql.conf"
+        # OrioleDB rewind configuration (20 minute window)
+        echo "orioledb.enable_rewind = true" >> "$DATDIR/postgresql.conf"
+        echo "orioledb.rewind_max_time = 1200" >> "$DATDIR/postgresql.conf"
+        echo "orioledb.rewind_max_transactions = 100000" >> "$DATDIR/postgresql.conf"
+        echo "orioledb.rewind_buffers = 13" >> "$DATDIR/postgresql.conf"
     elif [[ "$1" = "orioledb-17" && "$CURRENT_SYSTEM" = "aarch64-darwin" ]]; then
         # macOS specific configuration
         echo "macOS detected, applying macOS specific configuration"
@@ -261,8 +266,13 @@ orioledb_config_items() {
         perl -pi -e 's/ plv8,//g' "$DATDIR/supautils.conf"
         perl -pi -e 's/ pgjwt,//g' "$DATDIR/supautils.conf"
         perl -pi -e 's/(shared_preload_libraries\s*=\s*'\''.*?)'\''/\1, orioledb'\''/' "$DATDIR/postgresql.conf"
-        
+
         echo "default_table_access_method = 'orioledb'" >> "$DATDIR/postgresql.conf"
+        # OrioleDB rewind configuration (20 minute window)
+        echo "orioledb.enable_rewind = true" >> "$DATDIR/postgresql.conf"
+        echo "orioledb.rewind_max_time = 1200" >> "$DATDIR/postgresql.conf"
+        echo "orioledb.rewind_max_transactions = 100000" >> "$DATDIR/postgresql.conf"
+        echo "orioledb.rewind_buffers = 13" >> "$DATDIR/postgresql.conf"
     elif [[ "$VERSION" == "17" && "$CURRENT_SYSTEM" != "aarch64-darwin" ]]; then
         echo "non-macos pg 17 conf"
         sed -i 's/ timescaledb,//g;' "$DATDIR/postgresql.conf"


### PR DESCRIPTION
Enables the GUCs that power OrioleDB fast rewind

Currently configured for 20 mins max rewind

Tested locally to work

This is to get an early prototype in the hands of interested customers. In the long term we'll get a dedicated API endpoint for it. In the short term it'll be usable by
- hitting `select orioledb_rewind_by_time(1200);` via `/v1/projects/{ref}/database/query`
- Restart the database with `/platform/projects/{ref}/restart-services`

For 2-7 second rewind times

