### PR TITLE
feat: enable sccache for cargo-pgrx builds in GitHub Actions

### DIFF
--- a/.github/actions/nix-install-ephemeral/action.yml
+++ b/.github/actions/nix-install-ephemeral/action.yml
@@ -53,4 +53,7 @@ runs:
           trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           ${{ inputs.push-to-cache == 'true' && 'post-build-hook = /etc/nix/upload-to-cache.sh' || '' }}
           ${{ inputs.enable-sccache-sandbox-path == 'true' && 'extra-sandbox-paths = /nix/var/cache/sccache?' || '' }}
-          max-jobs = 4
+          max-jobs = 1
+          auto-allocate-uids = true
+          use-cgroups = true
+          experimental-features = nix-command flakes cgroups auto-allocate-uids

--- a/.github/actions/nix-install-ephemeral/action.yml
+++ b/.github/actions/nix-install-ephemeral/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: 'Whether to push build outputs to the Nix binary cache'
     required: false
     default: 'false'
+  enable-sccache-sandbox-path:
+    description: 'Whether to expose /nix/var/cache/sccache in the Nix sandbox'
+    required: false
+    default: 'false'
   aws-region:
     description: 'AWS region for the Nix binary cache S3 bucket'
     required: false
@@ -48,4 +52,5 @@ runs:
           substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com
           trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           ${{ inputs.push-to-cache == 'true' && 'post-build-hook = /etc/nix/upload-to-cache.sh' || '' }}
+          ${{ inputs.enable-sccache-sandbox-path == 'true' && 'extra-sandbox-paths = /nix/var/cache/sccache?' || '' }}
           max-jobs = 4

--- a/.github/actions/nix-install-ephemeral/action.yml
+++ b/.github/actions/nix-install-ephemeral/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: 'Whether to expose /nix/var/cache/sccache in the Nix sandbox'
     required: false
     default: 'false'
+  max-jobs:
+    description: 'Maximum number of parallel Nix builds'
+    required: false
+    default: ''
   aws-region:
     description: 'AWS region for the Nix binary cache S3 bucket'
     required: false
@@ -53,7 +57,7 @@ runs:
           trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           ${{ inputs.push-to-cache == 'true' && 'post-build-hook = /etc/nix/upload-to-cache.sh' || '' }}
           ${{ inputs.enable-sccache-sandbox-path == 'true' && 'extra-sandbox-paths = /nix/var/cache/sccache?' || '' }}
-          max-jobs = 1
-          auto-allocate-uids = true
-          use-cgroups = true
-          experimental-features = nix-command flakes cgroups auto-allocate-uids
+          ${{ inputs.max-jobs != '' && format('max-jobs = {0}', inputs.max-jobs) || '' }}
+          ${{ inputs.enable-sccache-sandbox-path == 'true' && 'auto-allocate-uids = true' || '' }}
+          ${{ inputs.enable-sccache-sandbox-path == 'true' && 'use-cgroups = true' || '' }}
+          experimental-features = nix-command flakes ${{ inputs.enable-sccache-sandbox-path == 'true' && 'cgroups auto-allocate-uids' || '' }}

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -14,10 +14,6 @@ permissions:
   contents: write
   packages: write
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
 jobs:
   nix-eval:
     uses: ./.github/workflows/nix-eval.yml
@@ -40,17 +36,31 @@ jobs:
       - name: Checkout Repo
         if: ${{ matrix.attr != '' }}
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Mount sccache disk
+        if: ${{ matrix.attr != '' && matrix.runs_on.group != 'self-hosted-runners-nix' }}
+        uses: useblacksmith/stickydisk@v1
+        with:
+          key: ${{ github.repository }}-sccache-${{ runner.os }}-${{ runner.arch }}
+          path: /nix/var/cache/sccache
       - name: Install nix (ephemeral)
         if: ${{ matrix.attr != '' && matrix.runs_on.group != 'self-hosted-runners-nix' }}
         uses: ./.github/actions/nix-install-ephemeral
         with:
           push-to-cache: 'true'
+          enable-sccache-sandbox-path: 'true'
         env:
           DEV_AWS_ROLE: ${{ secrets.DEV_AWS_ROLE }}
           NIX_SIGN_SECRET_KEY: ${{ secrets.NIX_SIGN_SECRET_KEY }}
       - name: Install nix (self-hosted)
         if: ${{ matrix.attr != '' && matrix.runs_on.group == 'self-hosted-runners-nix' }}
         uses: ./.github/actions/nix-install-self-hosted
+      - name: Allow sccache cache write access
+        if: ${{ matrix.attr != '' && matrix.runs_on.group != 'self-hosted-runners-nix' }}
+        run: |
+          sudo chgrp nixbld /nix/var/cache/sccache
+          sudo chmod 777 /nix/var/cache/sccache
+          sudo chmod g+s /nix/var/cache/sccache
+          sudo setfacl -d -m u::rwX,g::rwX,o::rwX /nix/var/cache/sccache
       - name: nix build
         if: ${{ matrix.attr != '' }}
         shell: bash
@@ -71,17 +81,31 @@ jobs:
       - name: Checkout Repo
         if: ${{ matrix.attr != '' }}
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Mount sccache disk
+        if: ${{ matrix.attr != '' && matrix.runs_on.group != 'self-hosted-runners-nix' }}
+        uses: useblacksmith/stickydisk@v1
+        with:
+          key: ${{ github.repository }}-sccache-${{ runner.os }}-${{ runner.arch }}
+          path: /nix/var/cache/sccache
       - name: Install nix (ephemeral)
         if: ${{ matrix.attr != '' && matrix.runs_on.group != 'self-hosted-runners-nix' }}
         uses: ./.github/actions/nix-install-ephemeral
         with:
           push-to-cache: 'true'
+          enable-sccache-sandbox-path: 'true'
         env:
           DEV_AWS_ROLE: ${{ secrets.DEV_AWS_ROLE }}
           NIX_SIGN_SECRET_KEY: ${{ secrets.NIX_SIGN_SECRET_KEY }}
       - name: Install nix (self-hosted)
         if: ${{ matrix.attr != '' && matrix.runs_on.group == 'self-hosted-runners-nix' }}
         uses: ./.github/actions/nix-install-self-hosted
+      - name: Allow sccache cache write access
+        if: ${{ matrix.attr != '' && matrix.runs_on.group != 'self-hosted-runners-nix' }}
+        run: |
+          sudo chgrp nixbld /nix/var/cache/sccache
+          sudo chmod 777 /nix/var/cache/sccache
+          sudo chmod g+s /nix/var/cache/sccache
+          sudo setfacl -d -m u::rwX,g::rwX,o::rwX /nix/var/cache/sccache
       - name: nix build
         if: ${{ matrix.attr != '' }}
         shell: bash
@@ -148,14 +172,28 @@ jobs:
       - name: Checkout Repo
         if: ${{ matrix.attr != '' }}
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Mount sccache disk
+        if: ${{ matrix.attr != '' && matrix.runs_on.group != 'self-hosted-runners-nix' }}
+        uses: useblacksmith/stickydisk@v1
+        with:
+          key: ${{ github.repository }}-sccache-${{ runner.os }}-${{ runner.arch }}
+          path: /nix/var/cache/sccache
       - name: Install nix
         if: ${{ matrix.attr != '' }}
         uses: ./.github/actions/nix-install-ephemeral
         with:
