### PR TITLE
fix(nix): use the same postgresql inside switch-ext-version

### DIFF
--- a/nix/packages/postgres.nix
+++ b/nix/packages/postgres.nix
@@ -102,11 +102,14 @@
               dbExtensions17
             else
               ourExtensions;
-          extCallPackage = pkgs.lib.callPackageWith (pkgs // {
-            inherit postgresql;
-            switch-ext-version = extCallPackage ./switch-ext-version.nix {};
-            overlayfs-on-package = extCallPackage ./overlayfs-on-package.nix {};
-          });
+          extCallPackage = pkgs.lib.callPackageWith (
+            pkgs
+            // {
+              inherit postgresql;
+              switch-ext-version = extCallPackage ./switch-ext-version.nix { };
+              overlayfs-on-package = extCallPackage ./overlayfs-on-package.nix { };
+            }
+          );
         in
         map (path: extCallPackage path { }) extensionsToUse;
 

--- a/nix/packages/postgres.nix
+++ b/nix/packages/postgres.nix
@@ -102,8 +102,13 @@
               dbExtensions17
             else
               ourExtensions;
+          extCallPackage = pkgs.lib.callPackageWith (pkgs // {
+            inherit postgresql;
+            switch-ext-version = extCallPackage ./switch-ext-version.nix {};
+            overlayfs-on-package = extCallPackage ./overlayfs-on-package.nix {};
+          });
         in
-        map (path: pkgs.callPackage path { inherit postgresql; }) extensionsToUse;
+        map (path: extCallPackage path { }) extensionsToUse;
 
       # Create an attrset that contains all the extensions included in a server.
       makeOurPostgresPkgsSet =
@@ -136,12 +141,13 @@
         version:
         let
           postgresql = getPostgresqlPackage version;
+          postgres-pkgs = makeOurPostgresPkgs version;
           ourExts = map (ext: {
             name = ext.name;
             version = ext.version;
-          }) (makeOurPostgresPkgs version);
+          }) postgres-pkgs;
 
-          pgbin = postgresql.withPackages (_ps: makeOurPostgresPkgs version);
+          pgbin = postgresql.withPackages (_ps: postgres-pkgs);
         in
         pkgs.symlinkJoin {
           inherit (pgbin) name version;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently, `switch-ext-version` uses `nixpkgs.postgresql`, instead of the `postgresql` chosen inside `nix/packages/postgres.nix`.

To test for this, we can add `builtins.trace postgresql.drvPath` inside `nix/packages/switch-ext-version.nix`:
```nix
{
  coreutils,
  overlayfs-on-package,
  lib,
  postgresql,
  writeShellApplication,
}:
builtins.trace postgresql.drvPath (writeShellApplication {
  name = "switch-ext-version";
  runtimeInputs = [ coreutils ];
...
```

## What is the current behavior?
```nix
$ nix eval .#psql_17/bin
trace: /nix/store/xb009c84shw6hlhv1rri66w6pwng03qi-postgresql-15.14.drv
«derivation /nix/store/0q2ffimhzn6rxnwskyr536p290l8fj8g-postgresql-and-plugins-17.6.drv»
```
`postgresql` has version 15.14, even though we chose `psql_17`.
## What is the new behavior?
Correct one is chosen.

```nix
$ nix eval .#psql_17/bin
trace: /nix/store/4x4hqj7cp4zxp8b946wicpzdjb7y3fzw-postgresql-17.6.drv
«derivation /nix/store/0q2ffimhzn6rxnwskyr536p290l8fj8g-postgresql-and-plugins-17.6.drv»
```

## Additional context

There are more stuff that I'd like to propose to change. For instance, there are IFDs for `Cargo.lock` that I believe would be pretty simple to change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized PostgreSQL extension packaging to unify how extensions are assembled and applied, improving maintainability and consistency across builds.
  * Introduced an intermediate package grouping to avoid redundant computation and simplify derivations; behavior is internal only and does not change any public interfaces or user-facing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->