### PR TITLE
fix: disable sticky disk usage in Nix eval workflow

### DIFF
--- a/.github/workflows/nix-eval.yml
+++ b/.github/workflows/nix-eval.yml
@@ -31,17 +31,6 @@ jobs:
         env:
           DEV_AWS_ROLE: ${{ secrets.DEV_AWS_ROLE }}
           NIX_SIGN_SECRET_KEY: ${{ secrets.NIX_SIGN_SECRET_KEY }}
-      - name: Restart Nix Daemon
-        run: |
-          sudo mv /nix/var/nix/daemon-socket/socket /tmp
-      - name: Mount Nix cache disk
-        uses: useblacksmith/stickydisk@a652394bf1bf95399f406e648482b41fbd25c51f # v1
-        with:
-          key: ${{ github.repository }}-nix-cache-eval-${{ runner.os }}
-          path: /nix
-      - name: Restart Nix Daemon
-        run: |
-          sudo systemctl restart nix-daemon.service nix-daemon.socket
       - id: set-matrix
         name: Generate Nix Matrix
         run: |


### PR DESCRIPTION
Need to be debugging a order issue with the Nix eval workflow, so disabling the sticky disk usage for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed three automation steps from the GitHub Actions workflow configuration, streamlining the CI pipeline and reducing overhead in the build process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->