### PR TITLE
chore: bump version to correct new version for potential release

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.025-orioledb"
-  postgres17: "17.6.1.068"
-  postgres15: "15.14.1.068"
+  postgresorioledb-17: "17.6.0.027-orioledb"
+  postgres17: "17.6.1.070"
+  postgres15: "15.14.1.070"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.19.0


### PR DESCRIPTION
Previous releases had set the wrong/conflicting version which made the ami release workflow fail. This PR advances the release to the correct new numbers to create a release without failure. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated PostgreSQL package versions across multiple releases to the latest patch updates (including updates for recent 17.x and 15.x releases).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->