### PR TITLE
ci: standardizes Nix installation across all GitHub Actions workflows

### DIFF
--- a/.github/actions/nix-install-ephemeral/action.yml
+++ b/.github/actions/nix-install-ephemeral/action.yml
@@ -1,0 +1,46 @@
+name: 'Install Nix on ephemeral runners'
+description: 'Installs Nix and sets up AWS credentials to push to the Nix binary cache'
+inputs:
+  push-to-cache:
+    description: 'Whether to push build outputs to the Nix binary cache'
+    required: false
+    default: 'false'
+runs:
+  using: 'composite'
+  steps:
+    - name: aws-creds
+      uses: aws-actions/configure-aws-credentials@v4
+      if: ${{ inputs.push-to-cache == 'true' }}
+      with:
+        role-to-assume: ${{ env.DEV_AWS_ROLE }}
+        aws-region: "us-east-1"
+        output-credentials: true
+        role-duration-seconds: 7200
+    - name: Setup AWS credentials for Nix
+      if: ${{ inputs.push-to-cache == 'true' }}
+      shell: bash
+      run: |
+        sudo -H aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
+        sudo -H aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
+        sudo -H aws configure set aws_session_token $AWS_SESSION_TOKEN
+        sudo mkdir -p /etc/nix
+        sudo -E python -c "import os; file = open('/etc/nix/nix-secret-key', 'w'); file.write(os.environ['NIX_SIGN_SECRET_KEY']); file.close()"
+        cat << 'EOF' | sudo tee /etc/nix/upload-to-cache.sh > /dev/null
+        #!/usr/bin/env bash
+        set -euo pipefail
+        set -f
+
+        export IFS=' '
+        /nix/var/nix/profiles/default/bin/nix copy --to 's3://nix-postgres-artifacts?secret-key=/etc/nix/nix-secret-key' $OUT_PATHS
+        EOF
+        sudo chmod +x /etc/nix/upload-to-cache.sh
+      env:
+        NIX_SIGN_SECRET_KEY: ${{ env.NIX_SIGN_SECRET_KEY }}
+    - name: Install nix
+      uses: cachix/install-nix-action@v31
+      with:
+        install_url: https://releases.nixos.org/nix/nix-2.32.2/install
+        extra_nix_config: |
+          substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com
+          trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+          ${{ inputs.push-to-cache == 'true' && 'post-build-hook = /etc/nix/upload-to-cache.sh' || '' }}

--- a/.github/workflows/dockerhub-release-matrix.yml
+++ b/.github/workflows/dockerhub-release-matrix.yml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       matrix_config: ${{ steps.set-matrix.outputs.matrix_config }}
     steps:
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: ./.github/actions/nix-install-ephemeral
       - name: Checkout Repo
         uses: supabase/postgres/.github/actions/shared-checkout@HEAD
       - name: Generate build matrix
@@ -55,7 +55,7 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: supabase/postgres/.github/actions/shared-checkout@HEAD
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: ./.github/actions/nix-install-ephemeral
       - name: Set PostgreSQL version environment variable
         run: echo "POSTGRES_MAJOR_VERSION=${{ matrix.version }}" >> $GITHUB_ENV
       
@@ -80,7 +80,7 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: supabase/postgres/.github/actions/shared-checkout@HEAD
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: ./.github/actions/nix-install-ephemeral
       - run: docker context create builders
       - uses: docker/setup-buildx-action@v3
         with:
@@ -136,7 +136,7 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: supabase/postgres/.github/actions/shared-checkout@HEAD
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: ./.github/actions/nix-install-ephemeral
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v2
         with:
@@ -180,7 +180,7 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: supabase/postgres/.github/actions/shared-checkout@HEAD
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: ./.github/actions/nix-install-ephemeral
 
       - name: Debug Input from Prepare
         run: |

--- a/.github/workflows/manual-docker-release.yml
+++ b/.github/workflows/manual-docker-release.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       matrix_config: ${{ steps.set-matrix.outputs.matrix_config }}
     steps:
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: ./.github/actions/nix-install-ephemeral
       - name: Checkout Repo
         uses: supabase/postgres/.github/actions/shared-checkout@HEAD
       - name: Generate build matrix
@@ -52,7 +52,7 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: supabase/postgres/.github/actions/shared-checkout@HEAD
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: ./.github/actions/nix-install-ephemeral
       - name: Set PostgreSQL version environment variable
         run: echo "POSTGRES_MAJOR_VERSION=${{ matrix.version }}" >> $GITHUB_ENV
       
@@ -77,7 +77,7 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: supabase/postgres/.github/actions/shared-checkout@HEAD
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: ./.github/actions/nix-install-ephemeral
       - run: docker context create builders
       - uses: docker/setup-buildx-action@v3
         with:
@@ -145,7 +145,7 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: supabase/postgres/.github/actions/shared-checkout@HEAD
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: ./.github/actions/nix-install-ephemeral
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v2
         with:
@@ -189,7 +189,7 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: supabase/postgres/.github/actions/shared-checkout@HEAD
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: ./.github/actions/nix-install-ephemeral
 
       - name: Debug Input from Prepare
         run: |

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -35,54 +35,12 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: supabase/postgres/.github/actions/shared-checkout@HEAD
-      - name: aws-creds
-        uses: aws-actions/configure-aws-credentials@v4
-        if: ${{ github.secret_source == 'Actions' }}
+      - uses: ./.github/actions/nix-install-ephemeral
         with:
