### PR TITLE
Run server macos

### DIFF
--- a/nix/tools/run-server.sh.in
+++ b/nix/tools/run-server.sh.in
@@ -295,6 +295,12 @@ orioledb_config_items() {
 
 # Apply OrioleDB configuration if needed
 orioledb_config_items "$VERSION"
+
+# Fix archive_command for macOS (Darwin doesn't have /bin/true, use /usr/bin/true instead)
+if [[ "$CURRENT_SYSTEM" == *"-darwin" ]]; then
+    perl -pi -e "s|archive_command = '/bin/true'|archive_command = '/usr/bin/true'|" "$DATDIR/postgresql.conf"
+fi
+
 # Configure Groonga
 export GRN_PLUGINS_DIR=$GROONGA/lib/groonga/plugins
 


### PR DESCRIPTION
The location of `true` in macos is `/usr/bin/true` and adding this logic fixes the archiving command function when running postgres locally in macos using `nix run .#start-server <version>` command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Fixed server startup configuration on macOS systems to correctly handle archive command settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->