### PR TITLE
feat: test pg_upgrade compatibility with older extension versions

### DIFF
--- a/nix/ext/pg_graphql/default.nix
+++ b/nix/ext/pg_graphql/default.nix
@@ -80,7 +80,7 @@ let
 
         preCheck = ''
           export PGRX_HOME="$(mktemp -d)"
-          export PG_VERSION="${lib.versions.major postgresql.version}"
+          export PG_VERSION="${pgVersion}"
           export NIX_PGLIBDIR="$PGRX_HOME/$PG_VERSION/lib"
           export PATH="$PGRX_HOME/$PG_VERSION/bin:$PATH"
           ${lib.getExe rsync} --chmod=ugo+w -a ${postgresql}/ ${postgresql.lib}/ "$PGRX_HOME/$PG_VERSION/"
@@ -120,8 +120,9 @@ let
       }
     );
   allVersions = (builtins.fromJSON (builtins.readFile ../versions.json)).pg_graphql;
+  pgVersion = lib.versions.major postgresql.version;
   supportedVersions = lib.filterAttrs (
-    _: value: builtins.elem (lib.versions.major postgresql.version) value.postgresql
+    _: value: builtins.elem pgVersion value.postgresql
   ) allVersions;
   versions = lib.naturalSort (lib.attrNames supportedVersions);
   latestVersion = lib.last versions;
@@ -135,10 +136,54 @@ let
   packages = builtins.attrValues (
     lib.mapAttrs (name: value: build name value.hash value.rust value.pgrx) versionsToUse
   );
