### PR TITLE
feat: exclude nixos-test builds on x86_64-linux from GitHub matrix

### DIFF
--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -396,7 +396,7 @@
             pg_regress
             ;
         }
-        // pkgs.lib.optionalAttrs (system == "aarch64-linux") (
+        // pkgs.lib.optionalAttrs (pkgs.stdenv.isLinux) (
           {
             inherit (self'.packages)
               postgresql_15_debug

--- a/nix/packages/github-matrix/github_matrix.py
+++ b/nix/packages/github-matrix/github_matrix.py
@@ -148,6 +148,11 @@ def parse_nix_eval_line(
             return Err({"attr": data["attr"], "error": error_msg})
         if data["drvPath"] in drv_paths:
             return Ok(None)
+        if (
+            "nixos-test" in data.get("requiredSystemFeatures", [])
+            and data["system"] == "x86_64-linux"
+        ):
+            return Ok(None)
         drv_paths.add(data["drvPath"])
         return Ok(data)
     except json.JSONDecodeError as e:


### PR DESCRIPTION
We want to build nixos-test only on aarch64-linux in CI. 
We still want to enable developers to run nixos-test builds locally on x86_64-linux, but we don't want these builds to be triggered automatically in CI.