### PR TITLE
feat(postgres): add PG 17.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ This is the same PostgreSQL build that powers [Supabase](https://supabase.io), b
 
 ## Primary Features
 - ✅ Postgres [postgresql-15.14](https://www.postgresql.org/docs/15/index.html)
-- ✅ Postgres [postgresql-17.6](https://www.postgresql.org/docs/17/index.html)
+- ✅ Postgres [postgresql-17.7](https://www.postgresql.org/docs/17/index.html)
 - ✅ Postgres [orioledb-postgresql-17_11](https://github.com/orioledb/orioledb)
 - ✅ Ubuntu 24.04 (Noble Numbat).
 - ✅ [wal_level](https://www.postgresql.org/docs/current/runtime-config-wal.html) = logical and [max_replication_slots](https://www.postgresql.org/docs/current/runtime-config-replication.html) = 5. Ready for replication.

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgres17: "17.7.1.001"
-  postgresorioledb-17: "17.6.0.010-orioledb"
-  postgres15: "15.14.1.053"
+  postgres17: "17.7.1.001-pg17_7"
+  postgresorioledb-17: "17.6.0.010-orioledb-pg17_7"
+  postgres15: "15.14.1.053-pg17_7"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.19.0

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -11,7 +11,7 @@ postgres_major:
 # Full version strings for each major version
 postgres_release:
   postgresorioledb-17: "17.5.1.073-orioledb"
-  postgres17: "17.6.1.052"
+  postgres17: "17.7.1.001"
   postgres15: "15.14.1.052"
 
 # Non Postgres Extensions

--- a/migrations/schema-17.sql
+++ b/migrations/schema-17.sql
@@ -4,8 +4,8 @@
 
 \restrict SupabaseTestDumpKey123
 
--- Dumped from database version 17.6
--- Dumped by pg_dump version 17.6
+-- Dumped from database version 17.7
+-- Dumped by pg_dump version 17.7
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;

--- a/nix/config.nix
+++ b/nix/config.nix
@@ -46,8 +46,8 @@ in
             hash = "sha256-Bt110wXNOHDuYrOTLmYcYkVD6vmuK6N83sCk+O3QUdI=";
           };
           "17" = {
-            version = "17.6";
-            hash = "sha256-4GMKNgCuonURcVVjJZ7CERzV9DU6SwQOC+gn+UzXqLA=";
+            version = "17.7";
+            hash = "sha256-7540MwLszTMRLxsvAke+STy1doMTretViwLeh5ei6bU";
           };
         };
         orioledb = {


### PR DESCRIPTION
## What kind of change does this PR introduce?

add PG 17.7 to our AMI

## What is the current behavior?

no 17.7

## What is the new behavior?

has 17.7

## Additional context

https://www.postgresql.org/about/news/postgresql-181-177-1611-1515-1420-and-1323-released-3171/

