### PR TITLE
chore: bump versions again

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.025-orioledb"
-  postgres17: "17.6.1.068"
-  postgres15: "15.14.1.068"
+  postgresorioledb-17: "17.6.0.026-orioledb"
+  postgres17: "17.6.1.069"
+  postgres15: "15.14.1.069"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.19.0


### PR DESCRIPTION
17.6.0.025-orioledb AMI creation [failed](https://github.com/supabase/postgres/actions/runs/20751443310/job/59581759604) because apparently the version has already been used (how??)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PostgreSQL versions: OrioLDB 17 (17.6.0.026), PostgreSQL 17 (17.6.1.069), and PostgreSQL 15 (15.14.1.069).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->