### PR TITLE
chore: bump versions

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.012-orioledb"
-  postgres17: "17.6.1.055"
-  postgres15: "15.14.1.055"
+  postgresorioledb-17: "17.6.0.013-orioledb"
+  postgres17: "17.6.1.056"
+  postgres15: "15.14.1.056"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.19.0


### PR DESCRIPTION
Last release failed because of a CI issue (fixed in https://github.com/supabase/postgres/pull/1948) - cutting another release