### PR TITLE
fix: Prepare job (lines 23-25): Moved checkout before nix-install-ephemeral

### DIFF
--- a/.github/workflows/dockerhub-release-matrix.yml
+++ b/.github/workflows/dockerhub-release-matrix.yml
@@ -20,9 +20,9 @@ jobs:
     outputs:
       matrix_config: ${{ steps.set-matrix.outputs.matrix_config }}
     steps:
-      - uses: ./.github/actions/nix-install-ephemeral
       - name: Checkout Repo
         uses: supabase/postgres/.github/actions/shared-checkout@HEAD
+      - uses: ./.github/actions/nix-install-ephemeral
       - name: Generate build matrix
         id: set-matrix
         run: |


### PR DESCRIPTION
fixed the ordering issue in .github/workflows/dockerhub-release-matrix.yml.

  What Was Changed

  Prepare job (lines 23-25): Moved checkout before nix-install-ephemeral

    steps:
  -   - uses: ./.github/actions/nix-install-ephemeral
      - name: Checkout Repo
        uses: supabase/postgres/.github/actions/shared-checkout@HEAD
  +   - uses: ./.github/actions/nix-install-ephemeral