+          enable-sccache-sandbox-path: 'true'
           push-to-cache: 'true'
         env:
           DEV_AWS_ROLE: ${{ secrets.DEV_AWS_ROLE }}
           NIX_SIGN_SECRET_KEY: ${{ secrets.NIX_SIGN_SECRET_KEY }}
+      - name: Allow sccache cache write access
+        if: ${{ matrix.attr != '' && matrix.runs_on.group != 'self-hosted-runners-nix' }}
+        run: |
+          sudo chgrp nixbld /nix/var/cache/sccache
+          sudo chmod 777 /nix/var/cache/sccache
+          sudo chmod g+s /nix/var/cache/sccache
+          sudo setfacl -d -m u::rwX,g::rwX,o::rwX /nix/var/cache/sccache
       - name: nix build
         if: ${{ matrix.attr != '' }}
         shell: bash
@@ -176,14 +214,28 @@ jobs:
       - name: Checkout Repo
         if: ${{ matrix.attr != '' }}
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Mount sccache disk
+        if: ${{ matrix.attr != '' && matrix.runs_on.group != 'self-hosted-runners-nix' }}
+        uses: useblacksmith/stickydisk@v1
+        with:
+          key: ${{ github.repository }}-sccache-${{ runner.os }}-${{ runner.arch }}
+          path: /nix/var/cache/sccache
       - name: Install nix
         if: ${{ matrix.attr != '' }}
         uses: ./.github/actions/nix-install-ephemeral
         with:
+          enable-sccache-sandbox-path: 'true'
           push-to-cache: 'true'
         env:
           DEV_AWS_ROLE: ${{ secrets.DEV_AWS_ROLE }}
           NIX_SIGN_SECRET_KEY: ${{ secrets.NIX_SIGN_SECRET_KEY }}
+      - name: Allow sccache cache write access
+        if: ${{ matrix.attr != '' && matrix.runs_on.group != 'self-hosted-runners-nix' }}
+        run: |
+          sudo chgrp nixbld /nix/var/cache/sccache
+          sudo chmod 777 /nix/var/cache/sccache
+          sudo chmod g+s /nix/var/cache/sccache
+          sudo setfacl -d -m u::rwX,g::rwX,o::rwX /nix/var/cache/sccache
       - name: nix build
         if: ${{ matrix.attr != '' }}
         shell: bash
@@ -217,15 +269,3 @@ jobs:
       (needs.nix-build-packages-x86_64-linux.result == 'skipped' || needs.nix-build-packages-x86_64-linux.result == 'success') &&
       (needs.nix-build-checks-x86_64-linux.result == 'skipped' || needs.nix-build-checks-x86_64-linux.result == 'success')
     uses: ./.github/workflows/test.yml
-
-  docker-image-test:
-    needs: [nix-eval, nix-build-packages-aarch64-linux, nix-build-checks-aarch64-linux]
-    if: |
-      !cancelled() &&
-      needs.nix-eval.result == 'success' &&
-      (needs.nix-build-packages-aarch64-linux.result == 'skipped' || needs.nix-build-packages-aarch64-linux.result == 'success') &&
-      (needs.nix-build-checks-aarch64-linux.result == 'skipped' || needs.nix-build-checks-aarch64-linux.result == 'success')
-    uses: ./.github/workflows/docker-image-test.yml
-    secrets:
-      DEV_AWS_ROLE: ${{ secrets.DEV_AWS_ROLE }}
-      NIX_SIGN_SECRET_KEY: ${{ secrets.NIX_SIGN_SECRET_KEY }}

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -59,8 +59,8 @@ jobs:
         if: ${{ matrix.attr != '' && matrix.postgresql_version && matrix.runs_on.group != 'self-hosted-runners-nix' }}
         run: |
           # With auto-allocate-uids, UID 872415232 (0x34000000) maps to nixbld inside sandbox
-          sudo chown -R 872415232 /nix/var/cache/sccache
-          sudo chmod -R 2777 /nix/var/cache/sccache
+          if [ -d /nix/var/cache/sccache ]; then sudo chown -R 872415232 /nix/var/cache/sccache; fi
+          if [ -d /nix/var/cache/sccache ]; then sudo chmod -R 2777 /nix/var/cache/sccache; fi
       - name: nix build
         if: ${{ matrix.attr != '' }}
         shell: bash
@@ -104,8 +104,8 @@ jobs:
         if: ${{ matrix.attr != '' && matrix.postgresql_version && matrix.runs_on.group != 'self-hosted-runners-nix' }}
         run: |
           # With auto-allocate-uids, UID 872415232 (0x34000000) maps to nixbld inside sandbox
-          sudo chown -R 872415232 /nix/var/cache/sccache
-          sudo chmod -R 2777 /nix/var/cache/sccache
+          if [ -d /nix/var/cache/sccache ]; then sudo chown -R 872415232 /nix/var/cache/sccache; fi
+          if [ -d /nix/var/cache/sccache ]; then sudo chmod -R 2777 /nix/var/cache/sccache; fi
       - name: nix build
         if: ${{ matrix.attr != '' }}
         shell: bash
@@ -126,9 +126,23 @@ jobs:
       - name: Checkout Repo
         if: ${{ matrix.attr != '' }}
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Mount sccache disk
+        if: ${{ matrix.attr != '' && matrix.postgresql_version }}
+        uses: useblacksmith/stickydisk@v1
+        with:
+          key: ${{ github.repository }}-sccache-${{ runner.os }}-${{ runner.arch }}-${{ matrix.cache_key }}
+          path: /nix/var/cache/sccache
       - name: Install nix
         if: ${{ matrix.attr != '' }}
         uses: ./.github/actions/nix-install-self-hosted
+      - name: Configure sccache cache directory
+        if: ${{ matrix.attr != '' && matrix.postgresql_version }}
+        run: |
+          mkdir -p /nix/var/cache/sccache || true
+          # Stop any existing sccache daemon to avoid stale TMPDIR state
+          if command -v sccache &> /dev/null; then
+            sccache --stop-server 2>/dev/null || true
+          fi
       - name: nix build
         if: ${{ matrix.attr != '' }}
         shell: bash
@@ -149,9 +163,23 @@ jobs:
       - name: Checkout Repo
         if: ${{ matrix.attr != '' }}
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Mount sccache disk
+        if: ${{ matrix.attr != '' && matrix.postgresql_version }}
+        uses: useblacksmith/stickydisk@v1
+        with:
+          key: ${{ github.repository }}-sccache-${{ runner.os }}-${{ runner.arch }}-${{ matrix.cache_key }}
+          path: /nix/var/cache/sccache
       - name: Install nix
         if: ${{ matrix.attr != '' }}
         uses: ./.github/actions/nix-install-self-hosted
+      - name: Configure sccache cache directory
+        if: ${{ matrix.attr != '' && matrix.postgresql_version }}
+        run: |
+          mkdir -p /nix/var/cache/sccache || true
+          # Stop any existing sccache daemon to avoid stale TMPDIR state
+          if command -v sccache &> /dev/null; then
+            sccache --stop-server 2>/dev/null || true
+          fi
       - name: nix build
         if: ${{ matrix.attr != '' }}
         shell: bash