-          role-to-assume: ${{ secrets.DEV_AWS_ROLE }}
-          aws-region: "us-east-1"
-          output-credentials: true
-          role-duration-seconds: 7200
-      - name: Setup AWS credentials for Nix
-        if: ${{ github.secret_source == 'Actions' }}
-        run: |
-          sudo -H aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
-          sudo -H aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
-          sudo -H aws configure set aws_session_token $AWS_SESSION_TOKEN
-      - name: write secret key
-        # use python so we don't interpolate the secret into the workflow logs, in case of bugs
-        run: |
-          sudo mkdir -p /etc/nix
-          sudo -E python -c "import os; file = open('/etc/nix/nix-secret-key', 'w'); file.write(os.environ['NIX_SIGN_SECRET_KEY']); file.close()"
+          push-to-cache: ${{ github.secret_source == 'Actions' && 'true' || 'false' }}
         env:
+          DEV_AWS_ROLE: ${{ secrets.DEV_AWS_ROLE }}
           NIX_SIGN_SECRET_KEY: ${{ secrets.NIX_SIGN_SECRET_KEY }}
-      - name: Setup cache script
-        if: ${{ github.secret_source == 'Actions' }}
-        run: |
-          cat << 'EOF' | sudo tee /etc/nix/upload-to-cache.sh > /dev/null
-          #!/usr/bin/env bash
-          set -euf
-          export IFS=' '
-          /nix/var/nix/profiles/default/bin/nix copy --to 's3://nix-postgres-artifacts?secret-key=/etc/nix/nix-secret-key' $OUT_PATHS
-          EOF
-          sudo chmod +x /etc/nix/upload-to-cache.sh
-      - name: Install nix
-        uses: cachix/install-nix-action@v27
-        if: ${{ github.secret_source == 'Actions' }}
-        with:
-          install_url: https://releases.nixos.org/nix/nix-2.29.1/install
-          extra_nix_config: |
-            substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com
-            trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-            post-build-hook = /etc/nix/upload-to-cache.sh
-      - name: Install nix
-        uses: cachix/install-nix-action@v27
-        if: ${{ github.secret_source == 'None' }}
-        with:
-          install_url: https://releases.nixos.org/nix/nix-2.29.1/install
-          extra_nix_config: |
-            substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com
-            trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
       - name: Aggressive disk cleanup for DuckDB build
         if: matrix.runner == 'macos-latest-xlarge'
         run: |
@@ -108,7 +66,8 @@ jobs:
           sudo rm -rf /tmp/* 2>/dev/null || true
           echo "=== AFTER CLEANUP ==="
           df -h
-      - name: Build psql bundle
+      - 
+        name: Build psql bundle
         run: >
           nix run "github:Mic92/nix-fast-build?rev=b1dae483ab7d4139a6297e02b6de9e5d30e43d48" 
           -- --skip-cached --no-nom ${{ matrix.runner == 'macos-latest-xlarge' && '--max-jobs 1' || '' }}

--- a/.github/workflows/publish-nix-pgupgrade-bin-flake-version.yml
+++ b/.github/workflows/publish-nix-pgupgrade-bin-flake-version.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout Repo
         uses: supabase/postgres/.github/actions/shared-checkout@HEAD
 
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: ./.github/actions/nix-install-ephemeral
 
       - name: Set PostgreSQL versions
         id: set-versions
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout Repo
         uses: supabase/postgres/.github/actions/shared-checkout@HEAD
 
-      - uses: DeterminateSystems/nix-installer-action@main  
+      - uses: ./.github/actions/nix-install-ephemeral
 
       - name: Grab release version
         id: process_release_version

--- a/.github/workflows/publish-nix-pgupgrade-scripts.yml
+++ b/.github/workflows/publish-nix-pgupgrade-scripts.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout Repo
         uses: supabase/postgres/.github/actions/shared-checkout@HEAD
       
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: ./.github/actions/nix-install-ephemeral
 
       - name: Set PostgreSQL versions
         id: set-versions
@@ -45,7 +45,7 @@ jobs:
       - name: Checkout Repo
         uses: supabase/postgres/.github/actions/shared-checkout@HEAD
 
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: ./.github/actions/nix-install-ephemeral
 
       - name: Grab release version
         id: process_release_version
@@ -96,8 +96,8 @@ jobs:
       - name: Checkout Repo
         uses: supabase/postgres/.github/actions/shared-checkout@HEAD
 
-      - uses: DeterminateSystems/nix-installer-action@main
-  
+      - uses: ./.github/actions/nix-install-ephemeral
+
       - name: Grab release version
         id: process_release_version
         run: |

--- a/.github/workflows/qemu-image-build.yml
+++ b/.github/workflows/qemu-image-build.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Checkout Repo
         uses: supabase/postgres/.github/actions/shared-checkout@HEAD
 
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: ./.github/actions/nix-install-ephemeral
 
       - name: Run checks if triggered manually
         if: ${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,11 +15,7 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: supabase/postgres/.github/actions/shared-checkout@HEAD
-      - uses: DeterminateSystems/nix-installer-action@main
-        with:
-          extra-conf: |
-            substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com
-            trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+      - uses: ./.github/actions/nix-install-ephemeral
       - name: Set PostgreSQL versions
         id: set-versions
         run: |
@@ -43,11 +39,7 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: supabase/postgres/.github/actions/shared-checkout@HEAD
-      - uses: DeterminateSystems/nix-installer-action@main
-        with:
-          extra-conf: |
-            substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com
-            trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+      - uses: ./.github/actions/nix-install-ephemeral
       - name: Set PostgreSQL version environment variable
         run: echo "POSTGRES_MAJOR_VERSION=${{ matrix.postgres_version }}" >> $GITHUB_ENV
       - name: Strip quotes from pg major and set env var


### PR DESCRIPTION
Follow up to https://github.com/supabase/postgres/pull/1874 that applied a similar change outside the CI.

We migrate from DeterminateSystems/nix-installer-action to the official Nix installer via a centralized composite action.
