### PR TITLE
fix(adminapi): update adminapi to disable caching on internal metrics endpoint

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -53,7 +53,7 @@ postgres_exporter_release_checksum:
   arm64: sha256:29ba62d538b92d39952afe12ee2e1f4401250d678ff4b354ff2752f4321c87a0
   amd64: sha256:cb89fc5bf4485fb554e0d640d9684fae143a4b2d5fa443009bd29c59f9129e84
 
-adminapi_release: "0.94.0"
+adminapi_release: "0.95.1"
 adminmgr_release: "0.32.3"
 supabase_admin_agent_release: 1.6.0
 supabase_admin_agent_splay: 30s


### PR DESCRIPTION
Part of INOPS-673

## What kind of change does this PR introduce?

This will disable caching on /metrics/aggregated.

## What is the current behavior?

Configurable caching shared by customer collection endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated admin API component to version 0.95.1.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->