### PR TITLE
feat: support multiple versions of the pg-safeupdate extension

### DIFF
--- a/nix/ext/pg-safeupdate.nix
+++ b/nix/ext/pg-safeupdate.nix
@@ -1,33 +1,86 @@
 {
+  pkgs,
   lib,
   stdenv,
   fetchFromGitHub,
   postgresql,
+  makeWrapper,
 }:
 
-stdenv.mkDerivation rec {
-  pname = "pg-safeupdate";
-  version = "1.4";
+let
+  pname = "safeupdate";
+  build =
+    version: hash:
+    stdenv.mkDerivation rec {
+      inherit pname version;
 
-  buildInputs = [ postgresql ];
+      buildInputs = [ postgresql ];
 
-  src = fetchFromGitHub {
-    owner = "eradman";
-    repo = pname;
-    rev = version;
-    hash = "sha256-1cyvVEC9MQGMr7Tg6EUbsVBrMc8ahdFS3+CmDkmAq4Y=";
-  };
+      src = fetchFromGitHub {
+        owner = "eradman";
+        repo = pname;
+        rev = version;
+        inherit hash;
+      };
 
-  installPhase = ''
-    install -D safeupdate${postgresql.dlSuffix} -t $out/lib
+      installPhase = ''
+        runHook preInstall
+
+        mkdir -p $out/share/postgresql/extension
+
+        # Install versioned library
+        install -Dm755 ${pname}${postgresql.dlSuffix} $out/lib/${pname}-${version}${postgresql.dlSuffix}
+
+        runHook postInstall
+      '';
+
+      meta = with lib; {
+        description = "A simple extension to PostgreSQL that requires criteria for UPDATE and DELETE";
+        homepage = "https://github.com/eradman/pg-safeupdate";
+        changelog = "https://github.com/eradman/pg-safeupdate/raw/${src.rev}/NEWS";
+        platforms = postgresql.meta.platforms;
+        license = licenses.postgresql;
+        broken = versionOlder postgresql.version "14";
+      };
+    };
+  allVersions = (builtins.fromJSON (builtins.readFile ./versions.json)).safeupdate;
+  supportedVersions = lib.filterAttrs (
+    _: value: builtins.elem (lib.versions.major postgresql.version) value.postgresql
+  ) allVersions;
+  versions = lib.naturalSort (lib.attrNames supportedVersions);
+  latestVersion = lib.last versions;
+  numberOfVersions = builtins.length versions;
+  packages = builtins.attrValues (
+    lib.mapAttrs (name: value: build name value.hash) supportedVersions
+  );
+in
+pkgs.buildEnv {
+  name = pname;
+  paths = packages;
+  nativeBuildInputs = [ makeWrapper ];
+  pathsToLink = [
+    "/lib"
+    "/share/postgresql/extension"
+  ];
+  postBuild = ''
+    ln -sfn ${pname}-${latestVersion}${postgresql.dlSuffix} $out/lib/${pname}${postgresql.dlSuffix}
+
+    # checks
+    (set -x
+       test "$(ls -A $out/lib/${pname}*${postgresql.dlSuffix} | wc -l)" = "${
+         toString (numberOfVersions + 1)
+       }"
+    )
   '';
 
-  meta = with lib; {
-    description = "A simple extension to PostgreSQL that requires criteria for UPDATE and DELETE";
-    homepage = "https://github.com/eradman/pg-safeupdate";
-    changelog = "https://github.com/eradman/pg-safeupdate/raw/${src.rev}/NEWS";
-    platforms = postgresql.meta.platforms;
-    license = licenses.postgresql;
-    broken = versionOlder postgresql.version "14";
+  passthru = {
+    inherit versions numberOfVersions;
+    pname = "${pname}-all";
+    defaultSettings = {
+      shared_preload_libraries = [ "safeupdate" ];
+    };
+    pgRegressTestName = "pg-safeupdate";
+    version =
+      "multi-" + lib.concatStringsSep "-" (map (v: lib.replaceStrings [ "." ] [ "-" ] v) versions);
   };
 }

--- a/nix/ext/tests/pg_safeupdate.nix
+++ b/nix/ext/tests/pg_safeupdate.nix
@@ -1,0 +1,133 @@
+{ self, pkgs }:
+let
+  pname = "safeupdate";
+  inherit (pkgs) lib;
+  installedExtension =
+    postgresMajorVersion: self.packages.${pkgs.system}."psql_${postgresMajorVersion}/exts/${pname}-all";
+  versions = postgresqlMajorVersion: (installedExtension postgresqlMajorVersion).versions;
+  postgresqlWithExtension =
+    postgresql:
+    let
+      majorVersion = lib.versions.major postgresql.version;
+      pkg = pkgs.buildEnv {
+        name = "postgresql-${majorVersion}-${pname}";
+        paths = [
+          postgresql
+          postgresql.lib
+          (installedExtension majorVersion)
+        ];
+        passthru = {
+          inherit (postgresql) version psqlSchema;
+          lib = pkg;
+          withPackages = _: pkg;
+        };
+        nativeBuildInputs = [ pkgs.makeWrapper ];
+        pathsToLink = [
+          "/"
+          "/bin"
+          "/lib"
+        ];
+        postBuild = ''
+          wrapProgram $out/bin/postgres --set NIX_PGLIBDIR $out/lib
+          wrapProgram $out/bin/pg_ctl --set NIX_PGLIBDIR $out/lib
+          wrapProgram $out/bin/pg_upgrade --set NIX_PGLIBDIR $out/lib
+        '';
+      };
+    in
+    pkg;
+  psql_15 = postgresqlWithExtension self.packages.${pkgs.system}.postgresql_15;
+  psql_17 = postgresqlWithExtension self.packages.${pkgs.system}.postgresql_17;
+in
+self.inputs.nixpkgs.lib.nixos.runTest {
+  name = pname;
+  hostPkgs = pkgs;
+  nodes.server =
+    { config, ... }:
+    {
+      services.postgresql = {
+        enable = true;
+        package = (postgresqlWithExtension psql_15);
+        settings = (installedExtension "15").defaultSettings or { };
+      };
+
+      specialisation.postgresql17.configuration = {
+        services.postgresql = {
+          package = lib.mkForce psql_17;
+          settings = (installedExtension "15").defaultSettings or { };
+        };
+
+        systemd.services.postgresql-migrate = {
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+            User = "postgres";
+            Group = "postgres";
+            StateDirectory = "postgresql";
+            WorkingDirectory = "${builtins.dirOf config.services.postgresql.dataDir}";
+          };
+          script =
+            let
+              oldPostgresql = psql_15;
+              newPostgresql = psql_17;
+              oldDataDir = "${builtins.dirOf config.services.postgresql.dataDir}/${oldPostgresql.psqlSchema}";
+              newDataDir = "${builtins.dirOf config.services.postgresql.dataDir}/${newPostgresql.psqlSchema}";
+            in
+            ''
+              if [[ ! -d ${newDataDir} ]]; then
+                install -d -m 0700 -o postgres -g postgres "${newDataDir}"
+                ${newPostgresql}/bin/initdb -D "${newDataDir}"
+                ${newPostgresql}/bin/pg_upgrade --old-datadir "${oldDataDir}" --new-datadir "${newDataDir}" \
+                  --old-bindir "${oldPostgresql}/bin" --new-bindir "${newPostgresql}/bin"
+              else
+                echo "${newDataDir} already exists"
+              fi
+            '';
+        };
+
+        systemd.services.postgresql = {
+          after = [ "postgresql-migrate.service" ];
+          requires = [ "postgresql-migrate.service" ];
+        };
+      };
+    };
+  testScript =
+    { nodes, ... }:
+    let
+      pg17-configuration = "${nodes.server.system.build.toplevel}/specialisation/postgresql17";
+    in
+    ''
+      from pathlib import Path
+      versions = {
+        "15": [${lib.concatStringsSep ", " (map (s: ''"${s}"'') (versions "15"))}],
+        "17": [${lib.concatStringsSep ", " (map (s: ''"${s}"'') (versions "17"))}],
+      }
+      extension_name = "${pname}"
+      support_upgrade = False
+      pg17_configuration = "${pg17-configuration}"
+      ext_has_background_worker = ${
+        if (installedExtension "15") ? hasBackgroundWorker then "True" else "False"
+      }
+      sql_test_directory = Path("${../../tests}")
+      pg_regress_test_name = "${(installedExtension "15").pgRegressTestName or pname}"
+
+      ${builtins.readFile ./lib.py}
+
+      start_all()
+
+      server.wait_for_unit("multi-user.target")
+      server.wait_for_unit("postgresql.service")
+
+      test = PostgresExtensionTest(server, extension_name, versions, sql_test_directory, support_upgrade)
+
+      with subtest("Check pg_regress with postgresql 15 after extension upgrade"):
+        test.check_pg_regress(Path("${psql_15}/lib/pgxs/src/test/regress/pg_regress"), "15", pg_regress_test_name)
+
+      with subtest("switch to postgresql 17"):
+        server.succeed(
+          f"{pg17_configuration}/bin/switch-to-configuration test >&2"
+        )
+
+      with subtest("Check pg_regress with postgresql 17 after extension upgrade"):
+        test.check_pg_regress(Path("${psql_17}/lib/pgxs/src/test/regress/pg_regress"), "17", pg_regress_test_name)
+    '';
+}

--- a/nix/ext/versions.json
+++ b/nix/ext/versions.json
@@ -768,6 +768,15 @@
       "hash": "sha256-crxj5R9jblIv0h8lpqddAoYe2UqgUlnvbOajKTzVces="
     }
   },
+  "safeupdate": {
+    "1.4": {
+      "postgresql": [
+        "15",
+        "17"
+      ],
+      "hash": "sha256-1cyvVEC9MQGMr7Tg6EUbsVBrMc8ahdFS3+CmDkmAq4Y="
+    }
+  },
   "wal2json": {
     "2.6": {
       "postgresql": [


### PR DESCRIPTION
Build multiple versions of the pg-safeupdate extension on different PostgreSQL versions.

Add test for the extension and their upgrade on PostgreSQL 15 and 17.