@@ -192,8 +220,8 @@ jobs:
         if: ${{ matrix.attr != '' && matrix.postgresql_version && matrix.runs_on.group != 'self-hosted-runners-nix' }}
         run: |
           # With auto-allocate-uids, UID 872415232 (0x34000000) maps to nixbld inside sandbox
-          sudo chown -R 872415232 /nix/var/cache/sccache
-          sudo chmod -R 2777 /nix/var/cache/sccache
+          if [ -d /nix/var/cache/sccache ]; then sudo chown -R 872415232 /nix/var/cache/sccache; fi
+          if [ -d /nix/var/cache/sccache ]; then sudo chmod -R 2777 /nix/var/cache/sccache; fi
       - name: nix build
         if: ${{ matrix.attr != '' }}
         shell: bash
@@ -234,8 +262,8 @@ jobs:
         if: ${{ matrix.attr != '' && matrix.postgresql_version && matrix.runs_on.group != 'self-hosted-runners-nix' }}
         run: |
           # With auto-allocate-uids, UID 872415232 (0x34000000) maps to nixbld inside sandbox
-          sudo chown -R 872415232 /nix/var/cache/sccache
-          sudo chmod -R 2777 /nix/var/cache/sccache
+          if [ -d /nix/var/cache/sccache ]; then sudo chown -R 872415232 /nix/var/cache/sccache; fi
+          if [ -d /nix/var/cache/sccache ]; then sudo chmod -R 2777 /nix/var/cache/sccache; fi
       - name: nix build
         if: ${{ matrix.attr != '' }}
         shell: bash

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -40,7 +40,7 @@ jobs:
         if: ${{ matrix.attr != '' && matrix.runs_on.group != 'self-hosted-runners-nix' }}
         uses: useblacksmith/stickydisk@v1
         with:
-          key: ${{ github.repository }}-sccache-${{ runner.os }}-${{ runner.arch }}
+          key: ${{ github.repository }}-sccache-${{ runner.os }}-${{ runner.arch }}-${{ matrix.cache_key }}
           path: /nix/var/cache/sccache
       - name: Install nix (ephemeral)
         if: ${{ matrix.attr != '' && matrix.runs_on.group != 'self-hosted-runners-nix' }}
@@ -57,10 +57,9 @@ jobs:
       - name: Allow sccache cache write access
         if: ${{ matrix.attr != '' && matrix.runs_on.group != 'self-hosted-runners-nix' }}
         run: |
-          sudo chgrp nixbld /nix/var/cache/sccache
-          sudo chmod 777 /nix/var/cache/sccache
-          sudo chmod g+s /nix/var/cache/sccache
-          sudo setfacl -d -m u::rwX,g::rwX,o::rwX /nix/var/cache/sccache
+          # With auto-allocate-uids, UID 872415232 (0x34000000) maps to nixbld inside sandbox
+          sudo chown -R 872415232 /nix/var/cache/sccache
+          sudo chmod -R 2777 /nix/var/cache/sccache
       - name: nix build
         if: ${{ matrix.attr != '' }}
         shell: bash
@@ -85,7 +84,7 @@ jobs:
         if: ${{ matrix.attr != '' && matrix.runs_on.group != 'self-hosted-runners-nix' }}
         uses: useblacksmith/stickydisk@v1
         with:
-          key: ${{ github.repository }}-sccache-${{ runner.os }}-${{ runner.arch }}
+          key: ${{ github.repository }}-sccache-${{ runner.os }}-${{ runner.arch }}-${{ matrix.cache_key }}
           path: /nix/var/cache/sccache
       - name: Install nix (ephemeral)
         if: ${{ matrix.attr != '' && matrix.runs_on.group != 'self-hosted-runners-nix' }}
@@ -102,10 +101,9 @@ jobs:
       - name: Allow sccache cache write access
         if: ${{ matrix.attr != '' && matrix.runs_on.group != 'self-hosted-runners-nix' }}
         run: |
-          sudo chgrp nixbld /nix/var/cache/sccache
-          sudo chmod 777 /nix/var/cache/sccache
-          sudo chmod g+s /nix/var/cache/sccache
-          sudo setfacl -d -m u::rwX,g::rwX,o::rwX /nix/var/cache/sccache
+          # With auto-allocate-uids, UID 872415232 (0x34000000) maps to nixbld inside sandbox
+          sudo chown -R 872415232 /nix/var/cache/sccache
+          sudo chmod -R 2777 /nix/var/cache/sccache
       - name: nix build
         if: ${{ matrix.attr != '' }}
         shell: bash
@@ -176,7 +174,7 @@ jobs:
         if: ${{ matrix.attr != '' && matrix.runs_on.group != 'self-hosted-runners-nix' }}
         uses: useblacksmith/stickydisk@v1
         with:
-          key: ${{ github.repository }}-sccache-${{ runner.os }}-${{ runner.arch }}
+          key: ${{ github.repository }}-sccache-${{ runner.os }}-${{ runner.arch }}-${{ matrix.cache_key }}
           path: /nix/var/cache/sccache
       - name: Install nix
         if: ${{ matrix.attr != '' }}
@@ -190,10 +188,9 @@ jobs:
       - name: Allow sccache cache write access
         if: ${{ matrix.attr != '' && matrix.runs_on.group != 'self-hosted-runners-nix' }}
         run: |
-          sudo chgrp nixbld /nix/var/cache/sccache
-          sudo chmod 777 /nix/var/cache/sccache
-          sudo chmod g+s /nix/var/cache/sccache
-          sudo setfacl -d -m u::rwX,g::rwX,o::rwX /nix/var/cache/sccache
+          # With auto-allocate-uids, UID 872415232 (0x34000000) maps to nixbld inside sandbox
+          sudo chown -R 872415232 /nix/var/cache/sccache
+          sudo chmod -R 2777 /nix/var/cache/sccache
       - name: nix build
         if: ${{ matrix.attr != '' }}
         shell: bash
@@ -218,7 +215,7 @@ jobs:
         if: ${{ matrix.attr != '' && matrix.runs_on.group != 'self-hosted-runners-nix' }}
         uses: useblacksmith/stickydisk@v1
         with:
-          key: ${{ github.repository }}-sccache-${{ runner.os }}-${{ runner.arch }}
+          key: ${{ github.repository }}-sccache-${{ runner.os }}-${{ runner.arch }}-${{ matrix.cache_key }}
           path: /nix/var/cache/sccache
       - name: Install nix
         if: ${{ matrix.attr != '' }}
@@ -232,10 +229,9 @@ jobs:
       - name: Allow sccache cache write access
         if: ${{ matrix.attr != '' && matrix.runs_on.group != 'self-hosted-runners-nix' }}
         run: |
