### PR TITLE
chore: add monthly flake.lock inputs update workflow

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -1,0 +1,24 @@
+name: Update Flake Lock
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+  update-flake-lock:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: ./.github/actions/nix-install-ephemeral
+
+      - name: Update flake.lock
+        uses: Mic92/update-flake-inputs@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-labels: |
+            dependencies
+            automated

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -8,17 +8,26 @@ on:
 jobs:
   update-flake-lock:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install Nix
         uses: ./.github/actions/nix-install-ephemeral
 
-      - name: Update flake.lock
-        uses: Mic92/update-flake-inputs@main
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          app-id: ${{ secrets.FLAKE_UPDATE_APP_ID }}
+          private-key: ${{ secrets.FLAKE_UPDATE_PRIVATE_KEY }}
+
+      - name: Update flake.lock
+        uses: Mic92/update-flake-inputs@73cb58f118541b956f5a061d12838ef1dd997867 # v1.0.3
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
           pr-labels: |
             dependencies
             automated


### PR DESCRIPTION
Adds GitHub Action to automatically update `flake.lock` every Month. Uses  [Mic92/update-flake-inputs](https://github.com/Mic92/update-flake-inputs) to create PRs with updated dependencies, preventing large, painful updates like the recent 2-year gap... https://github.com/supabase/postgres/pull/1714

Targets develop branch with automated and dependencies labels. Can also be triggered manually via `workflow_dispatch`.

The workflow is configured with `GITHUB_TOKEN` which works but **won't trigger CI workflows** on the created pull requests (GitHub prevents this to avoid infinite loops).

For CI workflows to run on the created PRs, you should set up a GitHub App:

1. **Easy setup**: Use the [web interface](https://mic92.github.io/update-flake-inputs/) to create a GitHub App with correct permissions
2. **Configure secrets**: Save the App ID as `APP_ID` and private key as `APP_PRIVATE_KEY` in repository secrets
3. **Update workflow**: Replace the `github-token` step to use the GitHub App token

See the [full documentation](https://github.com/Mic92/update-flake-inputs#using-with-github-app-token-recommended) for detailed instructions.

The current basic setup will work fine for creating PRs, the GitHub App is only needed if you want CI to automatically run on those PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow to update the project's lockfile and keep dependencies current.
  * Runs monthly and can be triggered manually; will open automated pull requests with appropriate labels to review and merge updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->