### PR TITLE
refactor: DRY extensions NixOS test

### DIFF
--- a/nix/ext/pg-safeupdate.nix
+++ b/nix/ext/pg-safeupdate.nix
@@ -32,6 +32,8 @@ let
         # Install versioned library
         install -Dm755 ${pname}${postgresql.dlSuffix} $out/lib/${pname}-${version}${postgresql.dlSuffix}
 
+        touch $out/share/postgresql/extension/${pname}--${version}.control
+        touch $out/share/postgresql/extension/${pname}--${version}.sql
         runHook postInstall
       '';
 
@@ -76,6 +78,21 @@ pkgs.buildEnv {
          toString (numberOfVersionsBuilt + 1)
        }"
     )
+
+    # Create empty upgrade files between consecutive versions
+    # plpgsql_check ships without upgrade scripts - extensions are backward-compatible
+    previous_version=""
+    for ver in ${lib.concatStringsSep " " versions}; do
+      if [[ -n "$previous_version" ]]; then
+        touch $out/share/postgresql/extension/${pname}--''${previous_version}--''${ver}.sql
+      fi
+      previous_version=$ver
+    done
+
+    {
+      echo "default_version = '${latestVersion}'"
+      cat $out/share/postgresql/extension/${pname}--${latestVersion}.control
+    } > $out/share/postgresql/extension/${pname}.control
   '';
 
   passthru = {

--- a/nix/packages/github-matrix/github_matrix.py
+++ b/nix/packages/github-matrix/github_matrix.py
@@ -296,7 +296,7 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    max_workers: int = os.cpu_count() or 1
+    max_workers: int = int(os.cpu_count() / 2) or 1
 
     cmd = build_nix_eval_command(max_workers, args.max_memory_size, args.flake_outputs)
 

--- a/nix/packages/github-matrix/github_matrix.py
+++ b/nix/packages/github-matrix/github_matrix.py
@@ -172,7 +172,7 @@ def run_nix_eval_jobs(
     Returns:
         Tuple of (packages, warnings_list, errors_list)
     """
-    debug(f"Running command: {' '.join(cmd)}")
+    print(f"Running: {' '.join(cmd)}", file=sys.stderr)
 
     # Disable colors in nix output
     env = os.environ.copy()

--- a/nix/packages/github-matrix/github_matrix.py
+++ b/nix/packages/github-matrix/github_matrix.py
@@ -89,7 +89,9 @@ BUILD_RUNNER_MAP: Dict[RunnerType, Dict[System, RunsOnConfig]] = {
 }
 
 
-def build_nix_eval_command(max_workers: int, flake_outputs: List[str]) -> List[str]:
+def build_nix_eval_command(
+    max_workers: int, max_memory_size: int, flake_outputs: List[str]
+) -> List[str]:
     """Build the nix-eval-jobs command with appropriate flags."""
     nix_eval_cmd = [
         "nix-eval-jobs",
@@ -104,6 +106,8 @@ def build_nix_eval_command(max_workers: int, flake_outputs: List[str]) -> List[s
         "--option",
         "accept-flake-config",
         "true",
+        "--max-memory-size",
+        str(max_memory_size),
         "--workers",
         str(max_workers),
         "--select",
@@ -281,6 +285,12 @@ def main() -> None:
         description="Generate GitHub Actions matrix for Nix builds"
     )
     parser.add_argument(
+        "--max-memory-size",
+        default=3072,
+        type=int,
+        help="Maximum memory per eval worker in MiB. Defaults to 3072 (3 GiB).",
+    )
+    parser.add_argument(
         "flake_outputs", nargs="+", help="Nix flake outputs to evaluate"
     )
 
@@ -288,7 +298,7 @@ def main() -> None:
 
     max_workers: int = os.cpu_count() or 1
 
-    cmd = build_nix_eval_command(max_workers, args.flake_outputs)
+    cmd = build_nix_eval_command(max_workers, args.max_memory_size, args.flake_outputs)
 
     # Run evaluation and collect packages, warnings, and errors
     packages, warnings_list, errors_list = run_nix_eval_jobs(cmd)

--- a/nix/tests/expected/z_15_ext_interface.out
+++ b/nix/tests/expected/z_15_ext_interface.out
@@ -31,9 +31,10 @@ order by
 -----------------
  pg_cron
  pgjwt
+ safeupdate
  tsm_system_time
  wal2json
-(4 rows)
+(5 rows)
 
 /*
 

--- a/nix/tests/expected/z_17_ext_interface.out
+++ b/nix/tests/expected/z_17_ext_interface.out
@@ -25,9 +25,10 @@ order by
  pg_cron
  pgjwt
  postgis_tiger_geocoder
+ safeupdate
  tsm_system_time
  wal2json
-(5 rows)
+(6 rows)
 
 /*
 

--- a/nix/tests/expected/z_orioledb-17_ext_interface.out
+++ b/nix/tests/expected/z_orioledb-17_ext_interface.out
@@ -25,9 +25,10 @@ order by
  pg_cron
  pgjwt
  postgis_tiger_geocoder
+ safeupdate
  tsm_system_time
  wal2json
-(5 rows)
+(6 rows)
 
 /*
 


### PR DESCRIPTION
Extract common NixOS test node configuration and functions into lib.nix to eliminate duplication across extension tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stopped automatic preloading of plpgsql and plpgsql_check libraries by default.

* **Chores**
  * Centralized and simplified PostgreSQL extension test infrastructure into a shared test library, reducing duplication and standardizing test node setup across many extension tests.
  * Removed several now-unnecessary in-file test networking/port-forwarding configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->