### PR TITLE
Fix for Issue #41529: plpgsql_check Recursive Function Error

### DIFF
--- a/nix/ext/plpgsql-check.nix
+++ b/nix/ext/plpgsql-check.nix
@@ -131,13 +131,10 @@ buildEnv {
 
   passthru = {
     inherit versions numberOfVersions switch-ext-version;
-    hasBackgroundWorker = true;
-    defaultSettings = {
-      shared_preload_libraries = [
-        "plpgsql"
-        "plpgsql_check"
-      ];
-    };
+    # plpgsql_check is a development/linting tool that should be loaded on-demand
+    # via CREATE EXTENSION, not automatically preloaded. Automatic preloading causes
+    # "cannot find parent statement on pldbgapi2 call stack" errors in recursive
+    # PL/pgSQL functions (see issue #41529)
     version =
       "multi-" + lib.concatStringsSep "-" (map (v: lib.replaceStrings [ "." ] [ "-" ] v) versions);
   };


### PR DESCRIPTION
Issue
plpgsql_check causes "cannot find parent statement on pldbgapi2 call stack" errors when running recursive PL/pgSQL functions. This happens because the extension's internal pldbgapi2 component (used for profiling/tracing) has a known limitation with tracking call stacks in recursive contexts. Since plpgsql_check was configured in shared_preload_libraries, it was automatically loaded for all sessions, affecting production workloads.

Ref: Issue [#41529](https://github.com/supabase/supabase/issues/41529)

Solution
Removed plpgsql_check from shared_preload_libraries in the Nix configuration.

The extension is no longer loaded automatically at startup.
It remains available for on-demand use via CREATE EXTENSION plpgsql_check; for development and linting purposes.
This prevents the recursion error in standard operations while preserving the tool's availability for developers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * The plpgsql_check extension is no longer automatically preloaded. It must now be manually loaded via CREATE EXTENSION when needed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->