### PR TITLE
feat: enable nixosTest on aarch64 darwin

### DIFF
--- a/nix/cargo-pgrx/mkPgrxExtension.nix
+++ b/nix/cargo-pgrx/mkPgrxExtension.nix
@@ -42,7 +42,7 @@ let
           import (builtins.fetchTarball {
             url = "https://channels.nixos.org/nixos-22.11/nixexprs.tar.xz";
             sha256 = "1j7h75a9hwkkm97jicky5rhvzkdwxsv5v46473rl6agvq2sj97y1";
-          }) { system = stdenv.hostPlatform.system; }
+          }) { inherit (stdenv.hostPlatform) system; }
         );
       in
       rustPlatform.bindgenHook.overrideAttrs {

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -439,21 +439,19 @@
             ;
           devShell = self'.devShells.default;
         }
-        // pkgs.lib.optionalAttrs (pkgs.stdenv.isLinux) (
-          {
-            inherit (self'.packages)
-              postgresql_15_debug
-              postgresql_15_src
-              postgresql_orioledb-17_debug
-              postgresql_orioledb-17_src
-              postgresql_17_debug
-              postgresql_17_src
-              ;
-          }
-          // (import ./ext/tests {
-            inherit self;
-            inherit pkgs;
-          })
-        );
+        // (import ./ext/tests {
+          inherit self;
+          inherit pkgs;
+        })
+        // pkgs.lib.optionalAttrs (pkgs.stdenv.isLinux) {
+          inherit (self'.packages)
+            postgresql_15_debug
+            postgresql_15_src
+            postgresql_orioledb-17_debug
+            postgresql_orioledb-17_src
+            postgresql_17_debug
+            postgresql_17_src
+            ;
+        };
     };
 }

--- a/nix/ext/tests/default.nix
+++ b/nix/ext/tests/default.nix
@@ -25,7 +25,7 @@ let
         let
           majorVersion =
             if postgresql.isOrioleDB then "orioledb-17" else lib.versions.major postgresql.version;
