### PR TITLE
docs: updated nix directory structure

### DIFF
--- a/nix/docs/nix-directory-structure.md
+++ b/nix/docs/nix-directory-structure.md
@@ -107,6 +107,7 @@ Directory containing custom package definitions such as:
   - `start-replica.nix` - Replication tools
   - `migrate-tool.nix` - Migration utilities
   - `dbmate-tool.nix` - Database migration tool
+  - `postgres.nix` - Postgres extension registry and ourExtensions list
 
 #### `nix/checks.nix`
 
@@ -132,7 +133,6 @@ PostgreSQL package definitions:
 
 PostgreSQL extensions:
 
-- `default.nix` - Extension registry and ourExtensions list
 - Individual `.nix` files - Extension definitions like:
   - `pgvector.nix` - Vector similarity search
   - `pgsodium.nix` - Encryption extension


### PR DESCRIPTION
## What kind of change does this PR introduce?

Updates the Nix Directory Structure documentation.

## What is the current behavior?

Closes #1957

The current doc says there exists default.nix file under nix/ext/ and it contains extension registry:

> default.nix` - Extension registry and ourExtensions list

but default.nix does not exist in nix/ext/ and ourExtensions list exists in [nix/packages/postgres.nix](https://github.com/supabase/postgres/blob/36ff81cc2712a254acbb619a20268cc5ea45d32e/nix/packages/postgres.nix#L15)

## What is the new behavior?

- Added `postgres.nix` under `nix/packages/`
- Removed `default.nix` under `nix/ext/`