### PR TITLE
fix: tmp alias until internal pr merges on admin-mgr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ common-nix.vars.pkr.hcl
 # pre-commit config is managed in nix
 .pre-commit-config.yaml
 nixos.qcow2
+.lsp
+.clj-kondo

--- a/ansible/files/pgbouncer_config/pgbouncer.service.j2
+++ b/ansible/files/pgbouncer_config/pgbouncer.service.j2
@@ -4,8 +4,8 @@ Documentation=man:pgbouncer(1)
 Documentation=https://www.pgbouncer.org/
 After=network.target
 {% if supabase_internal is defined %}
-Requires=database-optimizations.service
-After=database-optimizations.service
+Requires=database_optimizations.service
+After=database_optimizations.service
 {% endif %}
 
 [Service]

--- a/ansible/tasks/setup-wal-g.yml
+++ b/ansible/tasks/setup-wal-g.yml
@@ -76,3 +76,11 @@
         mode: '0664'
         owner: 'postgres'
         src: 'files/postgresql_config/conf.d/wal-g.conf'
+
+    - name: Create symlink for admin-mgr compatibility
+      ansible.builtin.file:
+        src: '/etc/postgresql-custom/conf.d/wal-g.conf'
+        dest: '/etc/postgresql-custom/wal-g.conf'
+        state: 'link'
+        owner: 'postgres'
+        group: 'postgres'

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.023-orioledb-wal-g"
-  postgres17: "17.6.1.066-wal-g"
-  postgres15: "15.14.1.066-wal-g"
+  postgresorioledb-17: "17.6.0.023-orioledb-wal-g-1"
+  postgres17: "17.6.1.066-wal-g-1"
+  postgres15: "15.14.1.066-wal-g-1"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.19.0

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.023-orioledb-wal-g-1"
-  postgres17: "17.6.1.066-wal-g-1"
-  postgres15: "15.14.1.066-wal-g-1"
+  postgresorioledb-17: "17.6.0.023-orioledb"
+  postgres17: "17.6.1.066"
+  postgres15: "15.14.1.066"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.19.0

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.022-orioledb"
-  postgres17: "17.6.1.065"
-  postgres15: "15.14.1.065"
+  postgresorioledb-17: "17.6.0.023-orioledb-wal-g"
+  postgres17: "17.6.1.066-wal-g"
+  postgres15: "15.14.1.066-wal-g"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.19.0

--- a/audit-specs/baselines/ami-build/service.yml
+++ b/audit-specs/baselines/ami-build/service.yml
@@ -116,7 +116,7 @@ service:
   supabase-admin-agent_salt:
     enabled: false
     running: false
-  database-optimizations:
+  database_optimizations:
     enabled: false
     running: false
   postgrest-optimizations:

--- a/audit-specs/baselines/baseline.yml
+++ b/audit-specs/baselines/baseline.yml
@@ -5461,7 +5461,7 @@ file:
     owner: "0"
     group: "0"
     filetype: file
-  /etc/systemd/system/database-optimizations.service:
+  /etc/systemd/system/database_optimizations.service:
     exists: true
     mode: "0644"
     owner: "0"
@@ -95424,7 +95424,7 @@ service:
   cron:
     enabled: true
     running: true
-  database-optimizations:
+  database_optimizations:
     enabled: false
     running: false
   dbus:

--- a/audit-specs/baselines/prod-deployed/files-systemd-deployed.yml
+++ b/audit-specs/baselines/prod-deployed/files-systemd-deployed.yml
@@ -55,7 +55,7 @@ file:
     group: '0'
     mode: '0644'
     owner: '0'
-  /etc/systemd/system/database-optimizations.service:
+  /etc/systemd/system/database_optimizations.service:
     exists: true
     filetype: file
     group: '0'

--- a/audit-specs/baselines/prod-deployed/service-deployed.yml
+++ b/audit-specs/baselines/prod-deployed/service-deployed.yml
@@ -46,7 +46,7 @@ service:
   cron:
     enabled: true
     running: true
-  database-optimizations:
+  database_optimizations:
     enabled: false
     running: false
   dbus:


### PR DESCRIPTION
We have an impending update to wal-g that will correct where it finds paths for config. In the mean time we'll add this alias to make sure wal-g starts

This PR also fixes pgbouncer mis config issue