### PR TITLE
fix: enable stickydisk again with new nix-installer-action

### DIFF
--- a/.github/actions/nix-install-ephemeral/action.yml
+++ b/.github/actions/nix-install-ephemeral/action.yml
@@ -40,11 +40,10 @@ runs:
         sudo chmod +x /etc/nix/upload-to-cache.sh
       env:
         NIX_SIGN_SECRET_KEY: ${{ env.NIX_SIGN_SECRET_KEY }}
-    - name: Install nix
-      uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15 # v31.9.0
+    - uses: NixOS/nix-installer-action@d6ef7ecd8f685af89869e5aca0580a33e3e3150c
       with:
-        install_url: https://releases.nixos.org/nix/nix-2.32.2/install
-        extra_nix_config: |
+        installer-version: 2.33.1
+        extra-conf: |
           substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com
           trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           ${{ inputs.push-to-cache == 'true' && 'post-build-hook = /etc/nix/upload-to-cache.sh' || '' }}

--- a/.github/workflows/base-image-nightly.yml
+++ b/.github/workflows/base-image-nightly.yml
@@ -26,21 +26,13 @@ jobs:
         with:
           ref: ${{ github.event.inputs.branch || 'develop' }}
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+      - name: Install nix (ephemeral)
+        uses: ./.github/actions/nix-install-ephemeral
         with:
-          role-to-assume: ${{ secrets.DEV_AWS_ROLE }}
-          aws-region: "us-east-1"
-          output-credentials: true
-          role-duration-seconds: 7200
-
-      - name: Install nix
-        uses: cachix/install-nix-action@ba0dd844c9180cbf77aa72a116d6fbc515d0e87b # v27
-        with:
-          install_url: https://releases.nixos.org/nix/nix-2.29.1/install
-          extra_nix_config: |
-            substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com
-            trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+          push-to-cache: 'true'
+        env:
+          DEV_AWS_ROLE: ${{ secrets.DEV_AWS_ROLE }}
+          NIX_SIGN_SECRET_KEY: ${{ secrets.NIX_SIGN_SECRET_KEY }}
 
       - name: Set execution ID and timestamp
         run: |

--- a/.github/workflows/nix-eval.yml
+++ b/.github/workflows/nix-eval.yml
@@ -24,6 +24,15 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Mount Nix cache disk
+        uses: useblacksmith/stickydisk@a652394bf1bf95399f406e648482b41fbd25c51f # v1
+        with:
+          key: ${{ github.repository }}-nix-cache-eval-${{ runner.os }}
+          path: /nix
+      - name: Remove existing Nix socket
+        run: |
+          sudo rm /nix/var/nix/daemon-socket/socket /nix/receipt.json || true
+          sudo chown root /nix /nix/var /nix/var/nix || true
       - name: Install nix
         uses: ./.github/actions/nix-install-ephemeral
         with:

--- a/Dockerfile-15
+++ b/Dockerfile-15
@@ -106,7 +106,7 @@ extra-experimental-features = nix-command flakes
 extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
 extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=
 EOF
-RUN curl -L https://releases.nixos.org/nix/nix-2.32.2/install | sh -s -- --daemon --no-channel-add --yes --nix-extra-conf-file /tmp/extra-nix.conf
+RUN curl -L https://releases.nixos.org/nix/nix-2.33.1/install | sh -s -- --daemon --no-channel-add --yes --nix-extra-conf-file /tmp/extra-nix.conf
 ENV PATH="${PATH}:/nix/var/nix/profiles/default/bin"
 
 COPY . /nixpg

--- a/Dockerfile-17
+++ b/Dockerfile-17
@@ -108,7 +108,7 @@ extra-experimental-features = nix-command flakes
 extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
 extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=
 EOF
-RUN curl -L https://releases.nixos.org/nix/nix-2.32.2/install | sh -s -- --daemon --no-channel-add --yes --nix-extra-conf-file /tmp/extra-nix.conf
+RUN curl -L https://releases.nixos.org/nix/nix-2.33.1/install | sh -s -- --daemon --no-channel-add --yes --nix-extra-conf-file /tmp/extra-nix.conf
 
 ENV PATH="${PATH}:/nix/var/nix/profiles/default/bin"
 

--- a/Dockerfile-orioledb-17
+++ b/Dockerfile-orioledb-17
@@ -108,7 +108,7 @@ extra-experimental-features = nix-command flakes
 extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
 extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=
 EOF
