### PR TITLE
fix: grant execute on pg_reload_conf() to postgres

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.5.1.061-orioledb"
-  postgres17: "17.6.1.040"
-  postgres15: "15.14.1.040"
+  postgresorioledb-17: "17.5.1.062-orioledb"
+  postgres17: "17.6.1.041"
+  postgres15: "15.14.1.041"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.19.0

--- a/migrations/db/migrations/20251105172723_grant_pg_reload_conf_to_postgres.sql
+++ b/migrations/db/migrations/20251105172723_grant_pg_reload_conf_to_postgres.sql
@@ -1,0 +1,5 @@
+-- migrate:up
+grant execute on function pg_catalog.pg_reload_conf() to postgres;
+
+-- migrate:down
+

--- a/migrations/db/migrations/20251105172723_grant_pg_reload_conf_to_postgres.sql
+++ b/migrations/db/migrations/20251105172723_grant_pg_reload_conf_to_postgres.sql
@@ -1,5 +1,5 @@
 -- migrate:up
-grant execute on function pg_catalog.pg_reload_conf() to postgres;
+grant execute on function pg_catalog.pg_reload_conf() to postgres with grant option;
 
 -- migrate:down
 

--- a/nix/tests/expected/z_15_roles.out
+++ b/nix/tests/expected/z_15_roles.out
@@ -36,3 +36,29 @@ order by
  supabase_storage_admin  | authenticator          | f
 (21 rows)
 
+-- Check all privileges of non-superuser roles on functions
+select
+  p.pronamespace::regnamespace as schema,
+  p.proname as object_name,
+  acl.grantee::regrole::text as grantee,
+  acl.privilege_type
+from pg_catalog.pg_proc p
+cross join lateral pg_catalog.aclexplode(p.proacl) as acl
+where p.pronamespace::regnamespace::text = 'pg_catalog'
+  and acl.grantee::regrole::text != 'supabase_admin'
+order by object_name, grantee, privilege_type;
+   schema   |          object_name           |      grantee      | privilege_type 
+------------+--------------------------------+-------------------+----------------
+ pg_catalog | pg_get_backend_memory_contexts | pg_read_all_stats | EXECUTE
+ pg_catalog | pg_get_shmem_allocations       | pg_read_all_stats | EXECUTE
+ pg_catalog | pg_ls_archive_statusdir        | pg_monitor        | EXECUTE
+ pg_catalog | pg_ls_logdir                   | pg_monitor        | EXECUTE
+ pg_catalog | pg_ls_logicalmapdir            | pg_monitor        | EXECUTE
+ pg_catalog | pg_ls_logicalsnapdir           | pg_monitor        | EXECUTE
+ pg_catalog | pg_ls_replslotdir              | pg_monitor        | EXECUTE
+ pg_catalog | pg_ls_tmpdir                   | pg_monitor        | EXECUTE
+ pg_catalog | pg_ls_tmpdir                   | pg_monitor        | EXECUTE
+ pg_catalog | pg_ls_waldir                   | pg_monitor        | EXECUTE
+ pg_catalog | pg_reload_conf                 | postgres          | EXECUTE
+(11 rows)
+

--- a/nix/tests/expected/z_17_roles.out
+++ b/nix/tests/expected/z_17_roles.out
@@ -167,3 +167,31 @@ order by
  supabase_storage_admin  | authenticator          | f
 (22 rows)
 
+-- Check all privileges of non-superuser roles on functions
+select
+  p.pronamespace::regnamespace as schema,
+  p.proname as object_name,
+  acl.grantee::regrole::text as grantee,
+  acl.privilege_type
+from pg_catalog.pg_proc p
+cross join lateral pg_catalog.aclexplode(p.proacl) as acl
+where p.pronamespace::regnamespace::text = 'pg_catalog'
+  and acl.grantee::regrole::text != 'supabase_admin'
+order by object_name, grantee, privilege_type;
+   schema   |          object_name           |      grantee      | privilege_type 
+------------+--------------------------------+-------------------+----------------
+ pg_catalog | pg_current_logfile             | pg_monitor        | EXECUTE
+ pg_catalog | pg_current_logfile             | pg_monitor        | EXECUTE
+ pg_catalog | pg_get_backend_memory_contexts | pg_read_all_stats | EXECUTE
+ pg_catalog | pg_get_shmem_allocations       | pg_read_all_stats | EXECUTE
+ pg_catalog | pg_ls_archive_statusdir        | pg_monitor        | EXECUTE
+ pg_catalog | pg_ls_logdir                   | pg_monitor        | EXECUTE
+ pg_catalog | pg_ls_logicalmapdir            | pg_monitor        | EXECUTE
+ pg_catalog | pg_ls_logicalsnapdir           | pg_monitor        | EXECUTE
+ pg_catalog | pg_ls_replslotdir              | pg_monitor        | EXECUTE
+ pg_catalog | pg_ls_tmpdir                   | pg_monitor        | EXECUTE
+ pg_catalog | pg_ls_tmpdir                   | pg_monitor        | EXECUTE
+ pg_catalog | pg_ls_waldir                   | pg_monitor        | EXECUTE
+ pg_catalog | pg_reload_conf                 | postgres          | EXECUTE
+(13 rows)
+

--- a/nix/tests/sql/z_15_roles.sql
+++ b/nix/tests/sql/z_15_roles.sql
@@ -11,3 +11,15 @@ left join
     pg_roles g on m.roleid = g.oid
 order by
     r.rolname, g.rolname;
+
+-- Check all privileges of non-superuser roles on functions
+select
+  p.pronamespace::regnamespace as schema,
+  p.proname as object_name,
+  acl.grantee::regrole::text as grantee,
+  acl.privilege_type
+from pg_catalog.pg_proc p
+cross join lateral pg_catalog.aclexplode(p.proacl) as acl
+where p.pronamespace::regnamespace::text = 'pg_catalog'
+  and acl.grantee::regrole::text != 'supabase_admin'
+order by object_name, grantee, privilege_type;

--- a/nix/tests/sql/z_17_roles.sql
+++ b/nix/tests/sql/z_17_roles.sql
@@ -72,3 +72,15 @@ where r.rolname not in ('pg_create_subscription', 'pg_maintain', 'pg_use_reserve
 and g.rolname not in ('pg_create_subscription', 'pg_maintain', 'pg_use_reserved_connections')
 order by
     r.rolname, g.rolname;
+
+-- Check all privileges of non-superuser roles on functions
+select
+  p.pronamespace::regnamespace as schema,
+  p.proname as object_name,
+  acl.grantee::regrole::text as grantee,
+  acl.privilege_type
+from pg_catalog.pg_proc p
+cross join lateral pg_catalog.aclexplode(p.proacl) as acl
+where p.pronamespace::regnamespace::text = 'pg_catalog'
+  and acl.grantee::regrole::text != 'supabase_admin'
+order by object_name, grantee, privilege_type;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Grants `postgres` EXECUTE privileges on the `pg_reload_conf()` function.

## What is the current behavior?

`postgres` cannot execute `pg_reload_conf()`.

## What is the new behavior?

`postgres` can execute `pg_reload_conf()`.

## Additional context
