### PR TITLE
fix: we won't deploy this newest version of plv8 yet

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.5.1.056-orioledb"
-  postgres17: "17.6.1.035"
-  postgres15: "15.14.1.035"
+  postgresorioledb-17: "17.5.1.057-orioledb"
+  postgres17: "17.6.1.036"
+  postgres15: "15.14.1.036"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.19.0

--- a/nix/ext/versions.json
+++ b/nix/ext/versions.json
@@ -433,12 +433,6 @@
         "15"
       ],
       "hash": "sha256-g1A/XPC0dX2360Gzvmo9/FSQnM6Wt2K4eR0pH0p9fz4="
-    },
-    "3.2.3": {
-      "postgresql": [
-        "15"
-      ],
-      "hash": "sha256-ivQZJSNn5giWF351fqZ7mBZoJkGtby5T7beK45g3Zqs="
     }
   },
   "postgis": {


### PR DESCRIPTION
We should not advance plv8 version past 3.1.10 yet