-          sudo chgrp nixbld /nix/var/cache/sccache
-          sudo chmod 777 /nix/var/cache/sccache
-          sudo chmod g+s /nix/var/cache/sccache
-          sudo setfacl -d -m u::rwX,g::rwX,o::rwX /nix/var/cache/sccache
+          # With auto-allocate-uids, UID 872415232 (0x34000000) maps to nixbld inside sandbox
+          sudo chown -R 872415232 /nix/var/cache/sccache
+          sudo chmod -R 2777 /nix/var/cache/sccache
       - name: nix build
         if: ${{ matrix.attr != '' }}
         shell: bash

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -37,7 +37,7 @@ jobs:
         if: ${{ matrix.attr != '' }}
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Mount sccache disk
-        if: ${{ matrix.attr != '' && matrix.runs_on.group != 'self-hosted-runners-nix' }}
+        if: ${{ matrix.attr != '' && matrix.postgresql_version && matrix.runs_on.group != 'self-hosted-runners-nix' }}
         uses: useblacksmith/stickydisk@v1
         with:
           key: ${{ github.repository }}-sccache-${{ runner.os }}-${{ runner.arch }}-${{ matrix.cache_key }}
@@ -47,7 +47,8 @@ jobs:
         uses: ./.github/actions/nix-install-ephemeral
         with:
           push-to-cache: 'true'
-          enable-sccache-sandbox-path: 'true'
+          enable-sccache-sandbox-path: ${{ matrix.postgresql_version && 'true' || 'false' }}
+          max-jobs: ${{ matrix.postgresql_version && '1' || '' }}
         env:
           DEV_AWS_ROLE: ${{ secrets.DEV_AWS_ROLE }}
           NIX_SIGN_SECRET_KEY: ${{ secrets.NIX_SIGN_SECRET_KEY }}
@@ -55,7 +56,7 @@ jobs:
         if: ${{ matrix.attr != '' && matrix.runs_on.group == 'self-hosted-runners-nix' }}
         uses: ./.github/actions/nix-install-self-hosted
       - name: Allow sccache cache write access
-        if: ${{ matrix.attr != '' && matrix.runs_on.group != 'self-hosted-runners-nix' }}
+        if: ${{ matrix.attr != '' && matrix.postgresql_version && matrix.runs_on.group != 'self-hosted-runners-nix' }}
         run: |
           # With auto-allocate-uids, UID 872415232 (0x34000000) maps to nixbld inside sandbox
           sudo chown -R 872415232 /nix/var/cache/sccache
@@ -81,7 +82,7 @@ jobs:
         if: ${{ matrix.attr != '' }}
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Mount sccache disk
-        if: ${{ matrix.attr != '' && matrix.runs_on.group != 'self-hosted-runners-nix' }}
+        if: ${{ matrix.attr != '' && matrix.postgresql_version && matrix.runs_on.group != 'self-hosted-runners-nix' }}
         uses: useblacksmith/stickydisk@v1
         with:
           key: ${{ github.repository }}-sccache-${{ runner.os }}-${{ runner.arch }}-${{ matrix.cache_key }}
@@ -91,7 +92,8 @@ jobs:
         uses: ./.github/actions/nix-install-ephemeral
         with:
           push-to-cache: 'true'
-          enable-sccache-sandbox-path: 'true'
+          enable-sccache-sandbox-path: ${{ matrix.postgresql_version && 'true' || 'false' }}
+          max-jobs: ${{ matrix.postgresql_version && '1' || '' }}
         env:
           DEV_AWS_ROLE: ${{ secrets.DEV_AWS_ROLE }}
           NIX_SIGN_SECRET_KEY: ${{ secrets.NIX_SIGN_SECRET_KEY }}
@@ -99,7 +101,7 @@ jobs:
         if: ${{ matrix.attr != '' && matrix.runs_on.group == 'self-hosted-runners-nix' }}
         uses: ./.github/actions/nix-install-self-hosted
       - name: Allow sccache cache write access
-        if: ${{ matrix.attr != '' && matrix.runs_on.group != 'self-hosted-runners-nix' }}
+        if: ${{ matrix.attr != '' && matrix.postgresql_version && matrix.runs_on.group != 'self-hosted-runners-nix' }}
         run: |
           # With auto-allocate-uids, UID 872415232 (0x34000000) maps to nixbld inside sandbox
           sudo chown -R 872415232 /nix/var/cache/sccache
@@ -171,7 +173,7 @@ jobs:
         if: ${{ matrix.attr != '' }}
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Mount sccache disk
-        if: ${{ matrix.attr != '' && matrix.runs_on.group != 'self-hosted-runners-nix' }}
+        if: ${{ matrix.attr != '' && matrix.postgresql_version && matrix.runs_on.group != 'self-hosted-runners-nix' }}
         uses: useblacksmith/stickydisk@v1
         with:
           key: ${{ github.repository }}-sccache-${{ runner.os }}-${{ runner.arch }}-${{ matrix.cache_key }}
@@ -180,13 +182,14 @@ jobs:
         if: ${{ matrix.attr != '' }}
         uses: ./.github/actions/nix-install-ephemeral
         with:
-          enable-sccache-sandbox-path: 'true'
+          enable-sccache-sandbox-path: ${{ matrix.postgresql_version && 'true' || 'false' }}
+          max-jobs: ${{ matrix.postgresql_version && '1' || '' }}
           push-to-cache: 'true'
         env:
           DEV_AWS_ROLE: ${{ secrets.DEV_AWS_ROLE }}
           NIX_SIGN_SECRET_KEY: ${{ secrets.NIX_SIGN_SECRET_KEY }}
       - name: Allow sccache cache write access
-        if: ${{ matrix.attr != '' && matrix.runs_on.group != 'self-hosted-runners-nix' }}
+        if: ${{ matrix.attr != '' && matrix.postgresql_version && matrix.runs_on.group != 'self-hosted-runners-nix' }}
         run: |
           # With auto-allocate-uids, UID 872415232 (0x34000000) maps to nixbld inside sandbox
           sudo chown -R 872415232 /nix/var/cache/sccache
@@ -212,7 +215,7 @@ jobs:
         if: ${{ matrix.attr != '' }}
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Mount sccache disk
-        if: ${{ matrix.attr != '' && matrix.runs_on.group != 'self-hosted-runners-nix' }}
+        if: ${{ matrix.attr != '' && matrix.postgresql_version && matrix.runs_on.group != 'self-hosted-runners-nix' }}
         uses: useblacksmith/stickydisk@v1
         with:
           key: ${{ github.repository }}-sccache-${{ runner.os }}-${{ runner.arch }}-${{ matrix.cache_key }}
@@ -221,13 +224,14 @@ jobs:
         if: ${{ matrix.attr != '' }}
         uses: ./.github/actions/nix-install-ephemeral
         with:
-          enable-sccache-sandbox-path: 'true'
+          enable-sccache-sandbox-path: ${{ matrix.postgresql_version && 'true' || 'false' }}
+          max-jobs: ${{ matrix.postgresql_version && '1' || '' }}
           push-to-cache: 'true'
         env:
           DEV_AWS_ROLE: ${{ secrets.DEV_AWS_ROLE }}
           NIX_SIGN_SECRET_KEY: ${{ secrets.NIX_SIGN_SECRET_KEY }}
       - name: Allow sccache cache write access
-        if: ${{ matrix.attr != '' && matrix.runs_on.group != 'self-hosted-runners-nix' }}
+        if: ${{ matrix.attr != '' && matrix.postgresql_version && matrix.runs_on.group != 'self-hosted-runners-nix' }}
         run: |
           # With auto-allocate-uids, UID 872415232 (0x34000000) maps to nixbld inside sandbox
           sudo chown -R 872415232 /nix/var/cache/sccache

