### PR TITLE
fix(pg-upgrade): fixes a bug initiate.sh's conf parser

### DIFF
--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
@@ -212,7 +212,7 @@ EOF
 
 function initiate_upgrade {
     mkdir -p "$MOUNT_POINT"
-    SHARED_PRELOAD_LIBRARIES=$(cat "$POSTGRES_CONFIG_PATH" | grep shared_preload_libraries | sed "s/shared_preload_libraries =\s\{0,1\}'\(.*\)'.*/\1/")
+    SHARED_PRELOAD_LIBRARIES=$(grep '^[[:space:]]*shared_preload_libraries' "$POSTGRES_CONFIG_PATH" | sed "s/shared_preload_libraries =\s\{0,1\}'\(.*\)'.*/\1/")
 
     # Wrappers officially launched in PG15; PG14 version is incompatible
     if [[ "$OLD_PGVERSION" =~ 14* ]]; then
@@ -241,7 +241,7 @@ function initiate_upgrade {
         SHARED_PRELOAD_LIBRARIES=$(echo "$SHARED_PRELOAD_LIBRARIES" | sed "s/.$//" | xargs)
     fi
 
-    PGDATAOLD=$(cat "$POSTGRES_CONFIG_PATH" | grep data_directory | sed "s/data_directory = '\(.*\)'.*/\1/")
+    PGDATAOLD=$(grep '^[[:space:]]*data_directory' "$POSTGRES_CONFIG_PATH" | sed "s/data_directory = '\(.*\)'.*/\1/")
 
     PGDATANEW="$MOUNT_POINT/pgdata"
 


### PR DESCRIPTION
- this fixes the bug in how initiate.sh parses the postgresql.conf file by ignoring commented-out lines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PostgreSQL upgrade process by enhancing configuration value extraction to properly handle indented configuration parameters, ensuring more reliable upgrades in various server environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->