### PR TITLE
feat: bump auth to v2.182.1

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.5.1.059-orioledb"
-  postgres17: "17.6.1.038"
-  postgres15: "15.14.1.038"
+  postgresorioledb-17: "17.5.1.060-orioledb"
+  postgres17: "17.6.1.039"
+  postgres15: "15.14.1.039"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.19.0
@@ -25,8 +25,8 @@ postgrest_release: 13.0.5
 postgrest_arm_release_checksum: sha256:7b4eafdaf76bc43b57f603109d460a838f89f949adccd02f452ca339f9a0a0d4
 postgrest_x86_release_checksum: sha256:05be2bd48abee6c1691fc7c5d005023466c6989e41a4fc7d1302b8212adb88b5
 
-gotrue_release: 2.180.0
-gotrue_release_checksum: sha1:386c1fb6be075004091b2fbd8662dc9dcdc7af04
+gotrue_release: 2.182.1
+gotrue_release_checksum: sha1:38a12109ad62df32460d88e4c7b2a475b88e7865
 
 aws_cli_release: 2.23.11
 


### PR DESCRIPTION
Bump to [auth@2.182.1](https://github.com/supabase/auth/releases/tag/v2.182.1)