### PR TITLE
feat: reduction of closure size for plv8

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.5.1.073-orioledb"
-  postgres17: "17.6.1.052"
-  postgres15: "15.14.1.052"
+  postgresorioledb-17: "17.5.1.073-orioledb-plv8-1"
+  postgres17: "17.6.1.052-plv8-1"
+  postgres15: "15.14.1.052-plv8-1"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.19.0

--- a/nix/ext/plv8/default.nix
+++ b/nix/ext/plv8/default.nix
@@ -14,6 +14,7 @@
   patchelf,
   buildEnv,
   nodejs_20,
+  libcxx,
 }:
 
 let
@@ -139,26 +140,26 @@ let
           ${lib.optionalString stdenv.isDarwin ''
             install_name_tool -add_rpath "${v8}/lib" $out/lib/$LIB_NAME
             install_name_tool -add_rpath "${postgresql}/lib" $out/lib/$LIB_NAME
-            install_name_tool -add_rpath "${stdenv.cc.cc.lib}/lib" $out/lib/$LIB_NAME
+            install_name_tool -add_rpath "${libcxx}/lib" $out/lib/$LIB_NAME
             install_name_tool -change @rpath/libv8_monolith.dylib ${v8}/lib/libv8_monolith.dylib $out/lib/$LIB_NAME
           ''}
 
           ${
             lib.optionalString (!stdenv.isDarwin) ''
-              ${patchelf}/bin/patchelf --set-rpath "${v8}/lib:${postgresql}/lib:${stdenv.cc.cc.lib}/lib" $out/lib/$LIB_NAME
+              ${patchelf}/bin/patchelf --set-rpath "${v8}/lib:${postgresql}/lib:${libcxx}/lib" $out/lib/$LIB_NAME
             ''
           }
         else
           ${lib.optionalString stdenv.isDarwin ''
             install_name_tool -add_rpath "${v8}/lib" $out/lib/$LIB_NAME
             install_name_tool -add_rpath "${postgresql}/lib" $out/lib/$LIB_NAME
-            install_name_tool -add_rpath "${stdenv.cc.cc.lib}/lib" $out/lib/$LIB_NAME
+            install_name_tool -add_rpath "${libcxx}/lib" $out/lib/$LIB_NAME
             install_name_tool -change @rpath/libv8_monolith.dylib ${v8}/lib/libv8_monolith.dylib $out/lib/$LIB_NAME
           ''}
 
           ${
             lib.optionalString (!stdenv.isDarwin) ''
-              ${patchelf}/bin/patchelf --set-rpath "${v8}/lib:${postgresql}/lib:${stdenv.cc.cc.lib}/lib" $out/lib/$LIB_NAME
+              ${patchelf}/bin/patchelf --set-rpath "${v8}/lib:${postgresql}/lib:${libcxx}/lib" $out/lib/$LIB_NAME
             ''
           }
         fi


### PR DESCRIPTION
Reduced the closure size (total dependency footprint) of the plv8 PostgreSQL extension by optimizing its runtime dependencies.

  What was changed:

  1. nix/ext/plv8/default.nix - Replaced stdenv.cc.cc.lib with libcxx in all rpath settings
    - Added libcxx to the function inputs
    - Updated 4 locations where runtime library paths are set (both Darwin/macOS and Linux paths)
    - This reduces closure size because stdenv.cc.cc.lib pulls in the entire compiler toolchain, while libcxx only brings in the C++ standard library