### PR TITLE
chore: prevent loopback ssh connections

### DIFF
--- a/ansible/tasks/setup-system.yml
+++ b/ansible/tasks/setup-system.yml
@@ -64,6 +64,18 @@
         dest: '/etc/apt/apt.conf.d/10periodic'
         src: 'files/apt_periodic'
 
+    - name: Set local ssh policy
+      ansible.builtin.copy:
+        content: |
+          Match Address 127.0.0.1,::1
+            ForceCommand /bin/false
+            DisableForwarding yes
+            PermitTunnel no
+        dest: /etc/ssh/sshd_config.d/local.conf
+        mode: '0644'
+        owner: 'root'
+        group: 'root'
+
 - name: Install other useful tools
   ansible.builtin.apt:
     pkg:

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.016-orioledb"
-  postgres17: "17.6.1.059"
-  postgres15: "15.14.1.059"
+  postgresorioledb-17: "17.6.0.017-orioledb"
+  postgres17: "17.6.1.060"
+  postgres15: "15.14.1.060"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.19.0


### PR DESCRIPTION
Block ssh connections that originate from localhost

There is nothing in the image that needs to ssh back into the host from itself