### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/dockerhub-release-matrix.yml
+++ b/.github/workflows/dockerhub-release-matrix.yml
@@ -164,7 +164,7 @@ jobs:
         run: |
           echo "${{ steps.output_version.outputs.result }}" >> results.txt  # Append results
       - name: Upload Results Artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: merge_results-${{ matrix.version }}
           path: results.txt
@@ -203,7 +203,7 @@ jobs:
             $"versions=$versions_str" | save --append $env.GITHUB_ENV
           '
       - name: Download Results Artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
         with:
           pattern: merge_results-*
       - name: Combine Results

--- a/.github/workflows/manual-docker-release.yml
+++ b/.github/workflows/manual-docker-release.yml
@@ -173,7 +173,7 @@ jobs:
         run: |
           echo "${{ steps.output_version.outputs.result }}" >> results.txt  # Append results
       - name: Upload Results Artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: merge_results-${{ matrix.version }}
           path: results.txt
@@ -212,7 +212,7 @@ jobs:
             $"versions=$versions_str" | save --append $env.GITHUB_ENV
           '
       - name: Download Results Artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
         with:
           pattern: merge_results-*
       - name: Combine Results

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - name: Checkout Repo
         if: ${{ matrix.attr != '' }}
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
       - name: Install nix (ephemeral)
         if: ${{ matrix.attr != '' && matrix.runs_on.group != 'self-hosted-runners-nix' }}
         uses: ./.github/actions/nix-install-ephemeral
@@ -66,7 +66,7 @@ jobs:
     steps:
       - name: Checkout Repo
         if: ${{ matrix.attr != '' }}
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
       - name: Install nix (ephemeral)
         if: ${{ matrix.attr != '' && matrix.runs_on.group != 'self-hosted-runners-nix' }}
         uses: ./.github/actions/nix-install-ephemeral
@@ -97,7 +97,7 @@ jobs:
     steps:
       - name: Checkout Repo
         if: ${{ matrix.attr != '' }}
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
       - name: Install nix
         if: ${{ matrix.attr != '' }}
         uses: ./.github/actions/nix-install-self-hosted
@@ -120,7 +120,7 @@ jobs:
     steps:
       - name: Checkout Repo
         if: ${{ matrix.attr != '' }}
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
       - name: Install nix
         if: ${{ matrix.attr != '' }}
         uses: ./.github/actions/nix-install-self-hosted
@@ -143,7 +143,7 @@ jobs:
     steps:
       - name: Checkout Repo
         if: ${{ matrix.attr != '' }}
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
       - name: Install nix
         if: ${{ matrix.attr != '' }}
         uses: ./.github/actions/nix-install-ephemeral
@@ -171,7 +171,7 @@ jobs:
     steps:
       - name: Checkout Repo
         if: ${{ matrix.attr != '' }}
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
       - name: Install nix
         if: ${{ matrix.attr != '' }}
         uses: ./.github/actions/nix-install-ephemeral

--- a/.github/workflows/nix-eval.yml
+++ b/.github/workflows/nix-eval.yml
@@ -23,7 +23,7 @@ jobs:
       checks_matrix: ${{ steps.set-matrix.outputs.checks_matrix }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
       - name: Install nix
         uses: ./.github/actions/nix-install-ephemeral
         with:


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [`34e1148`](https://github.com/actions/checkout/commit/34e114876b0b11c390a56381ad16ebd13914f8d5) | [`8e8c483`](https://github.com/actions/checkout/commit/8e8c483db84b4bee98b60c0593521ed34d9990e8) | [Release](https://github.com/actions/checkout/releases/tag/v6) | nix-build.yml, nix-eval.yml |
| `actions/download-artifact` | [`d3f86a1`](https://github.com/actions/download-artifact/commit/d3f86a106a0bac45b974a628896c90dbdf5c8093) | [`37930b1`](https://github.com/actions/download-artifact/commit/37930b1c2abaa49bbe596cd826c3c89aef350131) | [Release](https://github.com/actions/download-artifact/releases/tag/v7) | dockerhub-release-matrix.yml, manual-docker-release.yml |
| `actions/upload-artifact` | [`ea165f8`](https://github.com/actions/upload-artifact/commit/ea165f8d65b6e75b540449e92b4886f43607fa02) | [`b7c566a`](https://github.com/actions/upload-artifact/commit/b7c566a772e6b6bfb58ed0dc250532a479d7789f) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) | dockerhub-release-matrix.yml, manual-docker-release.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
