### PR TITLE
fix: create some compat aliases for services that look for config

### DIFF
--- a/ansible/tasks/setup-postgres.yml
+++ b/ansible/tasks/setup-postgres.yml
@@ -175,6 +175,22 @@
         group: 'postgres'
         src: 'files/postgresql_config/conf.d/read_replica.conf'
 
+    - name: Create symlink for admin-mgr compatibility
+      ansible.builtin.file:
+        src: '/etc/postgresql-custom/conf.d/read_replica.conf'
+        dest: '/etc/postgresql-custom/read-replica.conf'
+        state: 'link'
+        owner: 'postgres'
+        group: 'postgres'
+
+    - name: Create symlink for supabase-admin-api compatibility
+      ansible.builtin.file:
+        src: '/etc/postgresql-custom/conf.d/custom_overrides.conf'
+        dest: '/etc/postgresql-custom/custom-overrides.conf'
+        state: 'link'
+        owner: 'postgres'
+        group: 'postgres'
+
 # Install extensions before init
 - name: Install Postgres extensions
   ansible.builtin.import_tasks:

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.023-orioledb"
-  postgres17: "17.6.1.066"
-  postgres15: "15.14.1.066"
+  postgresorioledb-17: "17.6.0.023-orioledb-path-1"
+  postgres17: "17.6.1.066-path-1"
+  postgres15: "15.14.1.066-path-1"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.19.0


### PR DESCRIPTION
will follow up with PR on these services to change where they look

  The PostgreSQL configuration was refactored to use include_dir = '/etc/postgresql-custom/conf.d' which auto-includes all .conf files from that directory. This replaced explicit include statements for individual config files.

  However, other services (admin-mgr, supabase-admin-api) still write configuration to the old paths in the parent directory (/etc/postgresql-custom/). Files written there are not auto-included by PostgreSQL.

  Added symlinks to maintain backward compatibility:

  - /etc/postgresql-custom/read-replica.conf → conf.d/read_replica.conf
    - admin-mgr writes to the old path when configuring read replicas
  - /etc/postgresql-custom/custom-overrides.conf → conf.d/custom_overrides.conf
    - supabase-admin-api writes custom PostgreSQL settings to the old path

  These symlinks allow other services to continue using their existing paths while ensuring the configuration is actually loaded via the new include_dir mechanism.