### PR TITLE
fix: wrappers 0.5.3 missing

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.5.1.050-orioledb"
-  postgres17: "17.6.1.029"
-  postgres15: "15.14.1.029"
+  postgresorioledb-17: "17.5.1.050-orioledb-wfix-1"
+  postgres17: "17.6.1.029-wfix-1"
+  postgres15: "15.14.1.029-wfix-1"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.19.0

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.5.1.050-orioledb-wfix-1"
-  postgres17: "17.6.1.029-wfix-1"
-  postgres15: "15.14.1.029-wfix-1"
+  postgresorioledb-17: "17.5.1.051-orioledb"
+  postgres17: "17.6.1.030"
+  postgres15: "15.14.1.030"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.19.0

--- a/nix/ext/versions.json
+++ b/nix/ext/versions.json
@@ -572,6 +572,16 @@
       "pgrx": "0.12.9",
       "rust": "1.84.0"
     },
+    "0.5.3": {
+      "postgresql": [
+        "15",
+        "17",
+        "orioledb-17"
+      ],
+      "hash": "sha256-iaJriPEa0iVLpmnuUk9R3HS545Jhz7aH1clYvHEuEvs=",
+      "pgrx": "0.14.3",
+      "rust": "1.87.0"
+    },
     "0.5.4": {
       "postgresql": [
         "15",


### PR DESCRIPTION
0.5.3 was accidentally missing from wrappers. This caused a migration file to be missing, which can cause upgrades to fail. Once this PR is tested, it will be merged and will fix this issue