--- a/flake.lock
+++ b/flake.lock
@@ -118,15 +118,16 @@
     "nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1760472641,
-        "narHash": "sha256-BuKtM7Vr5EcxBXxUENBQPlOBwmNd5mkTRkSmlJi/iQ4=",
+        "lastModified": 1756804961,
+        "narHash": "sha256-TUkkfeQnfI7569O7bWI/v01GJct0OPYydLwINC6ksRo=",
         "owner": "NixOS",
         "repo": "nix",
-        "rev": "4041bfdb401ad6d1c31a292fab90392254be506a",
+        "rev": "e7540a269b3b711d67ae27b1bc2f93cc2d39eb21",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "2.31-maintenance",
         "repo": "nix",
         "type": "github"
       }
@@ -186,15 +187,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1760478325,
-        "narHash": "sha256-hA+NOH8KDcsuvH7vJqSwk74PyZP3MtvI/l+CggZcnTc=",
-        "owner": "nix-community",
+        "lastModified": 1768391686,
+        "narHash": "sha256-RQJz80jnTyX1Rria4ophU9JA1OXgQH2gI7KS+tt3tgc=",
+        "owner": "jfroche",
         "repo": "nix-eval-jobs",
-        "rev": "daa42f9e9c84aeff1e325dd50fda321f53dfd02c",
+        "rev": "643e2ee809cf9131a1bea239e250a719f8723010",
         "type": "github"
       },
       "original": {
-        "owner": "nix-community",
+        "owner": "jfroche",
+        "ref": "fix-warnings",
         "repo": "nix-eval-jobs",
         "type": "github"
       }
@@ -221,15 +223,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 315532800,
-        "narHash": "sha256-vhAtaRMIQiEghARviANBmSnhGz9Qf2IQJ+nQgsDXnVs=",
-        "rev": "c12c63cd6c5eb34c7b4c3076c6a99e00fcab86ec",
-        "type": "tarball",
-        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.11pre877036.c12c63cd6c5e/nixexprs.tar.xz"
+        "lastModified": 1752066716,
+        "narHash": "sha256-vMs55uRO/FmzFMWwVtXSnP1dxPC9u9M9I5jNVTqXVFA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "303269b20fe8f5218f8112ff1cbd2a926b75c147",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://nixos.org/channels/nixpkgs-unstable/nixexprs.tar.xz"
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "nixpkgs-lib": {

--- a/flake.lock
+++ b/flake.lock
@@ -118,16 +118,16 @@
     "nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1756804961,
-        "narHash": "sha256-TUkkfeQnfI7569O7bWI/v01GJct0OPYydLwINC6ksRo=",
+        "lastModified": 1770968833,
+        "narHash": "sha256-Q4zfM7aGr7FnhV0UAu0hCS+bG3I/U1YAVRJY+ep8a1I=",
         "owner": "NixOS",
         "repo": "nix",
-        "rev": "e7540a269b3b711d67ae27b1bc2f93cc2d39eb21",
+        "rev": "eef8a1a5ff03aad775ec4df66ff98e980cc458bc",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "2.31-maintenance",
+        "ref": "2.33-maintenance",
         "repo": "nix",
         "type": "github"
       }
@@ -187,16 +187,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1768391686,
-        "narHash": "sha256-RQJz80jnTyX1Rria4ophU9JA1OXgQH2gI7KS+tt3tgc=",
-        "owner": "jfroche",
+        "lastModified": 1771004889,
+        "narHash": "sha256-ONA7ztgyE2CC3T45NiGxQgCBQevAJ1+pEJlMQpREjBA=",
+        "owner": "nix-community",
         "repo": "nix-eval-jobs",
-        "rev": "643e2ee809cf9131a1bea239e250a719f8723010",
+        "rev": "8c9a3da0f95770bfc74e7a05823e212ff2bf1522",
         "type": "github"
       },
       "original": {
-        "owner": "jfroche",
-        "ref": "fix-warnings",
+        "owner": "nix-community",
         "repo": "nix-eval-jobs",
         "type": "github"
       }
@@ -223,17 +222,15 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1752066716,
-        "narHash": "sha256-vMs55uRO/FmzFMWwVtXSnP1dxPC9u9M9I5jNVTqXVFA=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "303269b20fe8f5218f8112ff1cbd2a926b75c147",
-        "type": "github"
+        "lastModified": 1767026758,
+        "narHash": "sha256-OuZZ71OA/6fZePPqgVinI4QVu9j1QCt+Q9i5ZgmSGqI=",
+        "rev": "346dd96ad74dc4457a9db9de4f4f57dab2e5731d",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre918255.346dd96ad74d/nixexprs.tar.xz"
       },
       "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://nixos.org/channels/nixpkgs-unstable/nixexprs.tar.xz"
       }
     },
     "nixpkgs-lib": {

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
     nix-editor.url = "github:snowfallorg/nix-editor";
     nix-eval-jobs.inputs.flake-parts.follows = "flake-parts";
     nix-eval-jobs.inputs.treefmt-nix.follows = "treefmt-nix";
-    nix-eval-jobs.url = "github:jfroche/nix-eval-jobs/fix-warnings";
+    nix-eval-jobs.url = "github:nix-community/nix-eval-jobs";
     nix2container.inputs.nixpkgs.follows = "nixpkgs";
     nix2container.url = "github:nlewo/nix2container";
     # Pin to a specific nixpkgs version that has compatible v8 and curl versions

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
     nix-editor.url = "github:snowfallorg/nix-editor";
     nix-eval-jobs.inputs.flake-parts.follows = "flake-parts";
     nix-eval-jobs.inputs.treefmt-nix.follows = "treefmt-nix";
-    nix-eval-jobs.url = "github:nix-community/nix-eval-jobs";
+    nix-eval-jobs.url = "github:jfroche/nix-eval-jobs/fix-warnings";
     nix2container.inputs.nixpkgs.follows = "nixpkgs";
     nix2container.url = "github:nlewo/nix2container";
     # Pin to a specific nixpkgs version that has compatible v8 and curl versions

--- a/nix/cargo-pgrx/buildPgrxExtension.nix
+++ b/nix/cargo-pgrx/buildPgrxExtension.nix
@@ -169,7 +169,7 @@ let
         echo "sccache: cache directory available, enabling"
         export RUSTC_WRAPPER="${sccache}/bin/sccache"
         export SCCACHE_DIR="/nix/var/cache/sccache"
-        export SCCACHE_CACHE_SIZE="500G"
+        export SCCACHE_CACHE_SIZE="50G"
       else
         echo "sccache: cache directory not available, skipping"
       fi

--- a/nix/cargo-pgrx/buildPgrxExtension.nix
+++ b/nix/cargo-pgrx/buildPgrxExtension.nix
@@ -164,12 +164,29 @@ let
 
     buildPhase = ''
       runHook preBuild
-
+      echo "Platform: ${stdenv.system}"
+      echo "isDarwin: ${lib.boolToString stdenv.isDarwin}"
       if [[ -d "/nix/var/cache/sccache" && -w "/nix/var/cache/sccache" ]]; then
-        echo "sccache: cache directory available, enabling"
-        export RUSTC_WRAPPER="${sccache}/bin/sccache"
-        export SCCACHE_DIR="/nix/var/cache/sccache"
-        export SCCACHE_CACHE_SIZE="50G"
+        if touch "/nix/var/cache/sccache/.test" 2>/dev/null && rm -f "/nix/var/cache/sccache/.test" 2>/dev/null; then
+          echo "sccache: cache directory available and writable, enabling"
+          ${lib.optionalString stdenv.isDarwin ''
+            # Darwin: Use shared /tmp for TMPDIR to avoid sccache caching per-build temp paths
+            export TMPDIR=/tmp
+            export TEMP=/tmp
+            export TEMPDIR=/tmp
+            export TMP=/tmp
+          ''}
+          export RUSTC_WRAPPER="${sccache}/bin/sccache"
+          export SCCACHE_DIR="/nix/var/cache/sccache"
+          export SCCACHE_CACHE_SIZE="50G"
+          export SCCACHE_LOG=debug
+          export SCCACHE_IDLE_TIMEOUT=0
+          # Use unique port per user to isolate sccache servers
+          USER_ID=$(id -u)
+          export SCCACHE_SERVER_PORT=$((4226 + USER_ID % 100))
+        else
+          echo "sccache: cache directory not accessible in sandbox, skipping"
+        fi
       else
         echo "sccache: cache directory not available, skipping"
       fi

--- a/nix/cargo-pgrx/buildPgrxExtension.nix
+++ b/nix/cargo-pgrx/buildPgrxExtension.nix
@@ -34,6 +34,7 @@
   stdenv,
   writeShellScriptBin,
   defaultBindgenHook,
+  sccache,
 }:
 
 # The idea behind: Use it mostly like rustPlatform.buildRustPackage and so