-RUN curl -L https://releases.nixos.org/nix/nix-2.32.2/install | sh -s -- --daemon --no-channel-add --yes --nix-extra-conf-file /tmp/extra-nix.conf
+RUN curl -L https://releases.nixos.org/nix/nix-2.33.1/install | sh -s -- --daemon --no-channel-add --yes --nix-extra-conf-file /tmp/extra-nix.conf
 
 ENV PATH="${PATH}:/nix/var/nix/profiles/default/bin"
 

--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
@@ -297,7 +297,7 @@ function initiate_upgrade {
                         --extra-conf "trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
                     else
                         echo "1.1.1. Installing Nix using the official installer"
-                        sh <(curl -L https://releases.nixos.org/nix/nix-2.32.2/install) --yes --daemon --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
+                        sh <(curl -L https://releases.nixos.org/nix/nix-2.33.1/install) --yes --daemon --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
 extra-experimental-features = nix-command flakes
 extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
 extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=

--- a/ebssurrogate/scripts/qemu-bootstrap-nix.sh
+++ b/ebssurrogate/scripts/qemu-bootstrap-nix.sh
@@ -82,7 +82,7 @@ execute_playbook
 ####################
 
 function install_nix() {
-    sudo su -c "sh <(curl -L https://releases.nixos.org/nix/nix-2.32.2/install) --yes --daemon --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
+    sudo su -c "sh <(curl -L https://releases.nixos.org/nix/nix-2.33.1/install) --yes --daemon --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
 extra-experimental-features = nix-command flakes
 extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
 extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=

--- a/nix/docs/start-here.md
+++ b/nix/docs/start-here.md
@@ -83,12 +83,12 @@ extra-substituters =
 
 **Important**: Replace `YOUR_USERNAME` with your actual username in the `trusted-users` line.
 
-### Step 2: Install Nix 2.29.2
+### Step 2: Install Nix 2.33.1
 
-Run the following command to install Nix 2.29.2 (the version used in CI) with the custom configuration:
+Run the following command to install Nix 2.33.1 (the version used in CI) with the custom configuration:
 
 ```bash
-curl -L https://releases.nixos.org/nix/nix-2.29.2/install | sh -s -- --daemon --yes --nix-extra-conf-file ./nix.conf
+curl -L https://releases.nixos.org/nix/nix-2.33.1/install | sh -s -- --daemon --yes --nix-extra-conf-file ./nix.conf
 ```
 
 This will install Nix with our build caches pre-configured, which should eliminate substituter-related errors.
@@ -103,7 +103,7 @@ same commands on your machine:
 
 ```
 $ nix --version
-nix (Nix) 2.29.2
+nix (Nix) 2.33.1
 ```
 
 ```
@@ -112,7 +112,7 @@ $ nix run nixpkgs#nix-info -- -m
  - host os: `Linux 5.15.90.1-microsoft-standard-WSL2, Ubuntu, 22.04.2 LTS (Jammy Jellyfish), nobuild`
  - multi-user?: `yes`
  - sandbox: `yes`
- - version: `nix-env (Nix) 2.29.2`
+ - version: `nix-env (Nix) 2.33.1`
  - channels(root): `"nixpkgs"`
  - nixpkgs: `/nix/var/nix/profiles/per-user/root/channels/nixpkgs`
 ```

--- a/scripts/nix-provision.sh
+++ b/scripts/nix-provision.sh
@@ -28,7 +28,7 @@ function install_packages {
 
 
 function install_nix() {
-    sudo su -c "sh <(curl -L https://releases.nixos.org/nix/nix-2.32.2/install) --yes --daemon --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
+    sudo su -c "sh <(curl -L https://releases.nixos.org/nix/nix-2.33.1/install) --yes --daemon --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
 extra-experimental-features = nix-command flakes
 extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
 extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=


### PR DESCRIPTION
Make sure the eval succeeds with both an empty /nix cache and a existing /nix cache.
Use the new nix installer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched to a new ephemeral Nix installer, standardized installer inputs, added max-jobs, and moved post-build hook into installer config.
  * Replaced long install steps with the ephemeral installer in CI, added cache mount and pre-install socket/ownership prep.
  * Updated installer version across images and scripts.

* **Bug Fixes**
  * Fixed installer invocation/heredoc handling to ensure configuration is applied.

* **Documentation**
  * Updated getting-started guide and version references to the new Nix release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->