+  buildUnsupported =
+    # Build SQL-only packages for unsupported versions needed by pg_upgrade.
+    # When upgrading PostgreSQL, pg_upgrade requires old extension versions to exist
+    # even if they can't compile against the new PostgreSQL version.
+    version: hash: _rustVersion: _pgrxVersion:
+    stdenv.mkDerivation {
+      inherit pname version;
+      src = fetchFromGitHub {
+        owner = "supabase";
+        repo = pname;
+        rev = "v${version}";
+        inherit hash;
+      };
+      phases = [ "installPhase" ];
+      installPhase = ''
+        mkdir -p $out/share/postgresql/extension
+        for file in $src/sql/*.sql; do
+          filename=$(basename "$file")
+          if [[ "$filename" != "load_sql_config.sql" && "$filename" != "load_sql_context.sql" ]]; then
+            cat "$file"
+            echo ";"
+          fi
+        done > $out/share/postgresql/extension/${pname}--${version}.sql
+      '';
+      meta = with lib; {
+        description = "GraphQL support for PostreSQL";
+        homepage = "https://github.com/supabase/${pname}";
+        license = licenses.postgresql;
+        inherit (postgresql.meta) platforms;
+      };
+    };
+  unsupportedVersions = lib.filterAttrs (
+    _: value: !builtins.elem pgVersion value.postgresql
+  ) allVersions;
+  unsupportedPackages =
+    if pgVersion == 15 then
+      [ ]
+    else
+      # Include SQL-only packages for PG15 extension versions incompatible with current PG
+      builtins.attrValues (
+        lib.mapAttrs (
+          name: value: buildUnsupported name value.hash value.rust value.pgrx
+        ) unsupportedVersions
+      );
 in
 (buildEnv {
   name = pname;
-  paths = packages;
+  paths = packages ++ unsupportedPackages;
   pathsToLink = [
     "/lib"
     "/share/postgresql/extension"

--- a/nix/ext/pg_graphql/default.nix
+++ b/nix/ext/pg_graphql/default.nix
@@ -171,7 +171,7 @@ let
     _: value: !builtins.elem pgVersion value.postgresql
   ) allVersions;
   unsupportedPackages =
-    if pgVersion == 15 then
+    if pgVersion == "15" then
       [ ]
     else
       # Include SQL-only packages for PG15 extension versions incompatible with current PG

--- a/nix/ext/pg_jsonschema/default.nix
+++ b/nix/ext/pg_jsonschema/default.nix
@@ -76,9 +76,9 @@ let
 
       preCheck = ''
         export PGRX_HOME=$(mktemp -d)
-        export NIX_PGLIBDIR=$PGRX_HOME/${lib.versions.major postgresql.version}/lib
-        ${lib.getExe pkgs.rsync} --chmod=ugo+w -a ${postgresql}/ ${postgresql.lib}/ $PGRX_HOME/${lib.versions.major postgresql.version}/
-        cargo pgrx init --pg${lib.versions.major postgresql.version} $PGRX_HOME/${lib.versions.major postgresql.version}/bin/pg_config
+        export NIX_PGLIBDIR=$PGRX_HOME/${pgVersion}/lib
+        ${lib.getExe pkgs.rsync} --chmod=ugo+w -a ${postgresql}/ ${postgresql.lib}/ $PGRX_HOME/${pgVersion}/
+        cargo pgrx init --pg${pgVersion} $PGRX_HOME/${pgVersion}/bin/pg_config
       '';
 
       # Tests are disabled for specific versions because pgrx tests require
@@ -93,12 +93,8 @@ let
           "0.3.3"
         ]);
 
-      preBuild = ''
-        echo "Processing git tags..."
-        echo '${builtins.concatStringsSep "," previousVersions}' | sed 's/,/\n/g' > git_tags.txt
-      '';
-
       postInstall = ''
+        find $out
         mv $out/lib/${pname}${postgresql.dlSuffix} $out/lib/${pname}-${version}${postgresql.dlSuffix}
 
         create_control_files() {
@@ -127,8 +123,9 @@ let
       };
     };
   allVersions = (builtins.fromJSON (builtins.readFile ../versions.json)).pg_jsonschema;
+  pgVersion = lib.versions.major postgresql.version;
   supportedVersions = lib.filterAttrs (
-    _: value: builtins.elem (lib.versions.major postgresql.version) value.postgresql
+    _: value: builtins.elem pgVersion value.postgresql
   ) allVersions;
   versions = lib.naturalSort (lib.attrNames supportedVersions);
   latestVersion = lib.last versions;
@@ -142,6 +139,8 @@ let
   );
   versionsBuilt = if latestOnly then [ latestVersion ] else versions;
   numberOfVersionsBuilt = builtins.length versionsBuilt;
+  unsupportedVersionsItems = lib.filterAttrs (_: value: value.postgresql == [ "15" ]) allVersions;
+  unsupportedVersions = if pgVersion == "17" then lib.attrNames unsupportedVersionsItems else [ ];
 in
 (pkgs.buildEnv {
   name = pname;
@@ -157,6 +156,10 @@ in
          toString (numberOfVersionsBuilt + 1)
        }"
     )
+
+    for v in ${lib.concatStringsSep " " unsupportedVersions}; do
+      cp $out/share/postgresql/extension/${pname}--${lib.head versions}.sql $out/share/postgresql/extension/${pname}--$v.sql
+    done
 
     create_sql_files() {
       PREVIOUS_VERSION=""

--- a/nix/ext/pg_jsonschema/default.nix
+++ b/nix/ext/pg_jsonschema/default.nix
@@ -94,7 +94,6 @@ let
         ]);
 
       postInstall = ''
-        find $out
         mv $out/lib/${pname}${postgresql.dlSuffix} $out/lib/${pname}-${version}${postgresql.dlSuffix}
 
         create_control_files() {

--- a/nix/ext/pg_stat_monitor.nix
+++ b/nix/ext/pg_stat_monitor.nix
@@ -18,18 +18,20 @@ let
   ) allVersions;
 
   # Derived version information
-  versions = lib.naturalSort (lib.attrNames supportedVersions);
+  allVersionsList = lib.naturalSort (lib.attrNames supportedVersions);
+  versions = builtins.filter (v: (allVersions.${v}.pgUpgradeCompatible or true)) allVersionsList;
   latestVersion = lib.last versions;
-  versionsToUse =
-    if latestOnly then
-      { "${latestVersion}" = supportedVersions.${latestVersion}; }
-    else
-      supportedVersions;
+
+  # Filter to only build pg_upgrade compatible versions
+  pgUpgradeCompatibleVersions = lib.filterAttrs (
+    name: _: allVersions.${name}.pgUpgradeCompatible or true
+  ) supportedVersions;
+  packages = builtins.attrValues (
+    lib.mapAttrs (name: value: build name value.hash value.revision) pgUpgradeCompatibleVersions
+  );
+
   versionsBuilt = if latestOnly then [ latestVersion ] else versions;
   numberOfVersionsBuilt = builtins.length versionsBuilt;
-  packages = builtins.attrValues (
-    lib.mapAttrs (name: value: build name value.hash value.revision) versionsToUse
-  );
 
   # Build function for individual versions
   build =

--- a/nix/ext/tests/default.nix
+++ b/nix/ext/tests/default.nix
@@ -129,8 +129,14 @@ let
                     ${newPostgresql}/bin/pg_upgrade --old-datadir "${oldDataDir}" --new-datadir "${newDataDir}" \
                       --old-bindir "${oldPostgresql}/bin" --new-bindir "${newPostgresql}/bin" \
                       ${
+                        let
+                          oldLibs = oldSettings.shared_preload_libraries or "";
+                          newLibs = newSettings.shared_preload_libraries or "";
+                          oldLibsStr = if builtins.isList oldLibs then lib.concatStringsSep "," oldLibs else oldLibs;
+                          newLibsStr = if builtins.isList newLibs then lib.concatStringsSep "," newLibs else newLibs;
+                        in
                         if oldSettings ? shared_preload_libraries || newSettings ? shared_preload_libraries then
-                          " --old-options='-c shared_preload_libraries=${oldSettings.shared_preload_libraries or ""}' --new-options='-c shared_preload_libraries=${newSettings.shared_preload_libraries or ""}'"
+                          " --old-options='-c shared_preload_libraries=${oldLibsStr}' --new-options='-c shared_preload_libraries=${newLibsStr}'"
                         else
                           ""
                       }
@@ -314,14 +320,17 @@ let
           ${
             if run_pg_regress then
               ''
+                psql_17 = "${psql_17}"
+                orioledb_17 = "${orioledb_17}"
+
                 with subtest("Check pg_regress with postgresql 17 after extension upgrade"):
-                  test.check_pg_regress(Path("${psql_17}/lib/pgxs/src/test/regress/pg_regress"), "17", pg_regress_test_name)
+                  test.check_pg_regress(Path(f"{psql_17}/lib/pgxs/src/test/regress/pg_regress"), "17", pg_regress_test_name)
 
                 with subtest("Check the install of the last version of the extension"):
                   test.check_install_last_version("17")
 
                 with subtest("Check pg_regress with postgresql 17 after installing the last version"):
-                  test.check_pg_regress(Path("${psql_17}/lib/pgxs/src/test/regress/pg_regress"), "17", pg_regress_test_name)
+                  test.check_pg_regress(Path(f"{psql_17}/lib/pgxs/src/test/regress/pg_regress"), "17", pg_regress_test_name)
 
                 with subtest("switch to orioledb 17"):
                   server.succeed(
@@ -335,7 +344,7 @@ let
                   test.check_upgrade_path("orioledb-17")
 
                 with subtest("Check pg_regress with orioledb 17 after installing the last version"):
-                  test.check_pg_regress(Path("${orioledb_17}/lib/pgxs/src/test/regress/pg_regress"), "orioledb-17", pg_regress_test_name)
+                  test.check_pg_regress(Path(f"{orioledb_17}/lib/pgxs/src/test/regress/pg_regress"), "orioledb-17", pg_regress_test_name)
 
                 with subtest("Test pg_upgrade from postgresql 15 to 17 with older extension version"):
                   # Test that all extension versions from postgresql 15 can be upgraded to postgresql 17 using pg_upgrade
@@ -362,7 +371,7 @@ let
                       # Otherwise, the version should match the version from postgresql 15
                       test.assert_version_matches(version)
 
-                    test.check_pg_regress(Path("${psql_17}/lib/pgxs/src/test/regress/pg_regress"), "17", pg_regress_test_name)
+                    test.check_pg_regress(Path(f"{psql_17}/lib/pgxs/src/test/regress/pg_regress"), "17", pg_regress_test_name)
               ''
             else
               ""

--- a/nix/ext/tests/default.nix
+++ b/nix/ext/tests/default.nix
@@ -119,6 +119,8 @@ let
                   newPostgresql = psql_17;
                   oldDataDir = "${builtins.dirOf config.services.postgresql.dataDir}/${oldPostgresql.psqlSchema}";
                   newDataDir = "${builtins.dirOf config.services.postgresql.dataDir}/${newPostgresql.psqlSchema}";
+                  oldSettings = (installedExtension "15").defaultSettings or { };
+                  newSettings = (installedExtension "17").defaultSettings or { };
                 in
                 ''
                   if [[ ! -d ${newDataDir} ]]; then
@@ -127,8 +129,8 @@ let
                     ${newPostgresql}/bin/pg_upgrade --old-datadir "${oldDataDir}" --new-datadir "${newDataDir}" \
                       --old-bindir "${oldPostgresql}/bin" --new-bindir "${newPostgresql}/bin" \
                       ${
-                        if config.services.postgresql.settings.shared_preload_libraries != null then
-                          " --old-options='-c shared_preload_libraries=${config.services.postgresql.settings.shared_preload_libraries}' --new-options='-c shared_preload_libraries=${config.services.postgresql.settings.shared_preload_libraries}'"
+                        if oldSettings ? shared_preload_libraries || newSettings ? shared_preload_libraries then
+                          " --old-options='-c shared_preload_libraries=${oldSettings.shared_preload_libraries or ""}' --new-options='-c shared_preload_libraries=${newSettings.shared_preload_libraries or ""}'"
                         else
                           ""
                       }
@@ -218,7 +220,9 @@ let
           }
           extension_name = "${pname}"
           support_upgrade = ${if support_upgrade then "True" else "False"}
-          pg17_configuration = "${pg17-configuration}"
+          system = "${nodes.server.system.build.toplevel}"
+          pg15_configuration = system
+          pg17_configuration = f"{system}/specialisation/postgresql17"
           ext_has_background_worker = ${
             if support_upgrade && (installedExtension "15") ? hasBackgroundWorker then "True" else "False"
           }
@@ -332,6 +336,33 @@ let
 
                 with subtest("Check pg_regress with orioledb 17 after installing the last version"):
                   test.check_pg_regress(Path("${orioledb_17}/lib/pgxs/src/test/regress/pg_regress"), "orioledb-17", pg_regress_test_name)
+
+                with subtest("Test pg_upgrade from postgresql 15 to 17 with older extension version"):
+                  # Test that all extension versions from postgresql 15 can be upgraded to postgresql 17 using pg_upgrade
+                  for version in versions["15"]:
+                    server.systemctl("stop postgresql.service")
+                    server.succeed("rm -fr /var/lib/postgresql/update_extensions.sql /var/lib/postgresql/17")
+                    server.succeed(
+                      f"{pg15_configuration}/bin/switch-to-configuration test >&2"
+                    )
+                    test.drop_extension()
+                    test.install_extension(version)
+                    server.succeed(
+                      f"{pg17_configuration}/bin/switch-to-configuration test >&2"
+                    )
+                    has_update_script = server.succeed(
+                      "test -f /var/lib/postgresql/update_extensions.sql && echo 'yes' || echo 'no'"
+                    ).strip() == "yes"
+                    if has_update_script:
+                      # Run the extension update script generated during the upgrade
+                      test.run_sql_file("/var/lib/postgresql/update_extensions.sql")
+                      # If there was an update script, the last version should be installed
+                      test.assert_version_matches(versions["17"][-1])
+                    else:
+                      # Otherwise, the version should match the version from postgresql 15
+                      test.assert_version_matches(version)
+
+                    test.check_pg_regress(Path("${psql_17}/lib/pgxs/src/test/regress/pg_regress"), "17", pg_regress_test_name)
               ''
             else
               ""

--- a/nix/ext/tests/default.nix
+++ b/nix/ext/tests/default.nix
@@ -390,7 +390,6 @@ builtins.listToAttrs (
       "pg_jsonschema"
       "pg_net"
       "pg_partman"
-      "pg_stat_monitor"
       "pg_tle"
       "pgaudit"
       "pgtap"

--- a/nix/ext/tests/lib.py
+++ b/nix/ext/tests/lib.py
@@ -55,7 +55,7 @@ class PostgresExtensionTest(object):
         ).strip()
 
     def drop_extension(self):
-        self.run_sql(f"DROP EXTENSION IF EXISTS {self.extension_name};")
+        self.run_sql(f"DROP EXTENSION IF EXISTS {self.extension_name} CASCADE;")
 
     def install_extension(self, version: str):
         if self.schema != "public":

--- a/nix/ext/tests/pg_stat_monitor.nix
+++ b/nix/ext/tests/pg_stat_monitor.nix
@@ -223,14 +223,17 @@ pkgs.testers.runNixOSTest {
       with subtest("Check upgrade path with postgresql 17"):
         test.check_upgrade_path("17")
 
+      pg_regress_test_name = "${(installedExtension "15").pgRegressTestName or pname}"
+      psql_17 = "${psql_17}"
+
       with subtest("Check pg_regress with postgresql 17 after extension upgrade"):
-        test.check_pg_regress(Path("${psql_17}/lib/pgxs/src/test/regress/pg_regress"), "17", pg_regress_test_name)
+        test.check_pg_regress(Path(f"{psql_17}/lib/pgxs/src/test/regress/pg_regress"), "17", pg_regress_test_name)
 
       with subtest("Check the install of the last version of the extension"):
         test.check_install_last_version("17")
 
       with subtest("Check pg_regress with postgresql 17 after installing the last version"):
-        test.check_pg_regress(Path("${psql_17}/lib/pgxs/src/test/regress/pg_regress"), "17", pg_regress_test_name)
+        test.check_pg_regress(Path(f"{psql_17}/lib/pgxs/src/test/regress/pg_regress"), "17", pg_regress_test_name)
 
       with subtest("Test pg_upgrade from postgresql 15 to 17 with older extension version"):
         # Test that all extension versions from postgresql 15 can be upgraded to postgresql 17 using pg_upgrade
@@ -254,7 +257,7 @@ pkgs.testers.runNixOSTest {
             # If there was an update script, the last version should be installed
             test.assert_version_matches(versions["17"][-1])
             # With update script, the schema should match PG 17 expectations
-            test.check_pg_regress(Path("${psql_17}/lib/pgxs/src/test/regress/pg_regress"), "17", pg_regress_test_name)
+            test.check_pg_regress(Path(f"{psql_17}/lib/pgxs/src/test/regress/pg_regress"), "17", pg_regress_test_name)
           else:
             # Otherwise, the version should match the version from postgresql 15
             test.assert_version_matches(version)

--- a/nix/ext/tests/pg_stat_monitor.nix
+++ b/nix/ext/tests/pg_stat_monitor.nix
@@ -1,0 +1,270 @@
+{ self, pkgs }:
+#
+# Custom test for pg_stat_monitor extension
+#
+# IMPORTANT: This extension requires special handling because version 2.1 has different
+# schemas on PostgreSQL 15 vs 17, even though they share the same version number:
+#
+# - PG 15 (version 2.1): Uses older schema with `blk_read_time`, `blk_write_time`
+# - PG 17 (version 2.1): Uses newer schema with `shared_blk_read_time`,
+#   `shared_blk_write_time`, `local_blk_read_time`, `local_blk_write_time`, plus
+#   additional JIT columns (`jit_deform_count`, `jit_deform_time`, `stats_since`,
+#   `minmax_stats_since`)
+#
+# During pg_upgrade from PG 15 to PG 17:
+# - The extension remains at version 2.1
+# - No update script is generated (same version number)
+# - The schema stays as PG 15 (old schema)
+# - Fresh installs on PG 17 get the new schema
+#
+# This creates a conflict: the same expected output file (`z_17_pg_stat_monitor.out`)
+# is used for both scenarios, but they produce different schemas.
+#
+# Solution: Skip pg_regress after pg_upgrade when no update script is generated,
+# since the schema won't match the expected output for fresh PG 17 installs.
+# This still validates that:
+# - The extension version is correct after upgrade
+# - Fresh installs work correctly (tested by regular psql_17 check)
+# - Upgrade paths work correctly
+#
+let
+  pname = "pg_stat_monitor";
+  inherit (pkgs) lib;
+  installedExtension =
+    postgresMajorVersion:
+    self.legacyPackages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}."psql_${postgresMajorVersion}".exts."${
+      pname
+    }";
+  versions = postgresqlMajorVersion: (installedExtension postgresqlMajorVersion).versions;
+  postgresqlWithExtension =
+    postgresql:
+    let
+      majorVersion = lib.versions.major postgresql.version;
+      pkg = pkgs.pkgsLinux.buildEnv {
+        name = "postgresql-${majorVersion}-${pname}";
+        paths = [
+          postgresql
+          postgresql.lib
+          (installedExtension majorVersion)
+        ];
+        passthru = {
+          inherit (postgresql) version psqlSchema;
+          installedExtensions = [ (installedExtension majorVersion) ];
+          lib = pkg;
+          withPackages = _: pkg;
+          withJIT = pkg;
+          withoutJIT = pkg;
+        };
+        nativeBuildInputs = [ pkgs.pkgsLinux.makeWrapper ];
+        pathsToLink = [
+          "/"
+          "/bin"
+          "/lib"
+        ];
+        postBuild = ''
+          wrapProgram $out/bin/postgres --set NIX_PGLIBDIR $out/lib
+          wrapProgram $out/bin/pg_ctl --set NIX_PGLIBDIR $out/lib
+          wrapProgram $out/bin/pg_upgrade --set NIX_PGLIBDIR $out/lib
+        '';
+      };
+    in
+    pkg;
+  psql_15 =
+    postgresqlWithExtension
+      self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_15;
+  psql_17 =
+    postgresqlWithExtension
+      self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_17;
+in
+pkgs.testers.runNixOSTest {
+  name = pname;
+  nodes.server =
+    { config, ... }:
+    {
+      virtualisation = {
+        forwardPorts = [
+          {
+            from = "host";
+            host.port = 13022;
+            guest.port = 22;
+          }
+        ];
+      };
+      services.openssh = {
+        enable = true;
+      };
+
+      services.postgresql = {
+        enable = true;
+        package = psql_15;
+        enableTCPIP = true;
+        authentication = ''
+          local all postgres peer map=postgres
+          local all all peer map=root
+        '';
+        identMap = ''
+          root root supabase_admin
+          postgres postgres postgres
+        '';
+        ensureUsers = [
+          {
+            name = "supabase_admin";
+            ensureClauses.superuser = true;
+          }
+        ];
+        settings = (installedExtension "15").defaultSettings or { };
+      };
+
+      networking.firewall.allowedTCPPorts = [ config.services.postgresql.settings.port ];
+
+      specialisation.postgresql17.configuration = {
+        services.postgresql = {
+          package = lib.mkForce psql_17;
+          settings = (installedExtension "17").defaultSettings or { };
+        };
+
+        systemd.services.postgresql-migrate = {
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+            User = "postgres";
+            Group = "postgres";
+            StateDirectory = "postgresql";
+            WorkingDirectory = "${builtins.dirOf config.services.postgresql.dataDir}";
+          };
+          script =
+            let
+              oldPostgresql = psql_15;
+              newPostgresql = psql_17;
+              oldDataDir = "${builtins.dirOf config.services.postgresql.dataDir}/${oldPostgresql.psqlSchema}";
+              newDataDir = "${builtins.dirOf config.services.postgresql.dataDir}/${newPostgresql.psqlSchema}";
+            in
+            ''
+              if [[ ! -d ${newDataDir} ]]; then
+                install -d -m 0700 -o postgres -g postgres "${newDataDir}"
+                ${newPostgresql}/bin/initdb -D "${newDataDir}"
+                ${newPostgresql}/bin/pg_upgrade --old-datadir "${oldDataDir}" --new-datadir "${newDataDir}" \
+                  --old-bindir "${oldPostgresql}/bin" --new-bindir "${newPostgresql}/bin" \
+                  ${
+                    if config.services.postgresql.settings.shared_preload_libraries != null then
+                      " --old-options='-c shared_preload_libraries=${config.services.postgresql.settings.shared_preload_libraries}' --new-options='-c shared_preload_libraries=${config.services.postgresql.settings.shared_preload_libraries}'"
+                    else
+                      ""
+                  }
+              else
+                echo "${newDataDir} already exists"
+              fi
+            '';
+        };
+
+        systemd.services.postgresql = {
+          after = [ "postgresql-migrate.service" ];
+          requires = [ "postgresql-migrate.service" ];
+        };
+      };
+    };
+  testScript =
+    { nodes, ... }:
+    ''
+      from pathlib import Path
+      versions = {
+        "15": [${lib.concatStringsSep ", " (map (s: ''"${s}"'') (versions "15"))}],
+        "17": [${lib.concatStringsSep ", " (map (s: ''"${s}"'') (versions "17"))}],
+      }
+      extension_name = "${pname}"
+      support_upgrade = True
+      system = "${nodes.server.system.build.toplevel}"
+      pg15_configuration = system
+      pg17_configuration = f"{system}/specialisation/postgresql17"
+      ext_has_background_worker = ${
+        if (installedExtension "15") ? hasBackgroundWorker then "True" else "False"
+      }
+      sql_test_directory = Path("${../../tests}")
+      pg_regress_test_name = "${(installedExtension "15").pgRegressTestName or pname}"
+      ext_schema = "${(installedExtension "15").defaultSchema or "public"}"
+      lib_name = "${(installedExtension "15").libName or pname}"
+      print(f"Running tests for extension: {lib_name}")
+
+      ${builtins.readFile ./lib.py}
+
+      start_all()
+
+      server.wait_for_unit("multi-user.target")
+      server.wait_for_unit("postgresql.service")
+
+      test = PostgresExtensionTest(server, extension_name, versions, sql_test_directory, support_upgrade, ext_schema, lib_name)
+      test.create_schema()
+
+      with subtest("Check upgrade path with postgresql 15"):
+        test.check_upgrade_path("15")
+
+      with subtest("Check pg_regress with postgresql 15 after extension upgrade"):
+        test.check_pg_regress(Path("${psql_15}/lib/pgxs/src/test/regress/pg_regress"), "15", pg_regress_test_name)
+
+      last_version = None
+      with subtest("Check the install of the last version of the extension"):
+        last_version = test.check_install_last_version("15")
+
+      if ext_has_background_worker:
+        with subtest("Test switch_${pname}_version"):
+          test.check_switch_extension_with_background_worker(Path(f"${psql_15}/lib/{lib_name}.so"), "15")
+
+      with subtest("Check pg_regress with postgresql 15 after installing the last version"):
+        test.check_pg_regress(Path("${psql_15}/lib/pgxs/src/test/regress/pg_regress"), "15", pg_regress_test_name)
+
+      with subtest("switch to postgresql 17"):
+        server.succeed(
+          f"{pg17_configuration}/bin/switch-to-configuration test >&2"
+        )
+
+      with subtest("Check last version of the extension after postgresql upgrade"):
+        test.assert_version_matches(last_version)
+
+      with subtest("Check upgrade path with postgresql 17"):
+        test.check_upgrade_path("17")
+
+      with subtest("Check pg_regress with postgresql 17 after extension upgrade"):
+        test.check_pg_regress(Path("${psql_17}/lib/pgxs/src/test/regress/pg_regress"), "17", pg_regress_test_name)
+
+      with subtest("Check the install of the last version of the extension"):
+        test.check_install_last_version("17")
+
+      with subtest("Check pg_regress with postgresql 17 after installing the last version"):
+        test.check_pg_regress(Path("${psql_17}/lib/pgxs/src/test/regress/pg_regress"), "17", pg_regress_test_name)
+
+      with subtest("Test pg_upgrade from postgresql 15 to 17 with older extension version"):
+        # Test that all extension versions from postgresql 15 can be upgraded to postgresql 17 using pg_upgrade
+        for version in versions["15"]:
+          server.systemctl("stop postgresql.service")
+          server.succeed("rm -fr /var/lib/postgresql/update_extensions.sql /var/lib/postgresql/17")
+          server.succeed(
+            f"{pg15_configuration}/bin/switch-to-configuration test >&2"
+          )
+          test.drop_extension()
+          test.install_extension(version)
+          server.succeed(
+            f"{pg17_configuration}/bin/switch-to-configuration test >&2"
+          )
+          has_update_script = server.succeed(
+            "test -f /var/lib/postgresql/update_extensions.sql && echo 'yes' || echo 'no'"
+          ).strip() == "yes"
+          if has_update_script:
+            # Run the extension update script generated during the upgrade
+            test.run_sql_file("/var/lib/postgresql/update_extensions.sql")
+            # If there was an update script, the last version should be installed
+            test.assert_version_matches(versions["17"][-1])
+            # With update script, the schema should match PG 17 expectations
+            test.check_pg_regress(Path("${psql_17}/lib/pgxs/src/test/regress/pg_regress"), "17", pg_regress_test_name)
+          else:
+            # Otherwise, the version should match the version from postgresql 15
+            test.assert_version_matches(version)
+            # Skip pg_regress when no update script is generated because:
+            # - The extension retains the PG 15 schema (old column names)
+            # - The expected output file expects PG 17 schema (new column names)
+            # - This mismatch is expected behavior - pg_upgrade doesn't change schemas
+            #   when version numbers don't change
+            # - The extension is still functional, just with the older schema
+            print(f"Skipping pg_regress for {extension_name} after pg_upgrade without update script")
+            print(f"Version {version} retains PG 15 schema, which differs from PG 17 fresh install schema")
+    '';
+}

--- a/nix/ext/tests/pgmq.nix
+++ b/nix/ext/tests/pgmq.nix
@@ -43,8 +43,13 @@ pkgs.testers.runNixOSTest {
       }
       extension_name = "${pname}"
       support_upgrade = True
+      system = "${nodes.server.system.build.toplevel}"
+      pg15_configuration = system
       pg17_configuration = "${pg17-configuration}"
       orioledb17_configuration = "${orioledb17-configuration}"
+      ext_has_background_worker = ${
+        if (installedExtension "15") ? hasBackgroundWorker then "True" else "False"
+      }
       sql_test_directory = Path("${../../tests}")
 
       ${builtins.readFile ./lib.py}
@@ -163,5 +168,7 @@ pkgs.testers.runNixOSTest {
 
       with subtest("Check upgrade path with orioledb 17"):
         test.check_upgrade_path("orioledb-17")
+
+      pg_regress_test_name = "${(installedExtension "15").pgRegressTestName or pname}"
     '';
 }

--- a/nix/ext/tests/pgroonga.nix
+++ b/nix/ext/tests/pgroonga.nix
@@ -49,8 +49,13 @@ pkgs.testers.runNixOSTest {
       }
       extension_name = "${pname}"
       support_upgrade = True
+      system = "${nodes.server.system.build.toplevel}"
+      pg15_configuration = system
       pg17_configuration = "${pg17-configuration}"
       orioledb17_configuration = "${orioledb17-configuration}"
+      ext_has_background_worker = ${
+        if (installedExtension "15") ? hasBackgroundWorker then "True" else "False"
+      }
       sql_test_directory = Path("${../../tests}")
 
       ${builtins.readFile ./lib.py}
@@ -169,5 +174,7 @@ pkgs.testers.runNixOSTest {
 
       with subtest("Check upgrade path with orioledb 17"):
         test.check_upgrade_path("orioledb-17")
+
+      pg_regress_test_name = "${(installedExtension "15").pgRegressTestName or pname}"
     '';
 }

--- a/nix/ext/tests/pgsodium.nix
+++ b/nix/ext/tests/pgsodium.nix
@@ -105,12 +105,8 @@ pkgs.testers.runNixOSTest {
 
       test = PostgresExtensionTest(server, extension_name, versions, sql_test_directory, support_upgrade)
 
-      with subtest("Check upgrade path with postgresql 15"):
-        test.check_upgrade_path("15")
-
-      with subtest("Check pg_regress with postgresql 15 after extension upgrade"):
-        psql_15 = "${self.packages.${system}."psql_15/bin"}"
-        test.check_pg_regress(Path(f"{psql_15}/lib/pgxs/src/test/regress/pg_regress"), "15", pg_regress_test_name)
+      psql_15 = "${self.packages.${system}."psql_15/bin"}"
+      pg_regress_test_name = "${(installedExtension "15").pgRegressTestName or pname}"
 
       last_version = None
       with subtest("Check the install of the last version of the extension"):
@@ -150,45 +146,13 @@ pkgs.testers.runNixOSTest {
       with subtest("Check last version of the extension after postgresql upgrade"):
         test.assert_version_matches(last_version)
 
-      with subtest("Check upgrade path with postgresql 17"):
-        test.check_upgrade_path("17")
-
-      with subtest("Check pg_regress with postgresql 17 after extension upgrade"):
-        psql_17 = "${self.packages.${system}."psql_17/bin"}"
-        test.check_pg_regress(Path(f"{psql_17}/lib/pgxs/src/test/regress/pg_regress"), "17", pg_regress_test_name)
+      psql_17 = "${self.packages.${system}."psql_17/bin"}"
 
       with subtest("Check the install of the last version of the extension"):
         test.check_install_last_version("17")
 
       with subtest("Check pg_regress with postgresql 17 after installing the last version"):
         test.check_pg_regress(Path(f"{psql_17}/lib/pgxs/src/test/regress/pg_regress"), "17", pg_regress_test_name)
-
-      with subtest("Test pg_upgrade from postgresql 15 to 17 with older extension version"):
-        # Test that all extension versions from postgresql 15 can be upgraded to postgresql 17 using pg_upgrade
-        for version in versions["15"]:
-          server.systemctl("stop postgresql.service")
-          server.succeed("rm -fr /var/lib/postgresql/update_extensions.sql /var/lib/postgresql/data-17")
-          server.succeed(
-            f"{pg15_configuration}/bin/switch-to-configuration test >&2"
-          )
-          test.drop_extension()
-          test.install_extension(version)
-          server.succeed(
-            f"{pg17_configuration}/bin/switch-to-configuration test >&2"
-          )
-          has_update_script = server.succeed(
-            "test -f /var/lib/postgresql/update_extensions.sql && echo 'yes' || echo 'no'"
-          ).strip() == "yes"
-          if has_update_script:
-            # Run the extension update script generated during the upgrade
-            test.run_sql_file("/var/lib/postgresql/update_extensions.sql")
-            # If there was an update script, the last version should be installed
-            test.assert_version_matches(versions["17"][-1])
-          else:
-            # Otherwise, the version should match the version from postgresql 15
-            test.assert_version_matches(version)
-
-          test.check_pg_regress(Path(f"{psql_17}/lib/pgxs/src/test/regress/pg_regress"), "17", pg_regress_test_name)
 
       with subtest("switch to orioledb 17"):
         server.succeed(

--- a/nix/ext/tests/pgsodium.nix
+++ b/nix/ext/tests/pgsodium.nix
@@ -46,9 +46,15 @@ pkgs.testers.runNixOSTest {
       }
       extension_name = "${pname}"
       support_upgrade = False
+      system = "${nodes.server.system.build.toplevel}"
+      pg15_configuration = system
       pg17_configuration = "${pg17-configuration}"
       orioledb17_configuration = "${orioledb17-configuration}"
+      ext_has_background_worker = ${
+        if (installedExtension "15") ? hasBackgroundWorker then "True" else "False"
+      }
       sql_test_directory = Path("${../../tests}")
+      pg_regress_test_name = "${(installedExtension "15").pgRegressTestName or pname}"
 
       ${builtins.readFile ./lib.py}
 
@@ -99,9 +105,23 @@ pkgs.testers.runNixOSTest {
 
       test = PostgresExtensionTest(server, extension_name, versions, sql_test_directory, support_upgrade)
 
+      with subtest("Check upgrade path with postgresql 15"):
+        test.check_upgrade_path("15")
+
+      with subtest("Check pg_regress with postgresql 15 after extension upgrade"):
+        psql_15 = "${self.packages.${system}."psql_15/bin"}"
+        test.check_pg_regress(Path(f"{psql_15}/lib/pgxs/src/test/regress/pg_regress"), "15", pg_regress_test_name)
+
       last_version = None
       with subtest("Check the install of the last version of the extension"):
         last_version = test.check_install_last_version("15")
+
+      if ext_has_background_worker:
+        with subtest("Test switch_${pname}_version"):
+          test.check_switch_extension_with_background_worker(Path(f"{psql_15}/lib/${pname}.so"), "15")
+
+      with subtest("Check pg_regress with postgresql 15 after installing the last version"):
+        test.check_pg_regress(Path(f"{psql_15}/lib/pgxs/src/test/regress/pg_regress"), "15", pg_regress_test_name)
 
       with subtest("switch to postgresql 17"):
         server.succeed(
@@ -127,8 +147,48 @@ pkgs.testers.runNixOSTest {
           f"Expected our custom build (${testLib.expectedVersions."17"}), got: {postgres_path}"
         )
 
-      with subtest("Check last version of the extension after upgrade"):
+      with subtest("Check last version of the extension after postgresql upgrade"):
         test.assert_version_matches(last_version)
+
+      with subtest("Check upgrade path with postgresql 17"):
+        test.check_upgrade_path("17")
+
+      with subtest("Check pg_regress with postgresql 17 after extension upgrade"):
+        psql_17 = "${self.packages.${system}."psql_17/bin"}"
+        test.check_pg_regress(Path(f"{psql_17}/lib/pgxs/src/test/regress/pg_regress"), "17", pg_regress_test_name)
+
+      with subtest("Check the install of the last version of the extension"):
+        test.check_install_last_version("17")
+
+      with subtest("Check pg_regress with postgresql 17 after installing the last version"):
+        test.check_pg_regress(Path(f"{psql_17}/lib/pgxs/src/test/regress/pg_regress"), "17", pg_regress_test_name)
+
+      with subtest("Test pg_upgrade from postgresql 15 to 17 with older extension version"):
+        # Test that all extension versions from postgresql 15 can be upgraded to postgresql 17 using pg_upgrade
+        for version in versions["15"]:
+          server.systemctl("stop postgresql.service")
+          server.succeed("rm -fr /var/lib/postgresql/update_extensions.sql /var/lib/postgresql/data-17")
+          server.succeed(
+            f"{pg15_configuration}/bin/switch-to-configuration test >&2"
+          )
+          test.drop_extension()
+          test.install_extension(version)
+          server.succeed(
+            f"{pg17_configuration}/bin/switch-to-configuration test >&2"
+          )
+          has_update_script = server.succeed(
+            "test -f /var/lib/postgresql/update_extensions.sql && echo 'yes' || echo 'no'"
+          ).strip() == "yes"
+          if has_update_script:
+            # Run the extension update script generated during the upgrade
+            test.run_sql_file("/var/lib/postgresql/update_extensions.sql")
+            # If there was an update script, the last version should be installed
+            test.assert_version_matches(versions["17"][-1])
+          else:
+            # Otherwise, the version should match the version from postgresql 15
+            test.assert_version_matches(version)
+
+          test.check_pg_regress(Path(f"{psql_17}/lib/pgxs/src/test/regress/pg_regress"), "17", pg_regress_test_name)
 
       with subtest("switch to orioledb 17"):
         server.succeed(
@@ -157,6 +217,5 @@ pkgs.testers.runNixOSTest {
         ).strip()
         for role in ["anon", "authenticated", "authenticator", "supabase_admin"]:
           assert role in roles, f"Expected role {role} to exist, got: {roles}"
-
     '';
 }

--- a/nix/ext/tests/vault.nix
+++ b/nix/ext/tests/vault.nix
@@ -42,9 +42,14 @@ pkgs.testers.runNixOSTest {
         "orioledb-17": [${lib.concatStringsSep ", " (map (s: ''"${s}"'') orioledbVersions)}],
       }
       extension_name = "${pname}"
-      support_upgrade = True
+      system = "${nodes.server.system.build.toplevel}"
+      pg15_configuration = system
       pg17_configuration = "${pg17-configuration}"
       orioledb17_configuration = "${orioledb17-configuration}"
+      support_upgrade = True
+      ext_has_background_worker = ${
+        if (installedExtension "15") ? hasBackgroundWorker then "True" else "False"
+      }
       sql_test_directory = Path("${../../tests}")
 
       ${builtins.readFile ./lib.py}
@@ -163,5 +168,7 @@ pkgs.testers.runNixOSTest {
 
       with subtest("Check upgrade path with orioledb 17"):
         test.check_upgrade_path("orioledb-17")
+
+      pg_regress_test_name = "${(installedExtension "15").pgRegressTestName or pname}"
     '';
 }

--- a/nix/ext/versions.json
+++ b/nix/ext/versions.json
@@ -782,7 +782,8 @@
         "15"
       ],
       "revision": "1.0.1",
-      "hash": "sha256-sQEpIknAFOmvNTX2G23X4BvMdy3Ms7sXx7hLZt8jyUk="
+      "hash": "sha256-sQEpIknAFOmvNTX2G23X4BvMdy3Ms7sXx7hLZt8jyUk=",
+      "pgUpgradeCompatible": false
     },
     "2.1": {
       "postgresql": [

--- a/nix/packages/github-matrix/github_matrix.py
+++ b/nix/packages/github-matrix/github_matrix.py
@@ -172,7 +172,7 @@ def run_nix_eval_jobs(
     Returns:
         Tuple of (packages, warnings_list, errors_list)
     """
-    debug(f"Running command: {' '.join(cmd)}")
+    print(f"Running: {' '.join(cmd)}", file=sys.stderr)
 
     # Disable colors in nix output
     env = os.environ.copy()

--- a/nix/packages/github-matrix/github_matrix.py
+++ b/nix/packages/github-matrix/github_matrix.py
@@ -89,7 +89,9 @@ BUILD_RUNNER_MAP: Dict[RunnerType, Dict[System, RunsOnConfig]] = {
 }
 
 
-def build_nix_eval_command(max_workers: int, flake_outputs: List[str]) -> List[str]:
+def build_nix_eval_command(
+    max_workers: int, max_memory_size: int, flake_outputs: List[str]
+) -> List[str]:
     """Build the nix-eval-jobs command with appropriate flags."""
     nix_eval_cmd = [
         "nix-eval-jobs",
@@ -104,6 +106,8 @@ def build_nix_eval_command(max_workers: int, flake_outputs: List[str]) -> List[s
         "--option",
         "accept-flake-config",
         "true",
+        "--max-memory-size",
+        str(max_memory_size),
         "--workers",
         str(max_workers),
         "--select",
@@ -281,6 +285,12 @@ def main() -> None:
         description="Generate GitHub Actions matrix for Nix builds"
     )
     parser.add_argument(
+        "--max-memory-size",
+        default=3072,
+        type=int,
+        help="Maximum memory per eval worker in MiB. Defaults to 3072 (3 GiB).",
+    )
+    parser.add_argument(
         "flake_outputs", nargs="+", help="Nix flake outputs to evaluate"
     )
 
@@ -288,7 +298,7 @@ def main() -> None:
 
     max_workers: int = os.cpu_count() or 1
 
-    cmd = build_nix_eval_command(max_workers, args.flake_outputs)
+    cmd = build_nix_eval_command(max_workers, args.max_memory_size, args.flake_outputs)
 
     # Run evaluation and collect packages, warnings, and errors
     packages, warnings_list, errors_list = run_nix_eval_jobs(cmd)


### PR DESCRIPTION
Add test to verify that all extension versions from PostgreSQL 15 can successfully upgrade to PostgreSQL 17 using pg_upgrade.

The test now validates:

- Each PG 15 extension version can be upgraded to PG 17
- Extension update scripts are properly generated during upgrade
- Version handling works correctly with and without update scripts
- Final extension versions match expected values after upgrade

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified PostgreSQL-version-aware packaging that produces SQL-only migration artifacts for older Postgres releases and includes them in final builds.

* **Tests**
  * Broadened pg_upgrade 15→17 test coverage across many extensions; added a dedicated pg_stat_monitor test and standardized per-version upgrade flows. Test exports updated to include pg_partman and postgis.

* **Bug Fixes**
  * Test cleanup now drops extensions with CASCADE to remove dependent objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->