### PR TITLE
fix: restore ami release to us east 1

### DIFF
--- a/.github/workflows/ami-release-nix.yml
+++ b/.github/workflows/ami-release-nix.yml
@@ -96,7 +96,7 @@ jobs:
           GIT_SHA=${{github.sha}}
           nix  run github:supabase/postgres/${GIT_SHA}#packer -- init amazon-arm64-nix.pkr.hcl
           # why is postgresql_major defined here instead of where the _three_ other postgresql_* variables are defined?
-          nix  run github:supabase/postgres/${GIT_SHA}#packer -- build -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${EXECUTION_ID}"  -var-file="development-arm.vars.pkr.hcl" -var-file="common-nix.vars.pkr.hcl" -var "ansible_arguments=-e postgresql_major=${POSTGRES_MAJOR_VERSION}"  amazon-arm64-nix.pkr.hcl
+          nix  run github:supabase/postgres/${GIT_SHA}#packer -- build -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${EXECUTION_ID}"  -var-file="development-arm.vars.pkr.hcl" -var-file="common-nix.vars.pkr.hcl" -var "ansible_arguments=-e postgresql_major=${POSTGRES_MAJOR_VERSION}" -var "region=us-east-1" -var 'ami_regions=["us-east-1"]' amazon-arm64-nix.pkr.hcl
 
       - name: Build AMI stage 2
         env:
@@ -105,7 +105,7 @@ jobs:
           GIT_SHA=${{github.sha}}
           nix  run github:supabase/postgres/${GIT_SHA}#packer -- init stage2-nix-psql.pkr.hcl
           POSTGRES_MAJOR_VERSION=${{ env.POSTGRES_MAJOR_VERSION }}
-          nix  run github:supabase/postgres/${GIT_SHA}#packer -- build -var "git_sha=${GIT_SHA}" -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${EXECUTION_ID}" -var "postgres_major_version=${POSTGRES_MAJOR_VERSION}" -var-file="development-arm.vars.pkr.hcl" -var-file="common-nix.vars.pkr.hcl" stage2-nix-psql.pkr.hcl
+          nix  run github:supabase/postgres/${GIT_SHA}#packer -- build -var "git_sha=${GIT_SHA}" -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${EXECUTION_ID}" -var "postgres_major_version=${POSTGRES_MAJOR_VERSION}" -var-file="development-arm.vars.pkr.hcl" -var-file="common-nix.vars.pkr.hcl" -var "region=us-east-1" -var 'ami_regions=["us-east-1"]' stage2-nix-psql.pkr.hcl
 
       - name: Grab release version
         id: process_release_version
@@ -184,9 +184,9 @@ jobs:
       - name: Cleanup resources after build
         if: ${{ always() }}
         run: |
-          aws ec2 describe-instances --filters "Name=tag:packerExecutionId,Values=${EXECUTION_ID}" --query "Reservations[].Instances[].InstanceId" --output text | xargs -r aws ec2 terminate-instances --instance-ids
+          aws ec2 --region us-east-1 describe-instances --filters "Name=tag:packerExecutionId,Values=${EXECUTION_ID}" --query "Reservations[].Instances[].InstanceId" --output text | xargs -r aws ec2 terminate-instances --region us-east-1 --instance-ids
 
       - name: Cleanup resources on build cancellation
         if: ${{ cancelled() }}
         run: |
-          aws ec2 describe-instances --filters "Name=tag:packerExecutionId,Values=${EXECUTION_ID}" --query "Reservations[].Instances[].InstanceId" --output text | xargs -r aws ec2 terminate-instances --instance-ids
+          aws ec2 --region us-east-1 describe-instances --filters "Name=tag:packerExecutionId,Values=${EXECUTION_ID}" --query "Reservations[].Instances[].InstanceId" --output text | xargs -r aws ec2 terminate-instances --region us-east-1 --instance-ids

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.5.1.065-orioledb-east-1"
-  postgres17: "17.6.1.044-east-1"
-  postgres15: "15.14.1.044-east-1"
+  postgresorioledb-17: "17.5.1.065-orioledb"
+  postgres17: "17.6.1.044"
+  postgres15: "15.14.1.044"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.19.0

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.5.1.066-orioledb"
-  postgres17: "17.6.1.045"
-  postgres15: "15.14.1.045"
+  postgresorioledb-17: "17.5.1.065-orioledb-east-1"
+  postgres17: "17.6.1.044-east-1"
+  postgres15: "15.14.1.044-east-1"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.19.0


### PR DESCRIPTION
In previous pr we consolidated testinfra to explicitly run in ap-southeast-1 this pr:

 - ami-release workflow: Explicitly builds and publishes to us-east-1
 - testinfra workflow: Explicitly builds and tests in ap-southeast-1


Just to clarify this builds on

  Config Prior to this PR (as of commit 79cbab5a)

  Stage 2 is now publishing to ap-southeast-1:
  - File: development-arm.vars.pkr.hcl:2
  - Setting: ami_regions = ["ap-southeast-1"]
  - Region: region = "ap-southeast-1"

  Previous Configuration (before commit 6f821212)

  Stage 2 was previously publishing to us-east-1:
  - Setting: ami_regions = ["us-east-1"]
  - Region: region = "us-east-1"

  When the Change Occurred

  The region consolidation happened in two commits on November 11, 2025:
  1. 6f821212 - "fix: try instead to consolidate all on ap-southeast-1"
  2. 79cbab5a - "fix: relocate testinfra build ops to ap-southeast-1 (#1908)"
