### PR TITLE
feat: add branch-based versioning for PR AMI builds

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  labels:
+    - blacksmith-2vcpu-ubuntu-2404-arm
+    - blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/ami-release-nix.yml
+++ b/.github/workflows/ami-release-nix.yml
@@ -67,15 +67,6 @@ jobs:
             substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com
             trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
 
-      - name: Run checks if triggered manually
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: |
-          SUFFIX=$(nix run nixpkgs#yq -- ".postgres_release[\"postgres${{ matrix.postgres_version }}\"]" ansible/vars.yml | sed -E 's/[0-9\.]+(.*)$/\1/')
-          if [[ -z "$SUFFIX" ]] ; then
-            echo "Version must include non-numeric characters if built manually."
-            exit 1
-          fi
-
       - name: Set PostgreSQL version environment variable
         run: |
           echo "POSTGRES_MAJOR_VERSION=${{ matrix.postgres_version }}" >> $GITHUB_ENV
@@ -83,8 +74,13 @@ jobs:
 
       - name: Generate common-nix.vars.pkr.hcl
         run: |
-          PG_VERSION=$(nix run nixpkgs#yq -- '.postgres_release["postgres'${{ matrix.postgres_version }}'"]' ansible/vars.yml)
-          PG_VERSION=$(echo "$PG_VERSION" | tr -d '"')  # Remove any surrounding quotes
+          PG_VERSION="$(nix run nixpkgs#yq -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]' ansible/vars.yml)"
+          BRANCH_NAME="$(echo "${{ github.ref }}" | sed 's|refs/heads/||')"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "$BRANCH_NAME" != "develop" && "$BRANCH_NAME" != release/* ]]; then
+             SUFFIX="${BRANCH_NAME//[^a-zA-Z0-9._-]/-}"
+             PG_VERSION="${PG_VERSION}-${SUFFIX}"
+             echo "Added branch suffix to version: $SUFFIX"
+          fi
           echo 'postgres-version = "'$PG_VERSION'"' > common-nix.vars.pkr.hcl
           # Ensure there's a newline at the end of the file
           echo "" >> common-nix.vars.pkr.hcl

--- a/.github/workflows/ami-release-nix.yml
+++ b/.github/workflows/ami-release-nix.yml
@@ -36,7 +36,7 @@ jobs:
         id: set-versions
         run: |
           VERSIONS=$(nix run nixpkgs#yq --  '.postgres_major[]' ansible/vars.yml | nix run nixpkgs#jq -- -R -s -c 'split("\n")[:-1]')
-          echo "postgres_versions=$VERSIONS" >> $GITHUB_OUTPUT
+          echo "postgres_versions=$VERSIONS" >> "$GITHUB_OUTPUT"
 
   build:
     needs: prepare
@@ -69,8 +69,8 @@ jobs:
 
       - name: Set PostgreSQL version environment variable
         run: |
-          echo "POSTGRES_MAJOR_VERSION=${{ matrix.postgres_version }}" >> $GITHUB_ENV
-          echo "EXECUTION_ID=${{ github.run_id }}-${{ matrix.postgres_version }}" >> $GITHUB_ENV
+          echo "POSTGRES_MAJOR_VERSION=${{ matrix.postgres_version }}" >> "$GITHUB_ENV"
+          echo "EXECUTION_ID=${{ github.run_id }}-${{ matrix.postgres_version }}" >> "$GITHUB_ENV"
 
       - name: Generate common-nix.vars.pkr.hcl
         run: |
@@ -81,7 +81,7 @@ jobs:
              PG_VERSION="${PG_VERSION}-${SUFFIX}"
              echo "Added branch suffix to version: $SUFFIX"
           fi
-          echo 'postgres-version = "'$PG_VERSION'"' > common-nix.vars.pkr.hcl
+          echo "postgres-version = \"$PG_VERSION\"" > common-nix.vars.pkr.hcl
           # Ensure there's a newline at the end of the file
           echo "" >> common-nix.vars.pkr.hcl
 
@@ -106,8 +106,8 @@ jobs:
       - name: Grab release version
         id: process_release_version
         run: |
-          VERSION=$(cat common-nix.vars.pkr.hcl | sed -e 's/postgres-version = "\(.*\)"/\1/g')
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          VERSION=$(sed -e 's/postgres-version = "\(.*\)"/\1/g' common-nix.vars.pkr.hcl)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "::notice title=AMI Published::Postgres AMI version: $VERSION"
 
       - name: Create nix flake revision tarball

--- a/.github/workflows/ami-release-nix.yml
+++ b/.github/workflows/ami-release-nix.yml
@@ -77,7 +77,7 @@ jobs:
           PG_VERSION="$(nix run nixpkgs#yq -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]' ansible/vars.yml)"
           BRANCH_NAME="$(echo "${{ github.ref }}" | sed 's|refs/heads/||')"
           if [[ "${{ github.event_name }}" == "workflow_dispatch" && "$BRANCH_NAME" != "develop" && "$BRANCH_NAME" != release/* ]]; then
-             SUFFIX="${BRANCH_NAME//[^a-zA-Z0-9._-]/-}"
+             SUFFIX="${BRANCH_NAME//[^a-zA-Z0-9._-]/-}-${{ github.run_id }}"
              PG_VERSION="${PG_VERSION}-${SUFFIX}"
              echo "Added branch suffix to version: $SUFFIX"
           fi

--- a/.github/workflows/ami-release-nix.yml
+++ b/.github/workflows/ami-release-nix.yml
@@ -108,6 +108,7 @@ jobs:
         run: |
           VERSION=$(cat common-nix.vars.pkr.hcl | sed -e 's/postgres-version = "\(.*\)"/\1/g')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "::notice title=AMI Published::Postgres AMI version: $VERSION"
 
       - name: Create nix flake revision tarball
         run: |

--- a/nix/hooks.nix
+++ b/nix/hooks.nix
@@ -1,4 +1,8 @@
 { inputs, ... }:
+let
+  ghWorkflows = builtins.attrNames (builtins.readDir ../.github/workflows);
+  lintedWorkflows = [ "ami-release-nix.yml" ];
+in
 {
   imports = [ inputs.git-hooks.flakeModule ];
   perSystem =
@@ -8,9 +12,17 @@
         check.enable = true;
         settings = {
           hooks = {
+            actionlint = {
+              enable = true;
+              excludes = builtins.filter (name: !builtins.elem name lintedWorkflows) ghWorkflows;
+              verbose = true;
+            };
+
             treefmt = {
               enable = true;
               package = config.treefmt.build.wrapper;
+              pass_filenames = false;
+              verbose = true;
             };
           };
         };


### PR DESCRIPTION
Manually create unique Postgres version names in branch often leads to
version conflicts with the base branch versions. These conflicts force
developers to deal with manual conflict resolution and unnecessary
rebuilds.

To address this, this change implement automatic branch-based versioning
for AMI builds triggered via workflow_dispatch on non-develop and
non-release branches. The branch name is sanitized and appended to the
Postgres version string.

Example: Branch `multi-version-ext/pg-partman` produces postgres version suffix
`multi-version-ext-pg-partman`