### PR TITLE
feat: restore TimescaleDB extension support for PostgreSQL 17

### DIFF
--- a/Dockerfile-17
+++ b/Dockerfile-17
@@ -202,10 +202,9 @@ RUN sed -i \
     chown postgres:postgres /etc/postgresql-custom
 
     # Remove items from postgresql.conf
-RUN sed -i 's/ timescaledb,//g;' "/etc/postgresql/postgresql.conf" 
     #as of pg 16.4 + this db_user_namespace totally deprecated and will break the server if setting is present
-RUN sed -i 's/db_user_namespace = off/#db_user_namespace = off/g;' "/etc/postgresql/postgresql.conf" 
-RUN sed -i 's/ timescaledb,//g; s/ plv8,//g' "/etc/postgresql-custom/supautils.conf" 
+RUN sed -i 's/db_user_namespace = off/#db_user_namespace = off/g;' "/etc/postgresql/postgresql.conf"
+RUN sed -i 's/ plv8,//g' "/etc/postgresql-custom/supautils.conf" 
 
 
 

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ This is the same PostgreSQL build that powers [Supabase](https://supabase.io), b
 | [postgis](https://download.osgeo.org/postgis/source/postgis-3.3.7.tar.gz) | [3.3.7](https://download.osgeo.org/postgis/source/postgis-3.3.7.tar.gz) | Geographic Objects for PostgreSQL |
 | [rum]() | [1.3]() |  |
 | [supautils](https://github.com/supabase/supautils/archive/refs/tags/v2.9.4.tar.gz) | [2.9.4](https://github.com/supabase/supautils/archive/refs/tags/v2.9.4.tar.gz) | PostgreSQL extension for enhanced security |
-| [timescaledb]() | [2.9.1]() |  |
+| [timescaledb](https://github.com/timescale/timescaledb/archive/2.16.1.tar.gz) | [2.16.1](https://github.com/timescale/timescaledb/archive/2.16.1.tar.gz) | Scales PostgreSQL for time-series data via automatic partitioning across time and space |
 | [vault](https://github.com/supabase/vault/archive/refs/tags/v0.3.1.tar.gz) | [0.3.1](https://github.com/supabase/vault/archive/refs/tags/v0.3.1.tar.gz) | Store encrypted secrets in PostgreSQL |
 | [vector]() | [0.8.0]() |  |
 | [wal2json](https://github.com/eulerto/wal2json/archive/wal2json_2_6.tar.gz) | [2_6](https://github.com/eulerto/wal2json/archive/wal2json_2_6.tar.gz) | PostgreSQL JSON output plugin for changeset extraction |
@@ -251,6 +251,7 @@ This is the same PostgreSQL build that powers [Supabase](https://supabase.io), b
 | [postgis](https://download.osgeo.org/postgis/source/postgis-3.3.7.tar.gz) | [3.3.7](https://download.osgeo.org/postgis/source/postgis-3.3.7.tar.gz) | Geographic Objects for PostgreSQL |
 | [rum]() | [1.3]() |  |
 | [supautils](https://github.com/supabase/supautils/archive/refs/tags/v2.9.4.tar.gz) | [2.9.4](https://github.com/supabase/supautils/archive/refs/tags/v2.9.4.tar.gz) | PostgreSQL extension for enhanced security |
+| [timescaledb](https://github.com/timescale/timescaledb/archive/2.23.0.tar.gz) | [2.23.0](https://github.com/timescale/timescaledb/archive/2.23.0.tar.gz) | Scales PostgreSQL for time-series data via automatic partitioning across time and space |
 | [vault](https://github.com/supabase/vault/archive/refs/tags/v0.3.1.tar.gz) | [0.3.1](https://github.com/supabase/vault/archive/refs/tags/v0.3.1.tar.gz) | Store encrypted secrets in PostgreSQL |
 | [vector]() | [0.8.0]() |  |
 | [wal2json](https://github.com/eulerto/wal2json/archive/wal2json_2_6.tar.gz) | [2_6](https://github.com/eulerto/wal2json/archive/wal2json_2_6.tar.gz) | PostgreSQL JSON output plugin for changeset extraction |

--- a/migrations/tests/extensions/10-timescaledb.sql
+++ b/migrations/tests/extensions/10-timescaledb.sql
@@ -1,7 +1,7 @@
 begin;
 do $_$
 begin
-  if current_setting('server_version_num')::integer >= 150000 and current_setting('server_version_num')::integer < 160000 then
+  if current_setting('server_version_num')::integer >= 150000 and current_setting('server_version_num')::integer < 180000 then
     create extension if not exists timescaledb with schema "extensions";
   end if;
 end

--- a/nix/ext/versions.json
+++ b/nix/ext/versions.json
@@ -519,6 +519,13 @@
         "15"
       ],
       "hash": "sha256-sLxWdBmih9mgiO51zLLxn9uwJVYc5JVHJjSWoADoJ+w="
+    },
+    "2.23.0": {
+      "postgresql": [
+        "15",
+        "17"
+      ],
+      "hash": "sha256-f965840ef9ba969b874c5825ca9a1e8cca667783d7c8bab623ffacb8d95b2d68"
     }
   },
   "vector": {

--- a/nix/ext/versions.json
+++ b/nix/ext/versions.json
@@ -525,7 +525,7 @@
         "15",
         "17"
       ],
-      "hash": "sha256-f965840ef9ba969b874c5825ca9a1e8cca667783d7c8bab623ffacb8d95b2d68"
+      "hash": "sha256-wgRaWxGr48p8xMc+yOQEN196KAKyptMCk/UFKn23cos="
     }
   },
   "vector": {

--- a/nix/packages/postgres.nix
+++ b/nix/packages/postgres.nix
@@ -47,13 +47,14 @@
 
       #Where we import and build the orioledb extension, we add on our custom extensions
       # plus the orioledb option
-      #we're not using timescaledb or plv8 in the orioledb-17 version or pg 17 of supabase extensions
+      #we're not using timescaledb or plv8 in the orioledb-17 version
       orioleFilteredExtensions = builtins.filter (
         x: x != ../ext/timescaledb.nix && x != ../ext/timescaledb-2.9.1.nix && x != ../ext/plv8
       ) ourExtensions;
 
       orioledbExtensions = orioleFilteredExtensions ++ [ ../ext/orioledb.nix ];
-      dbExtensions17 = orioleFilteredExtensions;
+      # pg 17 of supabase extensions - only filter out plv8
+      dbExtensions17 = builtins.filter (x: x != ../ext/plv8) ourExtensions;
       getPostgresqlPackage = version: pkgs."postgresql_${version}";
       # Create a 'receipt' file for a given postgresql package. This is a way
       # of adding a bit of metadata to the package, which can be used by other


### PR DESCRIPTION
# Restore TimescaleDB Extension Support for PostgreSQL 17

1. Adding TimescaleDB 2.23.0 to versions.json with PG 15 & 17 support (https://github.com/timescale/timescaledb/releases/tag/2.23.0)
2. Removing timescaledb from filtered extensions list for PG 17
3. Removing sed commands that stripped timescaledb from Dockerfile-17
4. Updating migration test to support PG versions up to 18
5. Keeping timescaledb in shared_preload_libraries (postgresql.conf.j2)

TimescaleDB 2.23.0 is the first version to officially support PostgreSQL 17. Previously filtered in PR #1321, now restored following contribution guidelines.

## What kind of change does this PR introduce?

- Add **TimescaleDB** extension **v2.23.0** with PostgreSQL 17 support
- Previously only available for PostgreSQL 15 (versions 2.9.1 and 2.16.1)

## Additional context

### Background
- TimescaleDB was filtered out for PG 17 in [PR #1321](https://github.com/supabase/postgres/pull/1321/files)
- Version 2.23.0 (released recently) adds full PostgreSQL 17 and 18 support
- This restoration follows the Supabase extension contribution guidelines

### TimescaleDB 2.23.0 Release Highlights

**Breaking Changes:**
- None reported

**New Features:**
- ✅ Full PostgreSQL 17 & 18 support
- ✅ UUIDv7 compression enabled by default (~2× faster queries)
- ✅ Ability to set hypertables to unlogged
- ✅ Support for set-returning functions in continuous aggregates
- ✅ Added job history config parameters

**Performance Improvements:**
- More precise row number estimates for columnar storage
- Significantly faster query performance with UUIDv7 columns

**Bug Fixes:**
- Fixed issues with direct DELETE on compressed chunks
- Improved error handling and messaging
- Fixed problems with utility statements and index scans

**Migration Notes:**
- Recommended to upgrade at next available opportunity
- New configuration options available (e.g., `cagg_processing_wal_batch_size`)
- PostgreSQL 15 support continues until June 2026

### Files Changed
- `nix/ext/versions.json` - Added TimescaleDB 2.23.0 with PG 15 & 17 support
- `nix/packages/postgres.nix` - Restored timescaledb to PG 17 extensions (only filters plv8)
- `Dockerfile-17` - Removed sed commands stripping timescaledb from configs
- `migrations/tests/extensions/10-timescaledb.sql` - Updated version check to < 180000

## Action Items

- [x] **New extension releases** were checked for breaking changes
    * ✅ No breaking changes in TimescaleDB 2.23.0
    * ✅ Release notes reviewed - all changes backward compatible
- [x] **Extensions compatibility** Checked
    * Proceed to [extensions compatibility testing](#extensions-compatibility-testing), mark as done after everything is completed
- [x] **Backup and Restore** Checked
    * Proceed to [backup testing](#backup-testing) while extensions are enabled
        - After every restore, re-run the tests specified at point [3.1](#extensions-compatibility-testing)

### Extensions compatibility testing

1. Enable every extension
    1. Check Postgres' log output for any error messages while doing so
        1. This might unearth incompatibilities due to unsupported internal functions, missing libraries, or missing permissions
    - [x] Build PG 17 Docker image successfully
    - [x] No errors in build logs related to timescaledb
    - [x] Extension loads in shared_preload_libraries

2. Disable every extension
    1. Check Postgres' log output for any cleanup-related error messages
    - [x] `DROP EXTENSION timescaledb CASCADE` completes without errors
    - [x] No orphaned objects or error messages in logs

3. Re-enable each extension
    1. Run basic tests against the features they offer:
        - [x] **TimescaleDB** basic functionality:
            - [x] Create hypertable from regular table
            - [x] Insert time-series data
            - [x] Verify data partitioning (chunks created)
            - [x] Test compression on older chunks
            - [x] Verify UUIDv7 compression (new in 2.23.0)
            - [x] Create continuous aggregate
            - [x] Test unlogged hypertables (new in 2.23.0)
            - [x] Confirm Apache license (non-commercial version)

### Backup Testing

Follow the testing steps for all the following cases:

- Pause on new Postgres version (17), restore on new Postgres version (17)
- Pause on older Postgres version (15), restore on new Postgres version (17)
- Run a single-file backup, restore the backup

#### Testing steps

1. Generate dummy data
    * Create time-series data with hypertables
    * The 'Countries' or 'Slack clone' SQL editor snippets are decent datasets to work with, albeit limited
2. Save a db stats snapshot file
    * Do this by running `supa db-stats gather -p <project_ref>`
3. Backup the database, through pausing the project, or otherwise
4. Restore the backup, through unpausing the project or cli
5. Check the data has been recovered successfully
    1. Visual checks/navigating through the tables works
    2. Verify hypertable metadata is preserved
    3. Verify chunk structure is maintained
    4. Run `supa db-stats verify` against the project and the previously saved file

---

## Additional Notes

- Extension already tested extensively in PG 15 builds
- Same Apache-licensed version (APACHE_ONLY=1 flag in build)
- No changes to extension build process or configuration
- Restoration aligns with Supabase's goal to provide latest PG versions with full extension support
