### PR TITLE
Bump PostgREST to 14.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ This is the same PostgreSQL build that powers [Supabase](https://supabase.io), b
 | Goodie | Version | Description |
 | ------------- | :-------------: | ------------- |
 | [PgBouncer](https://www.pgbouncer.org/) | [1.19.0](http://www.pgbouncer.org/changelog.html#pgbouncer-119x) | Set up Connection Pooling. |
-| [PostgREST](https://postgrest.org/en/stable/) | [v13.0.4](https://github.com/PostgREST/postgrest/releases/tag/v13.0.4) | Instantly transform your database into an RESTful API. |
+| [PostgREST](https://postgrest.org/en/stable/) | [v14.1](https://github.com/PostgREST/postgrest/releases/tag/v14.1) | Instantly transform your database into an RESTful API. |
 | [WAL-G](https://github.com/wal-g/wal-g#wal-g) | [v2.0.1](https://github.com/wal-g/wal-g/releases/tag/v2.0.1) | Tool for physical database backup and recovery. | -->
 
 

--- a/ansible/tasks/setup-postgrest.yml
+++ b/ansible/tasks/setup-postgrest.yml
@@ -58,7 +58,7 @@
       {%- if platform == "arm64" -%}
         ubuntu-aarch64
       {%- elif platform == "amd64" -%}
-        inux-static-x86-64
+        linux-static-x86-64
       {%- endif -%}
 
 - name: PostgREST - unpack archive in /opt

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.014-orioledb"
-  postgres17: "17.6.1.057"
-  postgres15: "15.14.1.057"
+  postgresorioledb-17: "17.6.0.015-orioledb"
+  postgres17: "17.6.1.058"
+  postgres15: "15.14.1.058"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.19.0
@@ -21,9 +21,9 @@ pgbouncer_release_checksum: sha256:af0b05e97d0e1fd9ad45fe00ea6d2a934c63075f67f7e
 # The checksum can be found under "Assets", in the GitHub release page for each version.
 # The binaries used are: ubuntu-aarch64 and linux-static.
 # https://github.com/PostgREST/postgrest/releases
-postgrest_release: 13.0.5
-postgrest_arm_release_checksum: sha256:7b4eafdaf76bc43b57f603109d460a838f89f949adccd02f452ca339f9a0a0d4
-postgrest_x86_release_checksum: sha256:05be2bd48abee6c1691fc7c5d005023466c6989e41a4fc7d1302b8212adb88b5
+postgrest_release: 14.1
+postgrest_arm_release_checksum: sha256:68885d936873059b946afadaae697467daedacd7d8e697a80b7f0f6881c9c92f
+postgrest_x86_release_checksum: sha256:bdab6ab3389ca0d6c1f3b8363491674dbca71875c3f30261d92d8fecdde35277
 
 gotrue_release: 2.182.1
 gotrue_release_checksum: sha1:38a12109ad62df32460d88e4c7b2a475b88e7865


### PR DESCRIPTION
## What kind of change does this PR introduce?

Upgrades PostgREST to v14.1 (release notes for [v14.0](https://github.com/PostgREST/postgrest/releases/tag/v14.0) and [v14.1](https://github.com/PostgREST/postgrest/releases/tag/v14.1)).