### PR TITLE
fix: don't run a nix installer on qemu image build

### DIFF
--- a/.github/actions/nix-install-ephemeral/action.yml
+++ b/.github/actions/nix-install-ephemeral/action.yml
@@ -37,7 +37,6 @@ runs:
       env:
         NIX_SIGN_SECRET_KEY: ${{ env.NIX_SIGN_SECRET_KEY }}
     - name: Install nix
-      if: steps.check-runner.outputs.skip_nix_install != 'true'
       uses: cachix/install-nix-action@v31
       with:
         install_url: https://releases.nixos.org/nix/nix-2.32.2/install

--- a/.github/actions/nix-install-ephemeral/action.yml
+++ b/.github/actions/nix-install-ephemeral/action.yml
@@ -40,15 +40,15 @@ runs:
       id: check-runner
       shell: bash
       run: |
-        if [[ "${{ runner.name }}" == *"GitHub Actions"* ]] || [[ "$RUNNER_ENVIRONMENT" == "github-hosted" ]]; then
-          echo "is_self_hosted=false" >> $GITHUB_OUTPUT
-          echo "Running on GitHub-hosted runner, will install Nix"
+        if [[ "${{ runner.name }}" == "arm-native-runner" ]]; then
+          echo "skip_nix_install=true" >> $GITHUB_OUTPUT
+          echo "Running on arm-native-runner, skipping Nix installation (pre-installed)"
         else
-          echo "is_self_hosted=true" >> $GITHUB_OUTPUT
-          echo "Running on self-hosted runner, skipping Nix installation (should be pre-installed)"
+          echo "skip_nix_install=false" >> $GITHUB_OUTPUT
+          echo "Will install Nix"
         fi
     - name: Install nix
-      if: steps.check-runner.outputs.is_self_hosted != 'true'
+      if: steps.check-runner.outputs.skip_nix_install != 'true'
       uses: cachix/install-nix-action@v31
       with:
         install_url: https://releases.nixos.org/nix/nix-2.32.2/install

--- a/.github/actions/nix-install-ephemeral/action.yml
+++ b/.github/actions/nix-install-ephemeral/action.yml
@@ -36,17 +36,6 @@ runs:
         sudo chmod +x /etc/nix/upload-to-cache.sh
       env:
         NIX_SIGN_SECRET_KEY: ${{ env.NIX_SIGN_SECRET_KEY }}
-    - name: Check runner type
-      id: check-runner
-      shell: bash
-      run: |
-        if [[ "${{ runner.name }}" == "arm-native-runner" ]]; then
-          echo "skip_nix_install=true" >> $GITHUB_OUTPUT
-          echo "Running on arm-native-runner, skipping Nix installation (pre-installed)"
-        else
-          echo "skip_nix_install=false" >> $GITHUB_OUTPUT
-          echo "Will install Nix"
-        fi
     - name: Install nix
       if: steps.check-runner.outputs.skip_nix_install != 'true'
       uses: cachix/install-nix-action@v31

--- a/.github/actions/nix-install-ephemeral/action.yml
+++ b/.github/actions/nix-install-ephemeral/action.yml
@@ -36,7 +36,19 @@ runs:
         sudo chmod +x /etc/nix/upload-to-cache.sh
       env:
         NIX_SIGN_SECRET_KEY: ${{ env.NIX_SIGN_SECRET_KEY }}
+    - name: Check runner type
+      id: check-runner
+      shell: bash
+      run: |
+        if [[ "${{ runner.name }}" == *"GitHub Actions"* ]] || [[ "$RUNNER_ENVIRONMENT" == "github-hosted" ]]; then
+          echo "is_self_hosted=false" >> $GITHUB_OUTPUT
+          echo "Running on GitHub-hosted runner, will install Nix"
+        else
+          echo "is_self_hosted=true" >> $GITHUB_OUTPUT
+          echo "Running on self-hosted runner, skipping Nix installation (should be pre-installed)"
+        fi
     - name: Install nix
+      if: steps.check-runner.outputs.is_self_hosted != 'true'
       uses: cachix/install-nix-action@v31
       with:
         install_url: https://releases.nixos.org/nix/nix-2.32.2/install

--- a/.github/workflows/qemu-image-build.yml
+++ b/.github/workflows/qemu-image-build.yml
@@ -48,8 +48,6 @@ jobs:
       - name: Checkout Repo
         uses: supabase/postgres/.github/actions/shared-checkout@HEAD
 
-      - uses: ./.github/actions/nix-install-ephemeral
-
       - name: Run checks if triggered manually
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |


### PR DESCRIPTION
We should not install nix as a first step on our self hosted runner arm-native-runner. To solve the issue, I am removing the step from qemu image build