-          pkg = pkgs.buildEnv {
+          pkg = pkgs.pkgsLinux.buildEnv {
             name = "postgresql-${majorVersion}-${pname}";
             paths = [
               postgresql
@@ -42,7 +42,7 @@ let
               withoutJIT = pkg;
               installedExtensions = [ (installedExtension majorVersion) ];
             };
-            nativeBuildInputs = [ pkgs.makeWrapper ];
+            nativeBuildInputs = [ pkgs.pkgsLinux.makeWrapper ];
             pathsToLink = [
               "/"
               "/bin"
@@ -56,15 +56,18 @@ let
           };
         in
         pkg;
-      psql_15 = postgresqlWithExtension self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_15;
-      psql_17 = postgresqlWithExtension self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_17;
+      psql_15 =
+        postgresqlWithExtension
+          self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_15;
+      psql_17 =
+        postgresqlWithExtension
+          self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_17;
       orioledb_17 =
         postgresqlWithExtension
           self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_orioledb-17;
     in
-    self.inputs.nixpkgs.lib.nixos.runTest {
+    pkgs.testers.runNixOSTest {
       name = pname;
-      hostPkgs = pkgs;
       nodes.server =
         { config, ... }:
         {

--- a/nix/ext/tests/default.nix
+++ b/nix/ext/tests/default.nix
@@ -16,7 +16,7 @@ let
 
       installedExtension =
         postgresMajorVersion:
-        self.legacyPackages.${pkgs.stdenv.hostPlatform.system}."psql_${postgresMajorVersion}".exts."${
+        self.legacyPackages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}."psql_${postgresMajorVersion}".exts."${
           pname
         }";
       versions = postgresqlMajorVersion: (installedExtension postgresqlMajorVersion).versions;
@@ -33,7 +33,7 @@ let
               (installedExtension majorVersion)
             ]
             ++ lib.optional (postgresql.isOrioleDB
-            ) self.legacyPackages.${pkgs.stdenv.hostPlatform.system}.psql_orioledb-17.exts.orioledb;
+            ) self.legacyPackages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.psql_orioledb-17.exts.orioledb;
             passthru = {
               inherit (postgresql) version psqlSchema;
               lib = pkg;
@@ -64,7 +64,7 @@ let
           self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_17;
       orioledb_17 =
         postgresqlWithExtension
-          self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_orioledb-17;
+          self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_orioledb-17;
     in
     pkgs.testers.runNixOSTest {
       name = pname;
@@ -147,7 +147,8 @@ let
           specialisation.orioledb17.configuration = {
             services.postgresql = {
               package = lib.mkForce (
-                postgresqlWithExtension self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_orioledb-17
+                postgresqlWithExtension
+                  self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_orioledb-17
               );
               settings = lib.mkForce (
                 ((installedExtension "17").defaultSettings or { })
@@ -185,7 +186,7 @@ let
                 let
                   newPostgresql =
                     postgresqlWithExtension
-                      self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_orioledb-17;
+                      self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_orioledb-17;
                 in
                 ''
                   if [[ -z "${newPostgresql.psqlSchema}" ]]; then

--- a/nix/ext/tests/default.nix
+++ b/nix/ext/tests/default.nix
@@ -71,15 +71,6 @@ let
       nodes.server =
         { config, ... }:
         {
-          virtualisation = {
-            forwardPorts = [
-              {
-                from = "host";
-                host.port = 13022;
-                guest.port = 22;
-              }
-            ];
-          };
           services.openssh = {
             enable = true;
           };

--- a/nix/ext/tests/http.nix
+++ b/nix/ext/tests/http.nix
@@ -55,15 +55,6 @@ pkgs.testers.runNixOSTest {
   nodes.server =
     { config, ... }:
     {
-      virtualisation = {
-        forwardPorts = [
-          {
-            from = "host";
-            host.port = 13022;
-            guest.port = 22;
-          }
-        ];
-      };
       services.openssh = {
         enable = true;
       };

--- a/nix/ext/tests/http.nix
+++ b/nix/ext/tests/http.nix
@@ -2,9 +2,10 @@
 let
   pname = "http";
   inherit (pkgs) lib;
+  mockServer = ../../tests/http-mock-server.py;
   installedExtension =
     postgresMajorVersion:
-    self.legacyPackages.${pkgs.stdenv.hostPlatform.system}."psql_${postgresMajorVersion}".exts."${
+    self.legacyPackages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}."psql_${postgresMajorVersion}".exts."${
       pname
     }";
   versions = postgresqlMajorVersion: (installedExtension postgresqlMajorVersion).versions;
@@ -21,7 +22,7 @@ let
           (installedExtension majorVersion)
         ]
         ++ lib.optional (postgresql.isOrioleDB
-        ) self.legacyPackages.${pkgs.stdenv.hostPlatform.system}.psql_orioledb-17.exts.orioledb;
+        ) self.legacyPackages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.psql_orioledb-17.exts.orioledb;
         passthru = {
           inherit (postgresql) version psqlSchema;
           installedExtensions = [ (installedExtension majorVersion) ];
@@ -44,11 +45,15 @@ let
       };
     in
     pkg;
-  psql_15 = postgresqlWithExtension self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_15;
-  psql_17 = postgresqlWithExtension self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_17;
+  psql_15 =
+    postgresqlWithExtension
+      self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_15;
+  psql_17 =
+    postgresqlWithExtension
+      self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_17;
   orioledb_17 =
     postgresqlWithExtension
-      self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_orioledb-17;
+      self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_orioledb-17;
 in
 pkgs.testers.runNixOSTest {
   name = pname;
@@ -61,7 +66,9 @@ pkgs.testers.runNixOSTest {
 
       services.postgresql = {
         enable = true;
-        package = postgresqlWithExtension self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_15;
+        package =
+          postgresqlWithExtension
+            self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_15;
         settings = (installedExtension "15").defaultSettings or { };
         authentication = ''
           local all postgres peer map=postgres
@@ -79,18 +86,34 @@ pkgs.testers.runNixOSTest {
         ];
         initialScript = pkgs.writeText "init-postgres" ''
           CREATE TABLE IF NOT EXISTS test_config (key TEXT PRIMARY KEY, value TEXT);
-          INSERT INTO test_config (key, value) VALUES ('http_mock_port', '8880') ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value;
         '';
       };
 
       systemd.services.http-mock-server = {
         wantedBy = [ "multi-user.target" ];
+        before = [ "postgresql.service" ];
         serviceConfig = {
           Type = "simple";
+          Restart = "on-failure";
+          RestartSec = "2";
+          TimeoutStartSec = "30";
+          User = "root";
+        };
+        environment = {
+          HTTP_MOCK_PORT_FILE = "/tmp/http-mock-port";
+          PYTHONUNBUFFERED = "1";
         };
         script = ''
-          ${pkgs.python3}/bin/python3 ${../../tests/http-mock-server.py}
+          # Ensure temp directory exists
+          mkdir -p /tmp
+
+          # Start the mock server
+          exec ${pkgs.pkgsLinux.python3}/bin/python3 ${mockServer}
         '';
+      };
+
+      systemd.services.postgresql = {
+        after = [ "http-mock-server.service" ];
       };
 
       specialisation.postgresql17.configuration = {
@@ -142,7 +165,8 @@ pkgs.testers.runNixOSTest {
       specialisation.orioledb17.configuration = {
         services.postgresql = {
           package = lib.mkForce (
-            postgresqlWithExtension self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_orioledb-17
+            postgresqlWithExtension
+              self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_orioledb-17
           );
           settings = lib.mkForce (
             ((installedExtension "17").defaultSettings or { })
@@ -165,7 +189,6 @@ pkgs.testers.runNixOSTest {
             pkgs.writeText "init-postgres-with-orioledb" ''
               CREATE EXTENSION orioledb CASCADE;
               CREATE TABLE IF NOT EXISTS test_config (key TEXT PRIMARY KEY, value TEXT);
-              INSERT INTO test_config (key, value) VALUES ('http_mock_port', '8880') ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value;
             ''
           );
         };
@@ -184,7 +207,7 @@ pkgs.testers.runNixOSTest {
             let
               newPostgresql =
                 postgresqlWithExtension
-                  self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_orioledb-17;
+                  self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_orioledb-17;
             in
             ''
               if [[ -z "${newPostgresql.psqlSchema}" ]]; then
@@ -233,7 +256,36 @@ pkgs.testers.runNixOSTest {
       start_all()
 
       server.wait_for_unit("multi-user.target")
+      server.wait_for_unit("http-mock-server.service")
       server.wait_for_unit("postgresql.service")
+
+      # Read the HTTP mock port and configure it in PostgreSQL
+      # Wait for the port file to be created with retry logic
+      server.succeed("""
+        for i in {1..30}; do
+          if [ -f /tmp/http-mock-port ]; then
+            break
+          fi
+          echo "Waiting for HTTP mock server port file... ($i/30)"
+          sleep 1
+        done
+        
+        if [ ! -f /tmp/http-mock-port ]; then
+          echo "ERROR: HTTP mock server port file not found after 30 seconds"
+          systemctl status http-mock-server.service || true
+          journalctl -u http-mock-server.service --no-pager || true
+          exit 1
+        fi
+      """)
+
+      http_port = server.succeed("cat /tmp/http-mock-port").strip()
+      server.succeed(f"""
+        sudo -u postgres psql -d postgres -c '
+          CREATE TABLE IF NOT EXISTS test_config (key TEXT PRIMARY KEY, value TEXT);
+          INSERT INTO test_config (key, value) VALUES ('"'"'http_mock_port'"'"', '"'"'{http_port}'"'"')
+          ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value;
+        '
+      """)
 
       test = PostgresExtensionTest(server, extension_name, versions, sql_test_directory, support_upgrade, ext_schema, lib_name)
       test.create_schema()
@@ -259,6 +311,14 @@ pkgs.testers.runNixOSTest {
         server.succeed(
           "${pg17-configuration}/bin/switch-to-configuration test >&2"
         )
+        server.wait_for_unit("postgresql.service")
+        # Reconfigure the HTTP mock port after switching PostgreSQL version
+        server.succeed(f"""
+          sudo -u postgres psql -d postgres -c '
+            INSERT INTO test_config (key, value) VALUES ('"'"'http_mock_port'"'"', '"'"'{http_port}'"'"')
+            ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value;
+          '
+        """)
 
       with subtest("Check last version of the extension after postgresql upgrade"):
         test.assert_version_matches(last_version)
@@ -279,6 +339,14 @@ pkgs.testers.runNixOSTest {
         server.succeed(
           "${orioledb17-configuration}/bin/switch-to-configuration test >&2"
         )
+        server.wait_for_unit("postgresql.service")
+        # Reconfigure the HTTP mock port after switching to orioledb
+        server.succeed(f"""
+          sudo -u postgres psql -d postgres -c '
+            INSERT INTO test_config (key, value) VALUES ('"'"'http_mock_port'"'"', '"'"'{http_port}'"'"')
+            ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value;
+          '
+        """)
         installed_extensions=test.run_sql("""SELECT extname FROM pg_extension WHERE extname = 'orioledb';""")
         assert "orioledb" in installed_extensions
         test.create_schema()

--- a/nix/ext/tests/http.nix
+++ b/nix/ext/tests/http.nix
@@ -13,7 +13,7 @@ let
     let
       majorVersion =
         if postgresql.isOrioleDB then "orioledb-17" else lib.versions.major postgresql.version;
-      pkg = pkgs.buildEnv {
+      pkg = pkgs.pkgsLinux.buildEnv {
         name = "postgresql-${majorVersion}-${pname}";
         paths = [
           postgresql
@@ -30,7 +30,7 @@ let
           withJIT = pkg;
           withoutJIT = pkg;
         };
-        nativeBuildInputs = [ pkgs.makeWrapper ];
+        nativeBuildInputs = [ pkgs.pkgsLinux.makeWrapper ];
         pathsToLink = [
           "/"
           "/bin"
@@ -50,9 +50,8 @@ let
     postgresqlWithExtension
       self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_orioledb-17;
 in
-self.inputs.nixpkgs.lib.nixos.runTest {
+pkgs.testers.runNixOSTest {
   name = pname;
-  hostPkgs = pkgs;
   nodes.server =
     { config, ... }:
     {
@@ -106,7 +105,7 @@ self.inputs.nixpkgs.lib.nixos.runTest {
       specialisation.postgresql17.configuration = {
         services.postgresql = {
           package = lib.mkForce (
-            postgresqlWithExtension self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_17
+            postgresqlWithExtension self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_17
           );
           settings = ((installedExtension "17").defaultSettings or { });
         };
@@ -124,10 +123,10 @@ self.inputs.nixpkgs.lib.nixos.runTest {
             let
               oldPostgresql =
                 postgresqlWithExtension
-                  self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_15;
+                  self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_15;
               newPostgresql =
                 postgresqlWithExtension
-                  self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_17;
+                  self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_17;
               oldDataDir = "${builtins.dirOf config.services.postgresql.dataDir}/${oldPostgresql.psqlSchema}";
               newDataDir = "${builtins.dirOf config.services.postgresql.dataDir}/${newPostgresql.psqlSchema}";
             in

--- a/nix/ext/tests/orioledb.nix
+++ b/nix/ext/tests/orioledb.nix
@@ -6,24 +6,24 @@ let
     postgresql:
     let
       majorVersion = lib.versions.major postgresql.version;
-      pkg = pkgs.buildEnv {
+      pkg = pkgs.pkgsLinux.buildEnv {
         name = "postgresql-${majorVersion}-${pname}";
         paths = [
           postgresql
           postgresql.lib
-          (self.legacyPackages.${pkgs.stdenv.hostPlatform.system}."psql_orioledb-17".exts.orioledb)
+          (self.legacyPackages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}."psql_orioledb-17".exts.orioledb)
         ];
         passthru = {
           inherit (postgresql) version psqlSchema;
           installedExtensions = [
-            (self.legacyPackages.${pkgs.stdenv.hostPlatform.system}."psql_orioledb-17".exts.orioledb)
+            (self.legacyPackages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}."psql_orioledb-17".exts.orioledb)
           ];
           lib = pkg;
           withPackages = _: pkg;
           withJIT = pkg;
           withoutJIT = pkg;
         };
-        nativeBuildInputs = [ pkgs.makeWrapper ];
+        nativeBuildInputs = [ pkgs.pkgsLinux.makeWrapper ];
         pathsToLink = [
           "/"
           "/bin"
@@ -39,11 +39,10 @@ let
     pkg;
   psql_orioledb =
     postgresqlWithExtension
-      self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_orioledb-17;
+      self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_orioledb-17;
 in
-self.inputs.nixpkgs.lib.nixos.runTest {
+pkgs.testers.runNixOSTest {
   name = pname;
-  hostPkgs = pkgs;
   nodes.server =
     { ... }:
     {

--- a/nix/ext/tests/orioledb.nix
+++ b/nix/ext/tests/orioledb.nix
@@ -46,15 +46,6 @@ pkgs.testers.runNixOSTest {
   nodes.server =
     { ... }:
     {
-      virtualisation = {
-        forwardPorts = [
-          {
-            from = "host";
-            host.port = 13022;
-            guest.port = 22;
-          }
-        ];
-      };
       services.openssh = {
         enable = true;
       };

--- a/nix/ext/tests/pg_plan_filter.nix
+++ b/nix/ext/tests/pg_plan_filter.nix
@@ -4,7 +4,7 @@ let
   inherit (pkgs) lib;
   installedExtension =
     postgresMajorVersion:
-    self.legacyPackages.${pkgs.stdenv.hostPlatform.system}."psql_${postgresMajorVersion}".exts."${
+    self.legacyPackages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}."psql_${postgresMajorVersion}".exts."${
       pname
     }";
   versions = postgresqlMajorVersion: (installedExtension postgresqlMajorVersion).versions;
@@ -12,7 +12,7 @@ let
     postgresql:
     let
       majorVersion = lib.versions.major postgresql.version;
-      pkg = pkgs.buildEnv {
+      pkg = pkgs.pkgsLinux.buildEnv {
         name = "postgresql-${majorVersion}-${pname}";
         paths = [
           postgresql
@@ -27,7 +27,7 @@ let
           withJIT = pkg;
           withoutJIT = pkg;
         };
-        nativeBuildInputs = [ pkgs.makeWrapper ];
+        nativeBuildInputs = [ pkgs.pkgsLinux.makeWrapper ];
         pathsToLink = [
           "/"
           "/bin"
@@ -41,12 +41,15 @@ let
       };
     in
     pkg;
-  psql_15 = postgresqlWithExtension self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_15;
-  psql_17 = postgresqlWithExtension self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_17;
+  psql_15 =
+    postgresqlWithExtension
+      self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_15;
+  psql_17 =
+    postgresqlWithExtension
+      self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_17;
 in
-self.inputs.nixpkgs.lib.nixos.runTest {
+pkgs.testers.runNixOSTest {
   name = pname;
-  hostPkgs = pkgs;
   nodes.server =
     { config, ... }:
     {

--- a/nix/ext/tests/pg_plan_filter.nix
+++ b/nix/ext/tests/pg_plan_filter.nix
@@ -55,7 +55,7 @@ pkgs.testers.runNixOSTest {
     {
       services.postgresql = {
         enable = true;
-        package = (postgresqlWithExtension psql_15);
+        package = psql_15;
         settings = (installedExtension "15").defaultSettings or { };
       };
 

--- a/nix/ext/tests/pg_repack.nix
+++ b/nix/ext/tests/pg_repack.nix
@@ -47,15 +47,6 @@ pkgs.testers.runNixOSTest {
   nodes.server =
     { config, ... }:
     {
-      virtualisation = {
-        forwardPorts = [
-          {
-            from = "host";
-            host.port = 13022;
-            guest.port = 22;
-          }
-        ];
-      };
       services.openssh = {
         enable = true;
       };

--- a/nix/ext/tests/pg_repack.nix
+++ b/nix/ext/tests/pg_repack.nix
@@ -4,7 +4,7 @@ let
   inherit (pkgs) lib;
   installedExtension =
     postgresMajorVersion:
-    self.legacyPackages.${pkgs.stdenv.hostPlatform.system}."psql_${postgresMajorVersion}".exts."${
+    self.legacyPackages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}."psql_${postgresMajorVersion}".exts."${
       pname
     }";
   versions = postgresqlMajorVersion: (installedExtension postgresqlMajorVersion).versions;
@@ -12,7 +12,7 @@ let
     postgresql:
     let
       majorVersion = lib.versions.major postgresql.version;
-      pkg = pkgs.buildEnv {
+      pkg = pkgs.pkgsLinux.buildEnv {
         name = "postgresql-${majorVersion}-${pname}";
         paths = [
           postgresql
@@ -27,7 +27,7 @@ let
           withJIT = pkg;
           withoutJIT = pkg;
         };
-        nativeBuildInputs = [ pkgs.makeWrapper ];
+        nativeBuildInputs = [ pkgs.pkgsLinux.makeWrapper ];
         pathsToLink = [
           "/"
           "/bin"
@@ -42,9 +42,8 @@ let
     in
     pkg;
 in
-self.inputs.nixpkgs.lib.nixos.runTest {
+pkgs.testers.runNixOSTest {
   name = pname;
-  hostPkgs = pkgs;
   nodes.server =
     { config, ... }:
     {
@@ -63,7 +62,9 @@ self.inputs.nixpkgs.lib.nixos.runTest {
 
       services.postgresql = {
         enable = true;
-        package = postgresqlWithExtension self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_15;
+        package =
+          postgresqlWithExtension
+            self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_15;
         enableTCPIP = true;
         authentication = ''
           local all postgres peer map=postgres
@@ -86,7 +87,7 @@ self.inputs.nixpkgs.lib.nixos.runTest {
       specialisation.postgresql17.configuration = {
         services.postgresql = {
           package = lib.mkForce (
-            postgresqlWithExtension self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_17
+            postgresqlWithExtension self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_17
           );
         };
 
@@ -103,10 +104,10 @@ self.inputs.nixpkgs.lib.nixos.runTest {
             let
               oldPostgresql =
                 postgresqlWithExtension
-                  self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_15;
+                  self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_15;
               newPostgresql =
                 postgresqlWithExtension
-                  self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_17;
+                  self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_17;
               oldDataDir = "${builtins.dirOf config.services.postgresql.dataDir}/${oldPostgresql.psqlSchema}";
               newDataDir = "${builtins.dirOf config.services.postgresql.dataDir}/${newPostgresql.psqlSchema}";
             in

--- a/nix/ext/tests/pg_safeupdate.nix
+++ b/nix/ext/tests/pg_safeupdate.nix
@@ -4,7 +4,7 @@ let
   inherit (pkgs) lib;
   installedExtension =
     postgresMajorVersion:
-    self.legacyPackages.${pkgs.stdenv.hostPlatform.system}."psql_${postgresMajorVersion}".exts."${
+    self.legacyPackages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}."psql_${postgresMajorVersion}".exts."${
       pname
     }";
   versions = postgresqlMajorVersion: (installedExtension postgresqlMajorVersion).versions;
@@ -12,7 +12,7 @@ let
     postgresql:
     let
       majorVersion = lib.versions.major postgresql.version;
-      pkg = pkgs.buildEnv {
+      pkg = pkgs.pkgsLinux.buildEnv {
         name = "postgresql-${majorVersion}-${pname}";
         paths = [
           postgresql
@@ -27,7 +27,7 @@ let
           withJIT = pkg;
           withoutJIT = pkg;
         };
-        nativeBuildInputs = [ pkgs.makeWrapper ];
+        nativeBuildInputs = [ pkgs.pkgsLinux.makeWrapper ];
         pathsToLink = [
           "/"
           "/bin"
@@ -41,12 +41,15 @@ let
       };
     in
     pkg;
-  psql_15 = postgresqlWithExtension self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_15;
-  psql_17 = postgresqlWithExtension self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_17;
+  psql_15 =
+    postgresqlWithExtension
+      self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_15;
+  psql_17 =
+    postgresqlWithExtension
+      self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_17;
 in
-self.inputs.nixpkgs.lib.nixos.runTest {
+pkgs.testers.runNixOSTest {
   name = pname;
-  hostPkgs = pkgs;
   nodes.server =
     { config, ... }:
     {

--- a/nix/ext/tests/pg_safeupdate.nix
+++ b/nix/ext/tests/pg_safeupdate.nix
@@ -55,7 +55,7 @@ pkgs.testers.runNixOSTest {
     {
       services.postgresql = {
         enable = true;
-        package = (postgresqlWithExtension psql_15);
+        package = psql_15;
         settings = (installedExtension "15").defaultSettings or { };
       };
 

--- a/nix/ext/tests/pgjwt.nix
+++ b/nix/ext/tests/pgjwt.nix
@@ -53,16 +53,6 @@ pkgs.testers.runNixOSTest {
   nodes.server =
     { config, ... }:
     {
-      virtualisation = {
-        forwardPorts = [
-          {
-            from = "host";
-            host.port = 13022;
-            guest.port = 22;
-          }
-        ];
-      };
-
       services.postgresql = {
         enable = true;
         package = psql_15;

--- a/nix/ext/tests/pgjwt.nix
+++ b/nix/ext/tests/pgjwt.nix
@@ -4,7 +4,7 @@ let
   inherit (pkgs) lib;
   installedExtension =
     postgresMajorVersion:
-    self.legacyPackages.${pkgs.stdenv.hostPlatform.system}."psql_${postgresMajorVersion}".exts."${
+    self.legacyPackages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}."psql_${postgresMajorVersion}".exts."${
       pname
     }";
   versions = postgresqlMajorVersion: (installedExtension postgresqlMajorVersion).versions;
@@ -12,7 +12,7 @@ let
     postgresql:
     let
       majorVersion = lib.versions.major postgresql.version;
-      pkg = pkgs.buildEnv {
+      pkg = pkgs.pkgsLinux.buildEnv {
         name = "postgresql-${majorVersion}-${pname}";
         paths = [
           postgresql
@@ -27,7 +27,7 @@ let
           withJIT = pkg;
           withoutJIT = pkg;
         };
-        nativeBuildInputs = [ pkgs.makeWrapper ];
+        nativeBuildInputs = [ pkgs.pkgsLinux.makeWrapper ];
         pathsToLink = [
           "/"
           "/bin"
@@ -41,12 +41,15 @@ let
       };
     in
     pkg;
-  psql_15 = postgresqlWithExtension self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_15;
-  psql_17 = postgresqlWithExtension self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_17;
+  psql_15 =
+    postgresqlWithExtension
+      self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_15;
+  psql_17 =
+    postgresqlWithExtension
+      self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_17;
 in
-self.inputs.nixpkgs.lib.nixos.runTest {
+pkgs.testers.runNixOSTest {
   name = pname;
-  hostPkgs = pkgs;
   nodes.server =
     { config, ... }:
     {

--- a/nix/ext/tests/pgmq.nix
+++ b/nix/ext/tests/pgmq.nix
@@ -4,7 +4,7 @@ let
   inherit (pkgs) lib;
   installedExtension =
     postgresMajorVersion:
-    self.legacyPackages.${pkgs.stdenv.hostPlatform.system}."psql_${postgresMajorVersion}".exts."${
+    self.legacyPackages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}."psql_${postgresMajorVersion}".exts."${
       pname
     }";
   versions = postgresqlMajorVersion: (installedExtension postgresqlMajorVersion).versions;
@@ -12,7 +12,7 @@ let
     postgresql:
     let
       majorVersion = lib.versions.major postgresql.version;
-      pkg = pkgs.buildEnv {
+      pkg = pkgs.pkgsLinux.buildEnv {
         name = "postgresql-${majorVersion}-${pname}";
         paths = [
           postgresql
@@ -27,7 +27,7 @@ let
           withJIT = pkg;
           withoutJIT = pkg;
         };
-        nativeBuildInputs = [ pkgs.makeWrapper ];
+        nativeBuildInputs = [ pkgs.pkgsLinux.makeWrapper ];
         pathsToLink = [
           "/"
           "/bin"
@@ -41,12 +41,15 @@ let
       };
     in
     pkg;
-  psql_15 = postgresqlWithExtension self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_15;
-  psql_17 = postgresqlWithExtension self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_17;
+  psql_15 =
+    postgresqlWithExtension
+      self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_15;
+  psql_17 =
+    postgresqlWithExtension
+      self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_17;
 in
-self.inputs.nixpkgs.lib.nixos.runTest {
+pkgs.testers.runNixOSTest {
   name = "timescaledb";
-  hostPkgs = pkgs;
   nodes.server =
     { config, ... }:
     {

--- a/nix/ext/tests/pgmq.nix
+++ b/nix/ext/tests/pgmq.nix
@@ -49,13 +49,13 @@ let
       self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_17;
 in
 pkgs.testers.runNixOSTest {
-  name = "timescaledb";
+  name = "pgmq";
   nodes.server =
     { config, ... }:
     {
       services.postgresql = {
         enable = true;
-        package = (postgresqlWithExtension psql_15);
+        package = psql_15;
         authentication = ''
           local all postgres peer map=postgres
           local all all peer map=root

--- a/nix/ext/tests/pgroonga.nix
+++ b/nix/ext/tests/pgroonga.nix
@@ -79,7 +79,7 @@ pkgs.testers.runNixOSTest {
       systemd.services.postgresql.environment.MECAB_DICDIR = "${
         self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.mecab-naist-jdic
       }/lib/mecab/dic/naist-jdic";
-      systemd.services.postgresql.environment.MECAB_CONFIG = "${pkgs.mecab}/bin/mecab-config";
+      systemd.services.postgresql.environment.MECAB_CONFIG = "${pkgs.pkgsLinux.mecab}/bin/mecab-config";
       systemd.services.postgresql.environment.GRN_PLUGINS_DIR = "${
         self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.supabase-groonga
       }/lib/groonga/plugins";

--- a/nix/ext/tests/pgroonga.nix
+++ b/nix/ext/tests/pgroonga.nix
@@ -4,7 +4,7 @@ let
   inherit (pkgs) lib;
   installedExtension =
     postgresMajorVersion:
-    self.legacyPackages.${pkgs.stdenv.hostPlatform.system}."psql_${postgresMajorVersion}".exts."${
+    self.legacyPackages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}."psql_${postgresMajorVersion}".exts."${
       pname
     }";
   versions = postgresqlMajorVersion: (installedExtension postgresqlMajorVersion).versions;
@@ -12,7 +12,7 @@ let
     postgresql:
     let
       majorVersion = lib.versions.major postgresql.version;
-      pkg = pkgs.buildEnv {
+      pkg = pkgs.pkgsLinux.buildEnv {
         name = "postgresql-${majorVersion}-${pname}";
         paths = [
           postgresql
@@ -27,7 +27,7 @@ let
           withJIT = pkg;
           withoutJIT = pkg;
         };
-        nativeBuildInputs = [ pkgs.makeWrapper ];
+        nativeBuildInputs = [ pkgs.pkgsLinux.makeWrapper ];
         pathsToLink = [
           "/"
           "/bin"
@@ -41,12 +41,15 @@ let
       };
     in
     pkg;
-  psql_15 = postgresqlWithExtension self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_15;
-  psql_17 = postgresqlWithExtension self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_17;
+  psql_15 =
+    postgresqlWithExtension
+      self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_15;
+  psql_17 =
+    postgresqlWithExtension
+      self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_17;
 in
-self.inputs.nixpkgs.lib.nixos.runTest {
+pkgs.testers.runNixOSTest {
   name = pname;
-  hostPkgs = pkgs;
   nodes.server =
     { config, ... }:
     {
@@ -83,11 +86,11 @@ self.inputs.nixpkgs.lib.nixos.runTest {
         ];
       };
       systemd.services.postgresql.environment.MECAB_DICDIR = "${
-        self.packages.${pkgs.stdenv.hostPlatform.system}.mecab-naist-jdic
+        self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.mecab-naist-jdic
       }/lib/mecab/dic/naist-jdic";
       systemd.services.postgresql.environment.MECAB_CONFIG = "${pkgs.mecab}/bin/mecab-config";
       systemd.services.postgresql.environment.GRN_PLUGINS_DIR = "${
-        self.packages.${pkgs.stdenv.hostPlatform.system}.supabase-groonga
+        self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.supabase-groonga
       }/lib/groonga/plugins";
 
       specialisation.postgresql17.configuration = {

--- a/nix/ext/tests/pgrouting.nix
+++ b/nix/ext/tests/pgrouting.nix
@@ -55,15 +55,6 @@ pkgs.testers.runNixOSTest {
   nodes.server =
     { config, ... }:
     {
-      virtualisation = {
-        forwardPorts = [
-          {
-            from = "host";
-            host.port = 13022;
-            guest.port = 22;
-          }
-        ];
-      };
       services.openssh = {
         enable = true;
       };

--- a/nix/ext/tests/pgrouting.nix
+++ b/nix/ext/tests/pgrouting.nix
@@ -4,7 +4,7 @@ let
   inherit (pkgs) lib;
   installedExtension =
     postgresMajorVersion:
-    self.legacyPackages.${pkgs.stdenv.hostPlatform.system}."psql_${postgresMajorVersion}".exts."${
+    self.legacyPackages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}."psql_${postgresMajorVersion}".exts."${
       pname
     }";
   versions = postgresqlMajorVersion: (installedExtension postgresqlMajorVersion).versions;
@@ -12,16 +12,17 @@ let
     postgresql:
     let
       majorVersion = lib.versions.major postgresql.version;
-      pkg = pkgs.buildEnv {
+      pkg = pkgs.pkgsLinux.buildEnv {
         name = "postgresql-${majorVersion}-${pname}";
         paths = [
           postgresql
           postgresql.lib
           (installedExtension majorVersion)
-          (self.legacyPackages.${pkgs.stdenv.hostPlatform.system}."psql_${majorVersion}".exts.postgis)
+          (self.legacyPackages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}."psql_${majorVersion}".exts.postgis
+          )
         ]
         ++ lib.optional (postgresql.isOrioleDB) (
-          self.legacyPackages.${pkgs.stdenv.hostPlatform.system}."psql_orioledb-17".exts.orioledb
+          self.legacyPackages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}."psql_orioledb-17".exts.orioledb
         );
         passthru = {
           inherit (postgresql) version psqlSchema;
@@ -31,7 +32,7 @@ let
           withJIT = pkg;
           withoutJIT = pkg;
         };
-        nativeBuildInputs = [ pkgs.makeWrapper ];
+        nativeBuildInputs = [ pkgs.pkgsLinux.makeWrapper ];
         pathsToLink = [
           "/"
           "/bin"
@@ -46,12 +47,11 @@ let
     in
     pkg;
   pg_regress = pkgs.callPackage ../pg_regress.nix {
-    postgresql = self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_15;
+    postgresql = self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_15;
   };
 in
-self.inputs.nixpkgs.lib.nixos.runTest {
+pkgs.testers.runNixOSTest {
   name = pname;
-  hostPkgs = pkgs;
   nodes.server =
     { config, ... }:
     {
@@ -73,13 +73,15 @@ self.inputs.nixpkgs.lib.nixos.runTest {
 
       services.postgresql = {
         enable = true;
-        package = postgresqlWithExtension self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_15;
+        package =
+          postgresqlWithExtension
+            self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_15;
       };
 
       specialisation.postgresql17.configuration = {
         services.postgresql = {
           package = lib.mkForce (
-            postgresqlWithExtension self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_17
+            postgresqlWithExtension self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_17
           );
         };
 
@@ -96,10 +98,10 @@ self.inputs.nixpkgs.lib.nixos.runTest {
             let
               oldPostgresql =
                 postgresqlWithExtension
-                  self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_15;
+                  self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_15;
               newPostgresql =
                 postgresqlWithExtension
-                  self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_17;
+                  self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_17;
               oldDataDir = "${builtins.dirOf config.services.postgresql.dataDir}/${oldPostgresql.psqlSchema}";
               newDataDir = "${builtins.dirOf config.services.postgresql.dataDir}/${newPostgresql.psqlSchema}";
             in
@@ -124,7 +126,8 @@ self.inputs.nixpkgs.lib.nixos.runTest {
       specialisation.orioledb17.configuration = {
         services.postgresql = {
           package = lib.mkForce (
-            postgresqlWithExtension self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_orioledb-17
+            postgresqlWithExtension
+              self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_orioledb-17
           );
           settings = {
             shared_preload_libraries = "orioledb";
@@ -155,7 +158,7 @@ self.inputs.nixpkgs.lib.nixos.runTest {
             let
               newPostgresql =
                 postgresqlWithExtension
-                  self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_orioledb-17;
+                  self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_orioledb-17;
             in
             ''
               set -x

--- a/nix/ext/tests/pgsodium.nix
+++ b/nix/ext/tests/pgsodium.nix
@@ -54,16 +54,6 @@ pkgs.testers.runNixOSTest {
   nodes.server =
     { config, ... }:
     {
-      virtualisation = {
-        forwardPorts = [
-          {
-            from = "host";
-            host.port = 13022;
-            guest.port = 22;
-          }
-        ];
-      };
-
       services.postgresql = {
         enable = true;
         package =

--- a/nix/ext/tests/pgsodium.nix
+++ b/nix/ext/tests/pgsodium.nix
@@ -4,7 +4,7 @@ let
   inherit (pkgs) lib;
   installedExtension =
     postgresMajorVersion:
-    self.legacyPackages.${pkgs.stdenv.hostPlatform.system}."psql_${postgresMajorVersion}".exts."${
+    self.legacyPackages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}."psql_${postgresMajorVersion}".exts."${
       pname
     }";
   versions = postgresqlMajorVersion: (installedExtension postgresqlMajorVersion).versions;
@@ -12,13 +12,14 @@ let
     postgresql:
     let
       majorVersion = lib.versions.major postgresql.version;
-      pkg = pkgs.buildEnv {
+      pkg = pkgs.pkgsLinux.buildEnv {
         name = "postgresql-${majorVersion}-${pname}";
         paths = [
           postgresql
           postgresql.lib
           (installedExtension majorVersion)
-          (self.legacyPackages.${pkgs.stdenv.hostPlatform.system}."psql_${majorVersion}".exts.hypopg)
+          (self.legacyPackages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}."psql_${majorVersion}".exts.hypopg
+          )
         ];
         passthru = {
           inherit (postgresql) version psqlSchema;
@@ -28,7 +29,7 @@ let
           withJIT = pkg;
           withoutJIT = pkg;
         };
-        nativeBuildInputs = [ pkgs.makeWrapper ];
+        nativeBuildInputs = [ pkgs.pkgsLinux.makeWrapper ];
         pathsToLink = [
           "/"
           "/bin"
@@ -48,9 +49,8 @@ let
     ''
   );
 in
-self.inputs.nixpkgs.lib.nixos.runTest {
+pkgs.testers.runNixOSTest {
   name = pname;
-  hostPkgs = pkgs;
   nodes.server =
     { config, ... }:
     {
@@ -66,7 +66,9 @@ self.inputs.nixpkgs.lib.nixos.runTest {
 
       services.postgresql = {
         enable = true;
-        package = postgresqlWithExtension self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_15;
+        package =
+          postgresqlWithExtension
+            self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_15;
         settings = {
           "shared_preload_libraries" = pname;
           "pgsodium.getkey_script" = pgsodiumGetKey;
@@ -76,7 +78,7 @@ self.inputs.nixpkgs.lib.nixos.runTest {
       specialisation.postgresql17.configuration = {
         services.postgresql = {
           package = lib.mkForce (
-            postgresqlWithExtension self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_17
+            postgresqlWithExtension self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_17
           );
         };
 
@@ -93,10 +95,10 @@ self.inputs.nixpkgs.lib.nixos.runTest {
             let
               oldPostgresql =
                 postgresqlWithExtension
-                  self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_15;
+                  self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_15;
               newPostgresql =
                 postgresqlWithExtension
-                  self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_17;
+                  self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_17;
               oldDataDir = "${builtins.dirOf config.services.postgresql.dataDir}/${oldPostgresql.psqlSchema}";
               newDataDir = "${builtins.dirOf config.services.postgresql.dataDir}/${newPostgresql.psqlSchema}";
             in

--- a/nix/ext/tests/plpgsql_check.nix
+++ b/nix/ext/tests/plpgsql_check.nix
@@ -53,15 +53,6 @@ pkgs.testers.runNixOSTest {
   nodes.server =
     { config, ... }:
     {
-      virtualisation = {
-        forwardPorts = [
-          {
-            from = "host";
-            host.port = 13022;
-            guest.port = 22;
-          }
-        ];
-      };
       services.openssh = {
         enable = true;
       };

--- a/nix/ext/tests/plpgsql_check.nix
+++ b/nix/ext/tests/plpgsql_check.nix
@@ -4,7 +4,7 @@ let
   inherit (pkgs) lib;
   installedExtension =
     postgresMajorVersion:
-    self.legacyPackages.${pkgs.stdenv.hostPlatform.system}."psql_${postgresMajorVersion}".exts."${
+    self.legacyPackages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}."psql_${postgresMajorVersion}".exts."${
       pname
     }";
   versions = postgresqlMajorVersion: (installedExtension postgresqlMajorVersion).versions;
@@ -12,7 +12,7 @@ let
     postgresql:
     let
       majorVersion = lib.versions.major postgresql.version;
-      pkg = pkgs.buildEnv {
+      pkg = pkgs.pkgsLinux.buildEnv {
         name = "postgresql-${majorVersion}-${pname}";
         paths = [
           postgresql
@@ -27,7 +27,7 @@ let
           withJIT = pkg;
           withoutJIT = pkg;
         };
-        nativeBuildInputs = [ pkgs.makeWrapper ];
+        nativeBuildInputs = [ pkgs.pkgsLinux.makeWrapper ];
         pathsToLink = [
           "/"
           "/bin"
@@ -41,12 +41,15 @@ let
       };
     in
     pkg;
-  psql_15 = postgresqlWithExtension self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_15;
-  psql_17 = postgresqlWithExtension self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_17;
+  psql_15 =
+    postgresqlWithExtension
+      self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_15;
+  psql_17 =
+    postgresqlWithExtension
+      self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_17;
 in
-self.inputs.nixpkgs.lib.nixos.runTest {
+pkgs.testers.runNixOSTest {
   name = pname;
-  hostPkgs = pkgs;
   nodes.server =
     { config, ... }:
     {

--- a/nix/ext/tests/plv8.nix
+++ b/nix/ext/tests/plv8.nix
@@ -51,15 +51,6 @@ pkgs.testers.runNixOSTest {
   nodes.server =
     { ... }:
     {
-      virtualisation = {
-        forwardPorts = [
-          {
-            from = "host";
-            host.port = 13022;
-            guest.port = 22;
-          }
-        ];
-      };
       services.openssh = {
         enable = true;
       };

--- a/nix/ext/tests/plv8.nix
+++ b/nix/ext/tests/plv8.nix
@@ -5,7 +5,7 @@ let
   inherit (pkgs) lib;
   installedExtension =
     postgresMajorVersion:
-    self.legacyPackages.${pkgs.stdenv.hostPlatform.system}."psql_${postgresMajorVersion}".exts."${
+    self.legacyPackages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}."psql_${postgresMajorVersion}".exts."${
       pname
     }";
   versions = postgresqlMajorVersion: (installedExtension postgresqlMajorVersion).versions;
@@ -13,7 +13,7 @@ let
     postgresql:
     let
       majorVersion = lib.versions.major postgresql.version;
-      pkg = pkgs.buildEnv {
+      pkg = pkgs.pkgsLinux.buildEnv {
         name = "postgresql-${majorVersion}-${pname}";
         paths = [
           postgresql
@@ -28,7 +28,7 @@ let
           withJIT = pkg;
           withoutJIT = pkg;
         };
-        nativeBuildInputs = [ pkgs.makeWrapper ];
+        nativeBuildInputs = [ pkgs.pkgsLinux.makeWrapper ];
         pathsToLink = [
           "/"
           "/bin"
@@ -42,11 +42,12 @@ let
       };
     in
     pkg;
-  psql_15 = postgresqlWithExtension self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_15;
+  psql_15 =
+    postgresqlWithExtension
+      self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_15;
 in
-self.inputs.nixpkgs.lib.nixos.runTest {
+pkgs.testers.runNixOSTest {
   name = pname;
-  hostPkgs = pkgs;
   nodes.server =
     { ... }:
     {
@@ -65,7 +66,9 @@ self.inputs.nixpkgs.lib.nixos.runTest {
 
       services.postgresql = {
         enable = true;
-        package = postgresqlWithExtension self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_15;
+        package =
+          postgresqlWithExtension
+            self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_15;
         authentication = ''
           local all postgres peer map=postgres
           local all all peer map=root

--- a/nix/ext/tests/postgis.nix
+++ b/nix/ext/tests/postgis.nix
@@ -1,6 +1,6 @@
 { self, pkgs }:
 let
-  pname = "pgroonga";
+  pname = "postgis";
   inherit (pkgs) lib;
   installedExtension =
     postgresMajorVersion:
@@ -41,12 +41,6 @@ let
       };
     in
     pkg;
-  psql_15 =
-    postgresqlWithExtension
-      self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_15;
-  psql_17 =
-    postgresqlWithExtension
-      self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_17;
 in
 pkgs.testers.runNixOSTest {
   name = pname;
@@ -59,34 +53,16 @@ pkgs.testers.runNixOSTest {
 
       services.postgresql = {
         enable = true;
-        package = psql_15;
-        enableTCPIP = true;
-        authentication = ''
-          local all postgres peer map=postgres
-          local all all peer map=root
-        '';
-        identMap = ''
-          root root supabase_admin
-          postgres postgres postgres
-        '';
-        ensureUsers = [
-          {
-            name = "supabase_admin";
-            ensureClauses.superuser = true;
-          }
-        ];
+        package =
+          postgresqlWithExtension
+            self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_15;
       };
-      systemd.services.postgresql.environment.MECAB_DICDIR = "${
-        self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.mecab-naist-jdic
-      }/lib/mecab/dic/naist-jdic";
-      systemd.services.postgresql.environment.MECAB_CONFIG = "${pkgs.mecab}/bin/mecab-config";
-      systemd.services.postgresql.environment.GRN_PLUGINS_DIR = "${
-        self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.supabase-groonga
-      }/lib/groonga/plugins";
 
       specialisation.postgresql17.configuration = {
         services.postgresql = {
-          package = lib.mkForce psql_17;
+          package = lib.mkForce (
+            postgresqlWithExtension self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_17
+          );
         };
 
         systemd.services.postgresql-migrate = {
@@ -100,8 +76,12 @@ pkgs.testers.runNixOSTest {
           };
           script =
             let
-              oldPostgresql = psql_15;
-              newPostgresql = psql_17;
+              oldPostgresql =
+                postgresqlWithExtension
+                  self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_15;
+              newPostgresql =
+                postgresqlWithExtension
+                  self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_17;
               oldDataDir = "${builtins.dirOf config.services.postgresql.dataDir}/${oldPostgresql.psqlSchema}";
               newDataDir = "${builtins.dirOf config.services.postgresql.dataDir}/${newPostgresql.psqlSchema}";
             in
@@ -129,63 +109,52 @@ pkgs.testers.runNixOSTest {
       pg17-configuration = "${nodes.server.system.build.toplevel}/specialisation/postgresql17";
     in
     ''
-      from pathlib import Path
       versions = {
         "15": [${lib.concatStringsSep ", " (map (s: ''"${s}"'') (versions "15"))}],
         "17": [${lib.concatStringsSep ", " (map (s: ''"${s}"'') (versions "17"))}],
       }
-      extension_name = "${pname}"
-      pg17_configuration = "${pg17-configuration}"
-      ext_has_background_worker = ${
-        if (installedExtension "15") ? hasBackgroundWorker then "True" else "False"
-      }
-      sql_test_directory = Path("${../../tests}")
-      pg_regress_test_name = "${(installedExtension "15").pgRegressTestName or pname}"
 
-      ${builtins.readFile ./lib.py}
+      def run_sql(query):
+        return server.succeed(f"""sudo -u postgres psql -t -A -F\",\" -c \"{query}\" """).strip()
+
+      def check_upgrade_path(pg_version):
+        with subtest("Check ${pname} upgrade path"):
+          firstVersion = versions[pg_version][0]
+          server.succeed("sudo -u postgres psql -c 'DROP EXTENSION IF EXISTS ${pname};'")
+          run_sql(f"""CREATE EXTENSION ${pname} WITH VERSION '{firstVersion}' CASCADE;""")
+          installed_version = run_sql(r"""SELECT extversion FROM pg_extension WHERE extname = '${pname}';""")
+          assert installed_version == firstVersion, f"Expected ${pname} version {firstVersion}, but found {installed_version}"
+          for version in versions[pg_version][1:]:
+            run_sql(f"""ALTER EXTENSION ${pname} UPDATE TO '{version}';""")
+            installed_version = run_sql(r"""SELECT extversion FROM pg_extension WHERE extname = '${pname}';""")
+            assert installed_version == version, f"Expected ${pname} version {version}, but found {installed_version}"
 
       start_all()
 
       server.wait_for_unit("multi-user.target")
       server.wait_for_unit("postgresql.service")
 
-      test = PostgresExtensionTest(server, extension_name, versions, sql_test_directory)
+      check_upgrade_path("15")
 
-      with subtest("Check upgrade path with postgresql 15"):
-        test.check_upgrade_path("15")
-
-      with subtest("Check pg_regress with postgresql 15 after extension upgrade"):
-        test.check_pg_regress(Path("${psql_15}/lib/pgxs/src/test/regress/pg_regress"), "15", pg_regress_test_name)
-
-      last_version = None
-      with subtest("Check the install of the last version of the extension"):
-        last_version = test.check_install_last_version("15")
-
-      if ext_has_background_worker:
-        with subtest("Test switch_${pname}_version"):
-          test.check_switch_extension_with_background_worker(Path("${psql_15}/lib/${pname}.so"), "15")
-
-      with subtest("Check pg_regress with postgresql 15 after installing the last version"):
-        test.check_pg_regress(Path("${psql_15}/lib/pgxs/src/test/regress/pg_regress"), "15", pg_regress_test_name)
+      with subtest("Check ${pname} latest extension version"):
+        server.succeed("sudo -u postgres psql -c 'DROP EXTENSION ${pname};'")
+        server.succeed("sudo -u postgres psql -c 'CREATE EXTENSION ${pname} CASCADE;'")
+        installed_extensions=run_sql(r"""SELECT extname, extversion FROM pg_extension where extname = '${pname}';""")
+        latestVersion = versions["15"][-1]
+        majMinVersion = ".".join(latestVersion.split('.')[:1])
+        assert f"${pname},{majMinVersion}" in installed_extensions, f"Expected ${pname} version {latestVersion}, but found {installed_extensions}"
 
       with subtest("switch to postgresql 17"):
         server.succeed(
-          f"{pg17_configuration}/bin/switch-to-configuration test >&2"
+          "${pg17-configuration}/bin/switch-to-configuration test >&2"
         )
 
-      with subtest("Check last version of the extension after postgresql upgrade"):
-        test.assert_version_matches(last_version)
+      with subtest("Check ${pname} latest extension version after upgrade"):
+        installed_extensions=run_sql(r"""SELECT extname, extversion FROM pg_extension;""")
+        latestVersion = versions["17"][-1]
+        majMinVersion = ".".join(latestVersion.split('.')[:1])
+        assert f"${pname},{majMinVersion}" in installed_extensions
 
-      with subtest("Check upgrade path with postgresql 17"):
-        test.check_upgrade_path("17")
-
-      with subtest("Check pg_regress with postgresql 17 after extension upgrade"):
-        test.check_pg_regress(Path("${psql_17}/lib/pgxs/src/test/regress/pg_regress"), "17", pg_regress_test_name)
-
-      with subtest("Check the install of the last version of the extension"):
-        test.check_install_last_version("17")
-
-      with subtest("Check pg_regress with postgresql 17 after installing the last version"):
-        test.check_pg_regress(Path("${psql_17}/lib/pgxs/src/test/regress/pg_regress"), "17", pg_regress_test_name)
+      check_upgrade_path("17")
     '';
 }

--- a/nix/ext/tests/postgis.nix
+++ b/nix/ext/tests/postgis.nix
@@ -141,8 +141,7 @@ pkgs.testers.runNixOSTest {
         server.succeed("sudo -u postgres psql -c 'CREATE EXTENSION ${pname} CASCADE;'")
         installed_extensions=run_sql(r"""SELECT extname, extversion FROM pg_extension where extname = '${pname}';""")
         latestVersion = versions["15"][-1]
-        majMinVersion = ".".join(latestVersion.split('.')[:1])
-        assert f"${pname},{majMinVersion}" in installed_extensions, f"Expected ${pname} version {latestVersion}, but found {installed_extensions}"
+        assert f"${pname},{latestVersion}" in installed_extensions, f"Expected ${pname} version {latestVersion}, but found {installed_extensions}"
 
       with subtest("switch to postgresql 17"):
         server.succeed(
@@ -152,8 +151,7 @@ pkgs.testers.runNixOSTest {
       with subtest("Check ${pname} latest extension version after upgrade"):
         installed_extensions=run_sql(r"""SELECT extname, extversion FROM pg_extension;""")
         latestVersion = versions["17"][-1]
-        majMinVersion = ".".join(latestVersion.split('.')[:1])
-        assert f"${pname},{majMinVersion}" in installed_extensions
+        assert f"${pname},{latestVersion}" in installed_extensions
 
       check_upgrade_path("17")
     '';

--- a/nix/ext/tests/timescaledb.nix
+++ b/nix/ext/tests/timescaledb.nix
@@ -52,7 +52,7 @@ pkgs.testers.runNixOSTest {
     {
       services.postgresql = {
         enable = true;
-        package = (postgresqlWithExtension psql_15);
+        package = psql_15;
         authentication = ''
           local all postgres peer map=postgres
           local all all peer map=root

--- a/nix/ext/tests/timescaledb.nix
+++ b/nix/ext/tests/timescaledb.nix
@@ -4,7 +4,7 @@ let
   inherit (pkgs) lib;
   installedExtension =
     postgresMajorVersion:
-    self.legacyPackages.${pkgs.stdenv.hostPlatform.system}."psql_${postgresMajorVersion}".exts."${
+    self.legacyPackages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}."psql_${postgresMajorVersion}".exts."${
       pname
     }";
   versions = (installedExtension "15").versions;
@@ -12,7 +12,7 @@ let
     postgresql:
     let
       majorVersion = lib.versions.major postgresql.version;
-      pkg = pkgs.buildEnv {
+      pkg = pkgs.pkgsLinux.buildEnv {
         name = "postgresql-${majorVersion}-${pname}";
         paths = [
           postgresql
@@ -27,7 +27,7 @@ let
           withJIT = pkg;
           withoutJIT = pkg;
         };
-        nativeBuildInputs = [ pkgs.makeWrapper ];
+        nativeBuildInputs = [ pkgs.pkgsLinux.makeWrapper ];
         pathsToLink = [
           "/"
           "/bin"
@@ -41,11 +41,12 @@ let
       };
     in
     pkg;
-  psql_15 = postgresqlWithExtension self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_15;
+  psql_15 =
+    postgresqlWithExtension
+      self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_15;
 in
-self.inputs.nixpkgs.lib.nixos.runTest {
+pkgs.testers.runNixOSTest {
   name = "timescaledb";
-  hostPkgs = pkgs;
   nodes.server =
     { ... }:
     {

--- a/nix/ext/tests/vault.nix
+++ b/nix/ext/tests/vault.nix
@@ -4,7 +4,7 @@ let
   inherit (pkgs) lib;
   installedExtension =
     postgresMajorVersion:
-    self.legacyPackages.${pkgs.stdenv.hostPlatform.system}."psql_${postgresMajorVersion}".exts."${
+    self.legacyPackages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}."psql_${postgresMajorVersion}".exts."${
       pname
     }";
   versions = postgresqlMajorVersion: (installedExtension postgresqlMajorVersion).versions;
@@ -12,13 +12,14 @@ let
     postgresql:
     let
       majorVersion = lib.versions.major postgresql.version;
-      pkg = pkgs.buildEnv {
+      pkg = pkgs.pkgsLinux.buildEnv {
         name = "postgresql-${majorVersion}-${pname}";
         paths = [
           postgresql
           postgresql.lib
           (installedExtension majorVersion)
-          (self.legacyPackages.${pkgs.stdenv.hostPlatform.system}."psql_${majorVersion}".exts.pgsodium) # dependency
+          (self.legacyPackages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}."psql_${majorVersion}".exts.pgsodium
+          ) # dependency
         ];
         passthru = {
           inherit (postgresql) version psqlSchema;
@@ -28,7 +29,7 @@ let
           withJIT = pkg;
           withoutJIT = pkg;
         };
-        nativeBuildInputs = [ pkgs.makeWrapper ];
+        nativeBuildInputs = [ pkgs.pkgsLinux.makeWrapper ];
         pathsToLink = [
           "/"
           "/bin"
@@ -47,12 +48,15 @@ let
       echo 0000000000000000000000000000000000000000000000000000000000000000
     ''
   );
-  psql_15 = postgresqlWithExtension self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_15;
-  psql_17 = postgresqlWithExtension self.packages.${pkgs.stdenv.hostPlatform.system}.postgresql_17;
+  psql_15 =
+    postgresqlWithExtension
+      self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_15;
+  psql_17 =
+    postgresqlWithExtension
+      self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_17;
 in
-self.inputs.nixpkgs.lib.nixos.runTest {
+pkgs.testers.runNixOSTest {
   name = pname;
-  hostPkgs = pkgs;
   nodes.server =
     { config, ... }:
     {

--- a/nix/ext/tests/vault.nix
+++ b/nix/ext/tests/vault.nix
@@ -60,16 +60,6 @@ pkgs.testers.runNixOSTest {
   nodes.server =
     { config, ... }:
     {
-      virtualisation = {
-        forwardPorts = [
-          {
-            from = "host";
-            host.port = 13022;
-            guest.port = 22;
-          }
-        ];
-      };
-
       services.postgresql = {
         enable = true;
         package = psql_15;

--- a/nix/postgresql/generic.nix
+++ b/nix/postgresql/generic.nix
@@ -322,7 +322,7 @@ let
 
           tests = {
             postgresql-wal-receiver = import ../../../../nixos/tests/postgresql-wal-receiver.nix {
-              system = stdenv.hostPlatform.system;
+              inherit (stdenv.hostPlatform) system;
               pkgs = self;
               package = this;
             };
@@ -330,7 +330,7 @@ let
           }
           // lib.optionalAttrs jitSupport {
             postgresql-jit = import ../../../../nixos/tests/postgresql-jit.nix {
-              system = stdenv.hostPlatform.system;
+              inherit (stdenv.hostPlatform) system;
               pkgs = self;
               package = this;
             };

--- a/nix/tests/http-mock-server.py
+++ b/nix/tests/http-mock-server.py
@@ -237,10 +237,14 @@ def run_server(port=None):
 
         port_file = os.environ.get("HTTP_MOCK_PORT_FILE", "/tmp/http-mock-port")
         try:
+            # Ensure directory exists
+            os.makedirs(os.path.dirname(port_file), exist_ok=True)
             with open(port_file, "w") as f:
                 f.write(str(port))
-        except:
-            pass  # Ignore if we can't write the port file
+            print(f"Port file written to {port_file}")
+        except Exception as e:
+            print(f"ERROR: Failed to write port file {port_file}: {e}")
+            raise e  # Don't ignore port file write errors
 
         server.serve_forever()
     except OSError as e:

--- a/nix/tests/http-mock-server.py
+++ b/nix/tests/http-mock-server.py
@@ -237,14 +237,16 @@ def run_server(port=None):
 
         port_file = os.environ.get("HTTP_MOCK_PORT_FILE", "/tmp/http-mock-port")
         try:
-            # Ensure directory exists
-            os.makedirs(os.path.dirname(port_file), exist_ok=True)
+            # Ensure directory exists (if any)
+            port_dir = os.path.dirname(port_file)
+            if port_dir:
+                os.makedirs(port_dir, exist_ok=True)
             with open(port_file, "w") as f:
                 f.write(str(port))
             print(f"Port file written to {port_file}")
         except Exception as e:
             print(f"ERROR: Failed to write port file {port_file}: {e}")
-            raise e  # Don't ignore port file write errors
+            raise  # Don't ignore port file write errors
 
         server.serve_forever()
     except OSError as e:


### PR DESCRIPTION
Build nixosTest using a local aarch64 linux builder and run nixosTest qemu VM in
aarch64 darwin. This keeps the tests fast as they don't require nested virtualisation.

For example, you can run the nixos test for the http extension on your aarch64 macOS with:

```shell
nix build .\#checks.aarch64-darwin.ext-http
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized Linux-specific package resolution and host-platform inheritance across test modules and packaging paths.

* **Tests**
  * Unified test harness to a Linux-focused runner, removed host→guest port forwarding and hostPkgs, added /lib to runtime links, improved service ordering/synchronization, and streamlined package wiring.
  * Added HTTP mock server integration with lifecycle and port propagation.

* **New Features**
  * Added an end-to-end PostGIS multi-version upgrade test.

* **Bug Fixes**
  * Improved mock-server port-file directory handling, logging, and error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->