### PR TITLE
fix: build extensions not supporting multiversion

### DIFF
--- a/nix/ext/pgtap.nix
+++ b/nix/ext/pgtap.nix
@@ -10,6 +10,7 @@
 
 stdenv.mkDerivation rec {
   pname = "pgtap";
+  name = pname;
   version = "1.2.0";
 
   src = fetchFromGitHub {

--- a/nix/ext/supautils.nix
+++ b/nix/ext/supautils.nix
@@ -7,6 +7,7 @@
 
 stdenv.mkDerivation rec {
   pname = "supautils";
+  name = pname;
   version = "3.0.1";
 
   buildInputs = [ postgresql ];


### PR DESCRIPTION
`pgtap` and `supautils` don't support multiversion (yet), so we need to
fix their drv name to be able to build them through the legacyPackage
set.
