### PR TITLE
fix: ban unencrypted direct connection to pg

### DIFF
--- a/ansible/files/fail2ban_config/filter-postgresql.conf.j2
+++ b/ansible/files/fail2ban_config/filter-postgresql.conf.j2
@@ -1,3 +1,4 @@
 [Definition]
 failregex = ^.*,.*,.*,.*,"<HOST>:.*password authentication failed for user.*$
+            ^.*no pg_hba\.conf entry for host "<HOST>",.*$
 ignoreregex = ^.*,.*,.*,.*,"127\.0\.0\.1.*password authentication failed for user.*$


### PR DESCRIPTION
We want to ban ip if unsupported connections attempts are repeatedly created (such as unencrypted, etc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PostgreSQL fail2ban filter configuration to improve authentication monitoring and security event detection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->