@@ -55,7 +56,7 @@
   postgresql,
   # enable override to generate bindings using bindgenHook.
   # Some older versions of cargo-pgrx use a bindgenHook that is not compatible with the
-  # current clang version present in stdenv
+  # current clang version present in stdenv
   bindgenHook ? defaultBindgenHook,
   # cargo-pgrx calls rustfmt on generated bindings, this is not strictly necessary, so we avoid the
   # dependency here. Set to false and provide rustfmt in nativeBuildInputs, if you need it, e.g.
@@ -157,11 +158,21 @@ let
         postgresql
         pkg-config
         bindgenHook
+        sccache
       ]
       ++ lib.optionals useFakeRustfmt [ fakeRustfmt ];
 
     buildPhase = ''
       runHook preBuild
+
+      if [[ -d "/nix/var/cache/sccache" && -w "/nix/var/cache/sccache" ]]; then
+        echo "sccache: cache directory available, enabling"
+        export RUSTC_WRAPPER="${sccache}/bin/sccache"
+        export SCCACHE_DIR="/nix/var/cache/sccache"
+        export SCCACHE_CACHE_SIZE="500G"
+      else
+        echo "sccache: cache directory not available, skipping"
+      fi
 
       echo "Executing cargo-pgrx buildPhase"
       ${preBuildAndTest}
@@ -182,6 +193,11 @@ let
         ${maybeDebugFlag} \
         --features "${builtins.concatStringsSep " " buildFeatures}" \
         --out-dir "$out"
+
+      if [[ -n "''${RUSTC_WRAPPER:-}" ]]; then
+        echo "sccache stats:"
+        ${sccache}/bin/sccache --show-stats
+      fi
 
       ${maybeLeaveBuildAndTestSubdir}
 

--- a/nix/docs/README.md
+++ b/nix/docs/README.md
@@ -41,6 +41,10 @@ learn how to play with `postgres` in the [build guide](./build-postgres.md).
 - **[Testing PG Upgrade Scripts](./testing-pg-upgrade-scripts.md)** - Testing PostgreSQL upgrades
 - **[Docker Image testing](./docker-testing.md)** - How to test the docker images against the pg_regress test suite.
 
+## CI/CD
+
+- **[sccache in CI](./sccache-ci.md)** - Rust compilation caching for pgrx extensions
+
 ## Reference
 
 - **[References](./references.md)** - Useful links and resources

