### PR TITLE
fix: adaptive retry on aws

### DIFF
--- a/.github/workflows/testinfra-ami-build.yml
+++ b/.github/workflows/testinfra-ami-build.yml
@@ -109,12 +109,18 @@ jobs:
           echo "" >> common-nix.vars.pkr.hcl
 
       - name: Build AMI stage 1
+        env:
+          AWS_MAX_ATTEMPTS: 10
+          AWS_RETRY_MODE: adaptive
         run: |
           GIT_SHA=${{github.sha}}
           nix run github:supabase/postgres/${GIT_SHA}#packer -- init amazon-arm64-nix.pkr.hcl
           nix run github:supabase/postgres/${GIT_SHA}#packer -- build -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${EXECUTION_ID}" -var-file="development-arm.vars.pkr.hcl" -var-file="common-nix.vars.pkr.hcl" -var "ansible_arguments=" -var "postgres-version=${{ steps.random.outputs.random_string }}" -var "region=ap-southeast-1" -var 'ami_regions=["ap-southeast-1"]' -var "force-deregister=true" -var "ansible_arguments=-e postgresql_major=${POSTGRES_MAJOR_VERSION}" amazon-arm64-nix.pkr.hcl
 
       - name: Build AMI stage 2
+        env:
+          AWS_MAX_ATTEMPTS: 10
+          AWS_RETRY_MODE: adaptive
         run: |
           GIT_SHA=${{github.sha}}
           nix run github:supabase/postgres/${GIT_SHA}#packer -- init stage2-nix-psql.pkr.hcl

--- a/amazon-arm64-nix.pkr.hcl
+++ b/amazon-arm64-nix.pkr.hcl
@@ -115,6 +115,12 @@ source "amazon-ebssurrogate" "source" {
   #secret_key   = "${var.aws_secret_key}"
   force_deregister = var.force-deregister
 
+  # Increase timeout for instance stop operations to handle large instances
+  aws_polling {
+    delay_seconds = 15
+    max_attempts  = 120  # 120 * 15s = 30 minutes max wait
+  }
+
   # Use latest official ubuntu noble ami owned by Canonical.
   source_ami_filter {
     filters = {

--- a/stage2-nix-psql.pkr.hcl
+++ b/stage2-nix-psql.pkr.hcl
@@ -81,6 +81,11 @@ source "amazon-ebs" "ubuntu" {
 
   associate_public_ip_address = true
 
+  # Increase timeout for instance stop operations to handle large instances
+  aws_polling {
+    delay_seconds = 15
+    max_attempts  = 120  # 120 * 15s = 30 minutes max wait
+  }
 
   ena_support = true
 


### PR DESCRIPTION
  Changes Made

  Added environment variables to both "Build AMI stage 1" and "Build AMI stage 2" steps in
  .github/workflows/testinfra-ami-build.yml:111,120:

  env:
    AWS_MAX_ATTEMPTS: 10
    AWS_RETRY_MODE: adaptive

  What This Does

  1. AWS_MAX_ATTEMPTS: 10 - The AWS SDK will retry failed API calls up to 10 times before giving up (default is 3)
  2. AWS_RETRY_MODE: adaptive - Uses intelligent retry logic that:
    - Backs off exponentially on throttling errors
    - Adapts retry timing based on AWS response patterns
    - Handles transient network issues (like your "unexpected EOF")
    - Works with rate limiting and temporary connectivity problems

  Expected Impact

  - Fixes the frequent "unexpected EOF" errors during snapshot tagging by automatically retrying when the AWS API connection drops
  - No workflow re-runs needed for transient failures - the build will self-heal
  - Minimal time overhead - Only adds delay when retries are actually needed
  - Works for both stages - Protects both the surrogate build and the stage 2 build

The frequent "unexpected EOF" was tied many times to a specific interaction with aws that doesn't require a full re-run of workflow 