### PR TITLE
fix: needs to run on merge not pre merge

### DIFF
--- a/.github/workflows/publish-migrations-staging.yml
+++ b/.github/workflows/publish-migrations-staging.yml
@@ -1,7 +1,9 @@
 name: Release Migrations - Staging
 
 on:
-  merge_group:
+  push:
+    branches:
+      - develop
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
We need the behavior and timing of this action retained to post merge similar to https://github.com/supabase/postgres/blob/develop/.github/workflows/ami-release-nix.yml 