### PR TITLE
fix: reserve the port for postgres_exporter with sysctl

### DIFF
--- a/ansible/tasks/setup-system.yml
+++ b/ansible/tasks/setup-system.yml
@@ -154,6 +154,13 @@
         value: 60
         state: 'present'
 
+    # postgres_exporter runs on port 9187 and postgresT occasionlly chooses it as random srcport
+    - name: Set net.ipv4.ip_local_reserved_ports=9187
+      ansible.builtin.sysctl:
+        name: 'net.ipv4.ip_local_reserved_ports'
+        value: 9187
+        state: 'present'
+
 - name: Execute tasks when (debpkg_mode or nixpkg_mode)
   when:
     - (debpkg_mode or nixpkg_mode)


### PR DESCRIPTION
Services can assign port 9187 randomly on startup as a srcport. This ensures it's reserved fro use by postgres_exporter

