### PR TITLE
refactor: Move PostgreSQL auto_explain config to conf.d

### DIFF
--- a/Dockerfile-15
+++ b/Dockerfile-15
@@ -192,7 +192,6 @@ RUN sed -i \
     #echo "pljava.libjvm_location = '/usr/lib/jvm/java-11-openjdk-${TARGETARCH}/lib/server/libjvm.so'" >> /etc/postgresql/postgresql.conf && \
     echo "pgsodium.getkey_script= '/usr/lib/postgresql/bin/pgsodium_getkey.sh'" >> /etc/postgresql/postgresql.conf && \    
     echo "vault.getkey_script= '/usr/lib/postgresql/bin/pgsodium_getkey.sh'" >> /etc/postgresql/postgresql.conf && \
-    echo 'auto_explain.log_min_duration = 10s' >> /etc/postgresql/postgresql.conf && \
     usermod -aG postgres wal-g && \
     mkdir -p /etc/postgresql-custom/conf.d && \
     chown -R postgres:postgres /etc/postgresql-custom

--- a/Dockerfile-17
+++ b/Dockerfile-17
@@ -197,7 +197,6 @@ RUN sed -i \
     #echo "pljava.libjvm_location = '/usr/lib/jvm/java-11-openjdk-${TARGETARCH}/lib/server/libjvm.so'" >> /etc/postgresql/postgresql.conf && \
     echo "pgsodium.getkey_script= '/usr/lib/postgresql/bin/pgsodium_getkey.sh'" >> /etc/postgresql/postgresql.conf && \
     echo "vault.getkey_script= '/usr/lib/postgresql/bin/pgsodium_getkey.sh'" >> /etc/postgresql/postgresql.conf && \
-    echo 'auto_explain.log_min_duration = 10s' >> /etc/postgresql/postgresql.conf && \
     usermod -aG postgres wal-g && \
     mkdir -p /etc/postgresql-custom/conf.d && \
     chown -R postgres:postgres /etc/postgresql-custom

--- a/Dockerfile-orioledb-17
+++ b/Dockerfile-orioledb-17
@@ -197,7 +197,6 @@ RUN sed -i \
     #echo "pljava.libjvm_location = '/usr/lib/jvm/java-11-openjdk-${TARGETARCH}/lib/server/libjvm.so'" >> /etc/postgresql/postgresql.conf && \
     echo "pgsodium.getkey_script= '/usr/lib/postgresql/bin/pgsodium_getkey.sh'" >> /etc/postgresql/postgresql.conf && \
     echo "vault.getkey_script= '/usr/lib/postgresql/bin/pgsodium_getkey.sh'" >> /etc/postgresql/postgresql.conf && \
-    echo 'auto_explain.log_min_duration = 10s' >> /etc/postgresql/postgresql.conf && \
     usermod -aG postgres wal-g && \
     mkdir -p /etc/postgresql-custom/conf.d && \
     chown -R postgres:postgres /etc/postgresql-custom

--- a/ansible/files/postgresql_config/conf.d/auto_explain.conf
+++ b/ansible/files/postgresql_config/conf.d/auto_explain.conf
@@ -1,0 +1,1 @@
+auto_explain.log_min_duration = 10s

--- a/ansible/files/postgresql_config/postgresql.conf.j2
+++ b/ansible/files/postgresql_config/postgresql.conf.j2
@@ -773,5 +773,4 @@ include_dir = '/etc/postgresql-custom/conf.d'  # include files ending in '.conf'
 #------------------------------------------------------------------------------
 
 # Add settings for extensions here
-auto_explain.log_min_duration = 10s
 cron.database_name = 'postgres'

--- a/ansible/tasks/finalize-ami.yml
+++ b/ansible/tasks/finalize-ami.yml
@@ -4,6 +4,17 @@
     group: 'postgres'
     src: 'files/postgresql_config/postgresql-csvlog.conf'
 
+- name: auto_explain and pg_cron confs
+  ansible.builtin.template:
+    dest: "/etc/postgresql-custom/conf.d/{{ ext_item }}.conf"
+    group: 'postgres'
+    src: "files/postgresql_config/conf.d/{{ ext_item | split('_') | join('') }}.conf"
+  loop:
+    - auto_explain
+    # - pg_cron
+  loop_control:
+    loop_var: 'ext_item'
+
 - name: UFW - Allow SSH connections
   community.general.ufw:
     name: 'OpenSSH'

--- a/ansible/tasks/finalize-ami.yml
+++ b/ansible/tasks/finalize-ami.yml
@@ -8,7 +8,7 @@
   ansible.builtin.template:
     dest: "/etc/postgresql-custom/conf.d/{{ ext_item }}.conf"
     group: 'postgres'
-    src: "files/postgresql_config/conf.d/{{ ext_item | split('_') | join('') }}.conf"
+    src: "files/postgresql_config/conf.d/{{ ext_item }}.conf"
   loop:
     - auto_explain
     # - pg_cron

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.011-orioledb"
-  postgres17: "17.6.1.054"
-  postgres15: "15.14.1.054"
+  postgresorioledb-17: "17.6.0.011-orioledb-INDATA-255"
+  postgres17: "17.6.1.054-INDATA-255"
+  postgres15: "15.14.1.054-INDATA-255"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.19.0


### PR DESCRIPTION
Moves `auto_explain.log_min_duration` setting from inline Dockerfile definitions and the main PostgreSQL configuration file to a dedicated `auto_explain.conf` file within the `conf.d` directory.

This change centralizes the configuration for better management and consistency across different PostgreSQL versions.

Updates PostgreSQL release versions in `ansible/vars.yml` with the project-specific suffix.