--- a/nix/docs/sccache-ci.md
+++ b/nix/docs/sccache-ci.md
@@ -1,0 +1,88 @@
+# sccache in CI
+
+This document explains how sccache is integrated into the Nix CI pipeline to accelerate Rust compilation for pgrx-based PostgreSQL extensions.
+
+## Overview
+
+Building pgrx extensions (pg_graphql, pg_jsonschema, wrappers, etc.) involves significant Rust compilation.
+sccache caches compiled artifacts to speed up subsequent builds when source code hasn't changed.
+
+The integration required solving several challenges around Nix's sandboxed builds and CI runner persistence.
+
+## Architecture
+
+Ephemeral CI runners (Blacksmith) use stickydisk for persistent storage at `/nix/var/cache/sccache`.
+Self-hosted Darwin runners use a local directory at the same path.
+
+The cache is keyed by PostgreSQL version to avoid cross-version cache pollution:
+- Extension packages: `sccache-Linux-ARM64-pg17`, `sccache-Linux-ARM64-pg15`, etc.
+- Non-extension packages: `sccache-Linux-ARM64-shared`
+
+| Platform | Runner type | sccache enabled |
+|----------|-------------|-----------------|
+| x86_64-linux | Blacksmith ephemeral | Yes (extensions only) |
+| aarch64-linux | Blacksmith ephemeral | Yes (extensions only) |
+| aarch64-linux | Self-hosted (KVM packages) | No |
+| aarch64-darwin | Self-hosted | Yes (extensions only) |
+
+## Nix sandbox integration
+
+Nix builds run in a sandbox that isolates the build environment.
+To allow sccache to persist across builds, the cache directory must be mounted into the sandbox via `extra-sandbox-paths`.
+
+### Linux with auto-allocate-uids
+
+On Linux, we use Nix's `auto-allocate-uids` feature which creates user namespaces for builds.
+This introduces a UID mapping challenge.
+
+The base UID is 872415232 (0x34000000).
+Inside the sandbox, processes run as root (UID 0), but outside the sandbox this maps to UID 872415232.
+Files created inside the sandbox are owned by this mapped UID.
+
+The workflow changes ownership to UID 872415232 before builds to ensure cache access works correctly.
+
+### Darwin
+
+Darwin doesn't have user namespaces.
+Builds run as nixbld users (members of the `nixbld` group).
+The cache directory is owned by the nixbld group with setgid permissions.
+
+## Compromises and limitations
+
+### max-jobs = 1 for extensions
+
+With `auto-allocate-uids`, each parallel Nix build gets a different UID slot (872415232, 872480768, etc.).
+When multiple builds run in parallel, they create files with different ownership, causing EPERM errors when one build tries to update another's cache files.
+
+To avoid this, extension builds use `max-jobs = 1`, serializing Nix builds so all use the same UID slot.
+Non-extension packages don't use sccache and can build in parallel.
+
+### Blacksmith stickydisk last-writer-wins
+
+Blacksmith's stickydisk has "last writer wins" semantics for concurrent writes.
+If multiple jobs write to the same cache key simultaneously, only the last job's writes persist.
+
+We mitigate this by using per-PostgreSQL-version cache keys, reducing concurrent writes to the same cache.
+
+### Extensions only
+
+sccache is only enabled for extension packages (those with `postgresql_version` in the matrix).
+Non-extension packages (PostgreSQL itself, tooling) build without sccache to allow parallel builds.
+
+## Debugging
+
+To check sccache statistics, look for output at the end of extension builds:
+
+```
+sccache stats:
+Compile requests                    150
+Compile requests executed           148
+Cache hits                          120
+Cache misses                         28
+```
+
+## References
+
+- [Nix auto-allocate-uids](https://nixos.org/manual/nix/stable/command-ref/conf-file.html#conf-auto-allocate-uids)
+- [sccache](https://github.com/mozilla/sccache)
+- [Blacksmith stickydisk](https://blacksmith.sh/docs/stickydisk)

--- a/nix/ext/pg_graphql/default.nix
+++ b/nix/ext/pg_graphql/default.nix
@@ -132,9 +132,11 @@ let
       supportedVersions;
   versionsBuilt = if latestOnly then [ latestVersion ] else versions;
   numberOfVersionsBuilt = builtins.length versionsBuilt;
-  packages = builtins.attrValues (
-    lib.mapAttrs (name: value: build name value.hash value.rust value.pgrx) versionsToUse
-  );
+  packagesAttrSet = lib.mapAttrs' (name: value: {
+    name = lib.replaceStrings [ "." ] [ "_" ] name;
+    value = build name value.hash value.rust value.pgrx;
+  }) versionsToUse;
+  packages = builtins.attrValues packagesAttrSet;
 in
 (buildEnv {
   name = pname;
@@ -187,6 +189,10 @@ in
         latestVersion
       else
         "multi-" + lib.concatStringsSep "-" (map (v: lib.replaceStrings [ "." ] [ "-" ] v) versions);
+    # Expose individual packages for CI to build separately
+    packages = packagesAttrSet // {
+      recurseForDerivations = true;
+    };
   };
 }).overrideAttrs
   (_: {

--- a/nix/ext/pg_jsonschema/default.nix
+++ b/nix/ext/pg_jsonschema/default.nix
@@ -137,9 +137,11 @@ let
       { "${latestVersion}" = supportedVersions.${latestVersion}; }
     else
       supportedVersions;
-  packages = builtins.attrValues (
-    lib.mapAttrs (name: value: build name value.hash value.rust value.pgrx) versionsToUse
-  );
+  packagesAttrSet = lib.mapAttrs' (name: value: {
+    name = lib.replaceStrings [ "." ] [ "_" ] name;
+    value = build name value.hash value.rust value.pgrx;
+  }) versionsToUse;
+  packages = builtins.attrValues packagesAttrSet;
   versionsBuilt = if latestOnly then [ latestVersion ] else versions;
   numberOfVersionsBuilt = builtins.length versionsBuilt;
 in
@@ -186,6 +188,10 @@ in
         latestVersion
       else
         "multi-" + lib.concatStringsSep "-" (map (v: lib.replaceStrings [ "." ] [ "-" ] v) versions);
