### PR TITLE
chore: bump to pg_net 0.20.0

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.038-orioledb"
-  postgres17: "17.6.1.081"
-  postgres15: "15.14.1.081"
+  postgresorioledb-17: "17.6.0.039-orioledb"
+  postgres17: "17.6.1.082"
+  postgres15: "15.14.1.082"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.039-orioledb-net-1"
-  postgres17: "17.6.1.082-net-1"
-  postgres15: "15.14.1.082-net-1"
+  postgresorioledb-17: "17.6.0.039-orioledb"
+  postgres17: "17.6.1.082"
+  postgres15: "15.14.1.082"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.039-orioledb"
-  postgres17: "17.6.1.082"
-  postgres15: "15.14.1.082"
+  postgresorioledb-17: "17.6.0.039-orioledb-net-1"
+  postgres17: "17.6.1.082-net-1"
+  postgres15: "15.14.1.082-net-1"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1

--- a/nix/ext/pg_net.nix
+++ b/nix/ext/pg_net.nix
@@ -52,8 +52,17 @@ let
       env.NIX_CFLAGS_COMPILE =
         if (lib.versionOlder version "0.19.1") then
           "-Wno-error"
-        else if (version == "0.19.5" && stdenv.isDarwin && stdenv.isAarch64) then
-          # Fix for dangling pointer warning in src/core.c:177 on aarch64-darwin with newer clang
+        else if
+          (
+            builtins.elem version [
+              "0.19.5"
+              "0.20.0"
+            ]
+            && stdenv.isDarwin
+          )
+        then
+          # Fix for dangling pointer warning on darwin with newer clang
+          # 0.19.5: src/core.c:177, 0.20.0: src/core.c:317
           "-Wno-error=dangling-assignment"
         else
           "";

--- a/nix/ext/versions.json
+++ b/nix/ext/versions.json
@@ -319,6 +319,13 @@
         "17"
       ],
       "hash": "sha256-Cpi2iASi1QJoED0Qs1dANqg/BNZTsz5S+pw8iYyW03Y="
+    },
+    "0.20.0": {
+      "postgresql": [
+        "15",
+        "17"
+      ],
+      "hash": "sha256-xMYS6VOWxUVErx6bXTvad6Gj7WTudxmiI9k9HzSvMDQ="
     }
   },
   "pgaudit": {


### PR DESCRIPTION
No SQL changes are done. Only C library fixes.

This bumps from 0.19.5 straight to 0.20.0:

- https://github.com/supabase/pg_net/releases/tag/v0.19.6
- https://github.com/supabase/pg_net/releases/tag/v0.19.7
- https://github.com/supabase/pg_net/releases/tag/v0.20.0
  + Adds prepared statements as a new feature (increases performance).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added pg_net version 0.20.0 with support for PostgreSQL 15 and 17.
* **Bug Fixes**
  * Extended macOS AArch64 build workaround to also apply to the new version to prevent a build error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->