### PR TITLE
feat: migrate from the DetSys Nix installer to the official Nix installer

### DIFF
--- a/Dockerfile-15
+++ b/Dockerfile-15
@@ -52,19 +52,19 @@ RUN apt update -y && apt install -y \
 
 RUN adduser --system  --home /var/lib/postgresql --no-create-home --shell /bin/bash --group --gecos "PostgreSQL administrator" postgres
 RUN adduser --system  --no-create-home --shell /bin/bash --group  wal-g
-RUN curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install linux \
---init none \
---no-confirm \
---extra-conf "substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com" \
---extra-conf "trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
-
+RUN cat <<EOF > /tmp/extra-nix.conf
+extra-experimental-features = nix-command flakes
+extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
+extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=
+EOF
+RUN curl -L https://releases.nixos.org/nix/nix-2.32.2/install | sh -s -- --daemon --no-channel-add --yes --nix-extra-conf-file /tmp/extra-nix.conf
 ENV PATH="${PATH}:/nix/var/nix/profiles/default/bin"
 
 COPY . /nixpg
 
 WORKDIR /nixpg
 
-RUN nix profile install .#psql_15/bin 
+RUN nix profile install .#psql_15/bin
 
 RUN nix store gc
 

--- a/Dockerfile-17
+++ b/Dockerfile-17
@@ -54,11 +54,12 @@ RUN apt update -y && apt install -y \
 
 RUN adduser --system  --home /var/lib/postgresql --no-create-home --shell /bin/bash --group --gecos "PostgreSQL administrator" postgres
 RUN adduser --system  --no-create-home --shell /bin/bash --group  wal-g
-RUN curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install linux \
---init none \
---no-confirm \
---extra-conf "substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com" \
---extra-conf "trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+RUN cat <<EOF > /tmp/extra-nix.conf
+extra-experimental-features = nix-command flakes
+extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
+extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=
+EOF
+RUN curl -L https://releases.nixos.org/nix/nix-2.32.2/install | sh -s -- --daemon --no-channel-add --yes --nix-extra-conf-file /tmp/extra-nix.conf
 
 ENV PATH="${PATH}:/nix/var/nix/profiles/default/bin"
 

--- a/Dockerfile-orioledb-17
+++ b/Dockerfile-orioledb-17
@@ -54,11 +54,12 @@ RUN apt update -y && apt install -y \
 
 RUN adduser --system  --home /var/lib/postgresql --no-create-home --shell /bin/bash --group --gecos "PostgreSQL administrator" postgres
 RUN adduser --system  --no-create-home --shell /bin/bash --group  wal-g
-RUN curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install linux \
---init none \
---no-confirm \
---extra-conf "substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com" \
---extra-conf "trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+RUN cat <<EOF > /tmp/extra-nix.conf
+extra-experimental-features = nix-command flakes
+extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
+extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=
+EOF
+RUN curl -L https://releases.nixos.org/nix/nix-2.32.2/install | sh -s -- --daemon --no-channel-add --yes --nix-extra-conf-file /tmp/extra-nix.conf
 
 ENV PATH="${PATH}:/nix/var/nix/profiles/default/bin"
 

--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
@@ -289,10 +289,11 @@ function initiate_upgrade {
                         --extra-conf "trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
                     else
                         echo "1.1.1. Installing Nix using the official installer"
-
-                        curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --no-confirm \
-                        --extra-conf "substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com" \
-                        --extra-conf "trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+                        sh <(curl -L https://releases.nixos.org/nix/nix-2.32.2/install) --yes --daemon --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
+extra-experimental-features = nix-command flakes
+extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
+extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=
+EXTRA_NIX_CONF
                     fi
                 else 
                     echo "1.1. Nix is installed; moving on."

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.5.1.064-orioledb"
-  postgres17: "17.6.1.043"
-  postgres15: "15.14.1.043"
+  postgresorioledb-17: "17.5.1.050-orioledb-inst-1"
+  postgres17: "17.6.1.029-inst-1"
+  postgres15: "15.14.1.029-inst-1"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.19.0

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.5.1.050-orioledb-inst-1"
-  postgres17: "17.6.1.029-inst-1"
-  postgres15: "15.14.1.029-inst-1"
+  postgresorioledb-17: "17.5.1.065-orioledb"
+  postgres17: "17.6.1.044"
+  postgres15: "15.14.1.044"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.19.0

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.5.1.065-orioledb"
-  postgres17: "17.6.1.044"
-  postgres15: "15.14.1.044"
+  postgresorioledb-17: "17.5.1.064-orioledb"
+  postgres17: "17.6.1.043"
+  postgres15: "15.14.1.043"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.19.0

--- a/ebssurrogate/scripts/qemu-bootstrap-nix.sh
+++ b/ebssurrogate/scripts/qemu-bootstrap-nix.sh
@@ -82,11 +82,13 @@ execute_playbook
 ####################
 
 function install_nix() {
-	sudo su -c "curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --no-confirm \
-    --extra-conf \"substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com\" \
-    --extra-conf \"trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=\" " -s /bin/bash root
-	. /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-
+    sudo su -c "sh <(curl -L https://releases.nixos.org/nix/nix-2.32.2/install) --yes --daemon --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
+extra-experimental-features = nix-command flakes
+extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
+extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=
+EXTRA_NIX_CONF" -s /bin/bash root
+    #shellcheck disable=SC1091
+    . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
 }
 
 function execute_stage2_playbook {

--- a/scripts/nix-provision.sh
+++ b/scripts/nix-provision.sh
@@ -23,11 +23,13 @@ function install_packages {
 
 
 function install_nix() {
-    sudo su -c "curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --no-confirm \
-    --extra-conf \"substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com\" \
-    --extra-conf \"trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=\" " -s /bin/bash root
+    sudo su -c "sh <(curl -L https://releases.nixos.org/nix/nix-2.32.2/install) --yes --daemon --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
+extra-experimental-features = nix-command flakes
+extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
+extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=
+EXTRA_NIX_CONF" -s /bin/bash root
+    #shellcheck disable=SC1091
     . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-
 }
 
 


### PR DESCRIPTION
The Determinate Nix Installer will stop distributing upstream Nix.

DetSys installer timeline:
* November 10: the installer to default to Determinate Nix.
* January 1: removing support for installing upstream Nix.

As https://github.com/NixOS/experimental-nix-installer is still work in progress, we use the official installer with nix pinned to v2.32.2

Note: a similar change has been made to the GitHub workflows in https://github.com/supabase/postgres/pull/1745/commits/c9681e8e53c50ee967bd829e0c51bef78ec8c588