+    # Expose individual packages for CI to build separately
+    packages = packagesAttrSet // {
+      recurseForDerivations = true;
+    };
   };
 }).overrideAttrs
   (_: {

--- a/nix/packages/github-matrix/github_matrix.py
+++ b/nix/packages/github-matrix/github_matrix.py
@@ -58,6 +58,7 @@ class GitHubActionPackage(TypedDict):
     system: System
     runs_on: RunsOnConfig
     postgresql_version: NotRequired[str]
+    cache_key: NotRequired[str]
 
 
 class NixEvalError(TypedDict):
@@ -213,8 +214,7 @@ def run_nix_eval_jobs(
 
 def is_extension_pkg(pkg: NixEvalJobsOutput) -> bool:
     """Check if the package is a postgresql extension package."""
-    attrs = pkg["attr"].split(".")
-    return attrs[-2] == "exts"
+    return ".exts." in pkg["attr"]
 
 
 # thank you buildbot-nix https://github.com/nix-community/buildbot-nix/blob/985d069a2a45cf4a571a4346107671adc2bd2a16/buildbot_nix/buildbot_nix/build_trigger.py#L297
@@ -249,6 +249,31 @@ def is_large_pkg(pkg: NixEvalJobsOutput) -> bool:
 def is_kvm_pkg(pkg: NixEvalJobsOutput) -> bool:
     """Determine if a package requires KVM"""
     return "kvm" in pkg.get("requiredSystemFeatures", [])
+
+
+def clean_package_for_output(pkg: NixEvalJobsOutput) -> GitHubActionPackage:
+    """Convert nix-eval-jobs output to GitHub Actions matrix package"""
+    runner = get_runner_for_package(pkg)
+    if runner is None:
+        raise ValueError(f"No runner configuration for system: {pkg['system']}")
+    returned_pkg: GitHubActionPackage = {
+        "attr": pkg["attr"],
+        "name": pkg["name"],
+        "system": pkg["system"],
+        "runs_on": runner,
+    }
+    if is_extension_pkg(pkg):
+        # Extract PostgreSQL version from attribute path
+        # e.g., legacyPackages.aarch64-linux.psql_17.exts.wrappers-pkgs.0_5_6
+        #   or  legacyPackages.aarch64-linux.psql_17.exts.pg_graphql
+        attrs = pkg["attr"].split(".")
+        exts_idx = attrs.index("exts")
+        pg_version = attrs[exts_idx - 1].split("_")[-1]
+        returned_pkg["postgresql_version"] = pg_version
+        returned_pkg["cache_key"] = f"pg{pg_version}"
+    else:
+        returned_pkg["cache_key"] = "shared"
+    return returned_pkg
 
 
 def get_runner_for_package(pkg: NixEvalJobsOutput) -> RunsOnConfig | None:
@@ -303,23 +328,6 @@ def main() -> None:
     # Run evaluation and collect packages, warnings, and errors
     packages, warnings_list, errors_list = run_nix_eval_jobs(cmd)
     gh_action_packages = sort_pkgs_by_closures(packages)
-
-    def clean_package_for_output(pkg: NixEvalJobsOutput) -> GitHubActionPackage:
-        """Convert nix-eval-jobs output to GitHub Actions matrix package"""
-        runner = get_runner_for_package(pkg)
-        if runner is None:
-            raise ValueError(f"No runner configuration for system: {pkg['system']}")
-        returned_pkg: GitHubActionPackage = {
-            "attr": pkg["attr"],
-            "name": pkg["name"],
-            "system": pkg["system"],
-            "runs_on": runner,
-        }
-        if is_extension_pkg(pkg):
-            # Extract PostgreSQL version from attribute path
-            attrs = pkg["attr"].split(".")
-            returned_pkg["postgresql_version"] = attrs[-3].split("_")[-1]
-        return returned_pkg
 
     # Group packages by system and type (checks vs packages)
     packages_by_system: Dict[System, List[GitHubActionPackage]] = defaultdict(list)

--- a/nix/packages/github-matrix/github_matrix.py
+++ b/nix/packages/github-matrix/github_matrix.py
@@ -172,7 +172,7 @@ def run_nix_eval_jobs(
     Returns:
         Tuple of (packages, warnings_list, errors_list)
     """
-    debug(f"Running command: {' '.join(cmd)}")
+    print(f"Running: {' '.join(cmd)}", file=sys.stderr)
 
     # Disable colors in nix output
     env = os.environ.copy()

--- a/nix/packages/github-matrix/github_matrix.py
+++ b/nix/packages/github-matrix/github_matrix.py
@@ -89,7 +89,9 @@ BUILD_RUNNER_MAP: Dict[RunnerType, Dict[System, RunsOnConfig]] = {
 }
 
 
-def build_nix_eval_command(max_workers: int, flake_outputs: List[str]) -> List[str]:
+def build_nix_eval_command(
+    max_workers: int, max_memory_size: int, flake_outputs: List[str]
+) -> List[str]:
     """Build the nix-eval-jobs command with appropriate flags."""
     nix_eval_cmd = [
         "nix-eval-jobs",
@@ -104,6 +106,8 @@ def build_nix_eval_command(max_workers: int, flake_outputs: List[str]) -> List[s
         "--option",
         "accept-flake-config",
         "true",
+        "--max-memory-size",
+        str(max_memory_size),
         "--workers",
         str(max_workers),
         "--select",
@@ -281,6 +285,12 @@ def main() -> None:
         description="Generate GitHub Actions matrix for Nix builds"
     )
     parser.add_argument(
+        "--max-memory-size",
+        default=3072,
+        type=int,
+        help="Maximum memory per eval worker in MiB. Defaults to 3072 (3 GiB).",
+    )
+    parser.add_argument(
         "flake_outputs", nargs="+", help="Nix flake outputs to evaluate"
     )
 
@@ -288,7 +298,7 @@ def main() -> None:
 
     max_workers: int = os.cpu_count() or 1
 
-    cmd = build_nix_eval_command(max_workers, args.flake_outputs)
+    cmd = build_nix_eval_command(max_workers, args.max_memory_size, args.flake_outputs)
 
     # Run evaluation and collect packages, warnings, and errors
     packages, warnings_list, errors_list = run_nix_eval_jobs(cmd)

--- a/nix/packages/github-matrix/tests/test_github_matrix.py
+++ b/nix/packages/github-matrix/tests/test_github_matrix.py
@@ -4,6 +4,7 @@ import pytest
 
 from github_matrix import (
     NixEvalJobsOutput,
+    clean_package_for_output,
     get_runner_for_package,
     is_extension_pkg,
     is_kvm_pkg,
@@ -260,3 +261,80 @@ class TestSortPkgsByClosures:
 
         result = sort_pkgs_by_closures([pkg1, pkg2])
         assert result == [pkg1, pkg2]
+
+
+class TestCleanPackageForOutput:
+    def test_extension_package_simple_path(self):
+        """Test extension package like pg_graphql with simple attr path"""
+        pkg: NixEvalJobsOutput = {
+            "attr": "legacyPackages.aarch64-linux.psql_17.exts.pg_graphql",
+            "attrPath": [
+                "legacyPackages",
+                "aarch64-linux",
+                "psql_17",
+                "exts",
+                "pg_graphql",
+            ],
+            "cacheStatus": "notBuilt",
+            "drvPath": "/nix/store/test.drv",
+            "name": "pg_graphql",
+            "system": "aarch64-linux",
+        }
+        result = clean_package_for_output(pkg)
+        assert result["postgresql_version"] == "17"
+        assert result["cache_key"] == "pg17"
+
+    def test_extension_package_versioned_path(self):
+        """Test extension package like wrappers with version suffix in attr path"""
+        pkg: NixEvalJobsOutput = {
+            "attr": "legacyPackages.aarch64-linux.psql_17.exts.wrappers-pkgs.0_5_6",
+            "attrPath": [
+                "legacyPackages",
+                "aarch64-linux",
+                "psql_17",
+                "exts",
+                "wrappers-pkgs",
+                "0_5_6",
+            ],
+            "cacheStatus": "notBuilt",
+            "drvPath": "/nix/store/test.drv",
+            "name": "wrappers-0.5.6",
+            "system": "aarch64-linux",
+        }
+        result = clean_package_for_output(pkg)
+        assert result["postgresql_version"] == "17"
+        assert result["cache_key"] == "pg17"
+
+    def test_extension_package_pg15(self):
+        """Test extension package with PostgreSQL 15"""
+        pkg: NixEvalJobsOutput = {
+            "attr": "legacyPackages.x86_64-linux.psql_15.exts.pg_cron",
+            "attrPath": [
+                "legacyPackages",
+                "x86_64-linux",
+                "psql_15",
+                "exts",
+                "pg_cron",
+            ],
+            "cacheStatus": "notBuilt",
+            "drvPath": "/nix/store/test.drv",
+            "name": "pg_cron",
+            "system": "x86_64-linux",
+        }
+        result = clean_package_for_output(pkg)
+        assert result["postgresql_version"] == "15"
+        assert result["cache_key"] == "pg15"
+
+    def test_non_extension_package(self):
+        """Test non-extension package gets shared cache key"""
+        pkg: NixEvalJobsOutput = {
+            "attr": "legacyPackages.x86_64-linux.psql_15",
+            "attrPath": ["legacyPackages", "x86_64-linux", "psql_15"],
+            "cacheStatus": "notBuilt",
+            "drvPath": "/nix/store/test.drv",
+            "name": "postgresql-15.0",
+            "system": "x86_64-linux",
+        }
+        result = clean_package_for_output(pkg)
+        assert "postgresql_version" not in result
+        assert result["cache_key"] == "shared"

--- a/nix/packages/github-matrix/tests/test_github_matrix.py
+++ b/nix/packages/github-matrix/tests/test_github_matrix.py
@@ -126,6 +126,24 @@ class TestGetRunnerForPackage:
             "labels": ["aarch64-linux"],
         }
 
+    def test_nixos_test_aarch64_linux(self):
+        """NixOS VM tests have both kvm and nixos-test in requiredSystemFeatures.
+        They must be routed to self-hosted runners with KVM support."""
+        pkg: NixEvalJobsOutput = {
+            "attr": "checks.aarch64-linux.ext-index_advisor",
+            "attrPath": ["checks", "aarch64-linux", "ext-index_advisor"],
+            "cacheStatus": "notBuilt",
+            "drvPath": "/nix/store/test.drv",
+            "name": "vm-test-run-index_advisor",
+            "system": "aarch64-linux",
+            "requiredSystemFeatures": ["kvm", "nixos-test"],
+        }
+        result = get_runner_for_package(pkg)
+        assert result == {
+            "group": "self-hosted-runners-nix",
+            "labels": ["aarch64-linux"],
+        }
+
     def test_large_package_x86_64_linux(self):
         pkg: NixEvalJobsOutput = {
             "attr": "legacyPackages.x86_64-linux.psql_15.exts.postgis",


### PR DESCRIPTION
Speed up rust builds by enabling sccache caching for cargo-pgrx builds in GitHub Actions. We mount a persistent disk at /var/cache/sccache and configure sccache to use it.