### PR TITLE
fix: add checksum to upgrade scripts

### DIFF
--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
@@ -243,6 +243,14 @@ function initiate_upgrade {
 
     PGDATAOLD=$(cat "$POSTGRES_CONFIG_PATH" | grep data_directory | sed "s/data_directory = '\(.*\)'.*/\1/")
 
+    # Check if old cluster has data checksums enabled
+    CHECKSUM_VERSION=$("$PGBINOLD/pg_controldata" "$PGDATAOLD" | grep -i checksum | awk '{print $NF}')
+    if [ "$CHECKSUM_VERSION" != "0" ]; then
+        CHECKSUM_FLAG="--data-checksums"
+    else
+        CHECKSUM_FLAG=""
+    fi
+
     PGDATANEW="$MOUNT_POINT/pgdata"
 
     # running upgrade using at least 1 cpu core
@@ -467,12 +475,12 @@ EXTRA_NIX_CONF
 
     if [ "$IS_NIX_UPGRADE" = "true" ]; then
         if [[ "${PGVERSION%%.*}" -ge 16 ]]; then
-            LC_ALL=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 LC_COLLATE=en_US.UTF-8 LANGUAGE=en_US.UTF-8 LANG=en_US.UTF-8 LOCALE_ARCHIVE=/usr/lib/locale/locale-archive su -c ". /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh && $PGBINNEW/initdb --data-checksums --encoding=$SERVER_ENCODING --locale-provider=icu --icu-locale=en_US.UTF-8 -L $PGSHARENEW -D $PGDATANEW/ --username=supabase_admin" -s "$SHELL" postgres
+            LC_ALL=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 LC_COLLATE=en_US.UTF-8 LANGUAGE=en_US.UTF-8 LANG=en_US.UTF-8 LOCALE_ARCHIVE=/usr/lib/locale/locale-archive su -c ". /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh && $PGBINNEW/initdb $CHECKSUM_FLAG --encoding=$SERVER_ENCODING --locale-provider=icu --icu-locale=en_US.UTF-8 -L $PGSHARENEW -D $PGDATANEW/ --username=supabase_admin" -s "$SHELL" postgres
         else
-            LC_ALL=en_US.UTF-8 LC_CTYPE=$SERVER_LC_CTYPE LC_COLLATE=$SERVER_LC_COLLATE LANGUAGE=en_US.UTF-8 LANG=en_US.UTF-8 LOCALE_ARCHIVE=/usr/lib/locale/locale-archive su -c ". /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh && $PGBINNEW/initdb --data-checksums --encoding=$SERVER_ENCODING --lc-collate=$SERVER_LC_COLLATE --lc-ctype=$SERVER_LC_CTYPE -L $PGSHARENEW -D $PGDATANEW/ --username=supabase_admin" -s "$SHELL" postgres
+            LC_ALL=en_US.UTF-8 LC_CTYPE=$SERVER_LC_CTYPE LC_COLLATE=$SERVER_LC_COLLATE LANGUAGE=en_US.UTF-8 LANG=en_US.UTF-8 LOCALE_ARCHIVE=/usr/lib/locale/locale-archive su -c ". /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh && $PGBINNEW/initdb $CHECKSUM_FLAG --encoding=$SERVER_ENCODING --lc-collate=$SERVER_LC_COLLATE --lc-ctype=$SERVER_LC_CTYPE -L $PGSHARENEW -D $PGDATANEW/ --username=supabase_admin" -s "$SHELL" postgres
         fi
     else
-        su -c "$PGBINNEW/initdb --data-checksums -L $PGSHARENEW -D $PGDATANEW/ --username=supabase_admin" -s "$SHELL" postgres
+        su -c "$PGBINNEW/initdb $CHECKSUM_FLAG -L $PGSHARENEW -D $PGDATANEW/ --username=supabase_admin" -s "$SHELL" postgres
 
     fi
 

--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
@@ -467,12 +467,12 @@ EXTRA_NIX_CONF
 
     if [ "$IS_NIX_UPGRADE" = "true" ]; then
         if [[ "${PGVERSION%%.*}" -ge 16 ]]; then
-            LC_ALL=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 LC_COLLATE=en_US.UTF-8 LANGUAGE=en_US.UTF-8 LANG=en_US.UTF-8 LOCALE_ARCHIVE=/usr/lib/locale/locale-archive su -c ". /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh && $PGBINNEW/initdb --encoding=$SERVER_ENCODING --locale-provider=icu --icu-locale=en_US.UTF-8 -L $PGSHARENEW -D $PGDATANEW/ --username=supabase_admin" -s "$SHELL" postgres
+            LC_ALL=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 LC_COLLATE=en_US.UTF-8 LANGUAGE=en_US.UTF-8 LANG=en_US.UTF-8 LOCALE_ARCHIVE=/usr/lib/locale/locale-archive su -c ". /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh && $PGBINNEW/initdb --data-checksums --encoding=$SERVER_ENCODING --locale-provider=icu --icu-locale=en_US.UTF-8 -L $PGSHARENEW -D $PGDATANEW/ --username=supabase_admin" -s "$SHELL" postgres
         else
-            LC_ALL=en_US.UTF-8 LC_CTYPE=$SERVER_LC_CTYPE LC_COLLATE=$SERVER_LC_COLLATE LANGUAGE=en_US.UTF-8 LANG=en_US.UTF-8 LOCALE_ARCHIVE=/usr/lib/locale/locale-archive su -c ". /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh && $PGBINNEW/initdb --encoding=$SERVER_ENCODING --lc-collate=$SERVER_LC_COLLATE --lc-ctype=$SERVER_LC_CTYPE -L $PGSHARENEW -D $PGDATANEW/ --username=supabase_admin" -s "$SHELL" postgres
+            LC_ALL=en_US.UTF-8 LC_CTYPE=$SERVER_LC_CTYPE LC_COLLATE=$SERVER_LC_COLLATE LANGUAGE=en_US.UTF-8 LANG=en_US.UTF-8 LOCALE_ARCHIVE=/usr/lib/locale/locale-archive su -c ". /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh && $PGBINNEW/initdb --data-checksums --encoding=$SERVER_ENCODING --lc-collate=$SERVER_LC_COLLATE --lc-ctype=$SERVER_LC_CTYPE -L $PGSHARENEW -D $PGDATANEW/ --username=supabase_admin" -s "$SHELL" postgres
         fi
     else
-        su -c "$PGBINNEW/initdb -L $PGSHARENEW -D $PGDATANEW/ --username=supabase_admin" -s "$SHELL" postgres
+        su -c "$PGBINNEW/initdb --data-checksums -L $PGSHARENEW -D $PGDATANEW/ --username=supabase_admin" -s "$SHELL" postgres
 
     fi
 

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.031-orioledb"
-  postgres17: "17.6.1.074"
-  postgres15: "15.14.1.074"
+  postgresorioledb-17: "17.6.0.031-orioledb-checksum-1"
+  postgres17: "17.6.1.074-checksum-1"
+  postgres15: "15.14.1.074-checksum-1"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.031-orioledb-checksum-1"
-  postgres17: "17.6.1.074-checksum-1"
-  postgres15: "15.14.1.074-checksum-1"
+  postgresorioledb-17: "17.6.0.032"
+  postgres17: "17.6.1.075"
+  postgres15: "15.14.1.075"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1


### PR DESCRIPTION
  The Problem                                                                                                                                                       
                                                                                                                                                                    
  Users upgrading via Supabase UI encounter this error:                                                                                                             
  old cluster uses data checksums but the new one does not                                                                                                          
                                                                                                                                                                    
  Root Cause                                                                                                                                                        
                                                                                                                                                                    
  Commit https://github.com/supabase/postgres/commit/cf9bce15975191006307400061e906bf1930663c (Nov 14, 2025) enabled data checksums for new PostgreSQL              
  installations, but the pg_upgrade scripts were not updated to match.                                                                                              
                                                                                                                                                                    
  Affected Files                                                                                                                                                    
  File: ansible/tasks/setup-postgres.yml                                                                                                                            
  Has --data-checksums?: Yes                                                                                                                                        
  Lines: https://github.com/supabase/postgres/blob/develop/ansible/tasks/setup-postgres.yml#L232,                                                                   
    https://github.com/supabase/postgres/blob/develop/ansible/tasks/setup-postgres.yml#L260,                                                                        
    https://github.com/supabase/postgres/blob/develop/ansible/tasks/setup-postgres.yml#L277                                                                         
  ────────────────────────────────────────                                                                                                                          
  File: ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh                                                                                              
  Has --data-checksums?: No                                                                                                                                         
  Lines: https://github.com/supabase/postgres/blob/develop/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh#L470,                                     
    https://github.com/supabase/postgres/blob/develop/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh#L472,                                          
    https://github.com/supabase/postgres/blob/develop/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh#L475                                           
  What Happens                                                                                                                                                      
                                                                                                                                                                    
  1. User has a database created after Nov 14, 2025 → checksums enabled via setup-postgres.yml                                                                      
  2. User initiates upgrade via Supabase UI                                                                                                                         
  3. initiate.sh runs initdb to create new cluster without --data-checksums                                                                                         
  4. pg_upgrade fails because old cluster has checksums but new cluster doesn't                                                                                     
                                                                                                                                                                    
  The Fix                                                                                                                                                           
                                                                                                                                                                    
  Detect whether the old cluster has checksums enabled using pg_controldata, then conditionally pass --data-checksums to initdb.                                    
                                                                                                                                                                    
  Add detection after PGDATAOLD is set (after line 244):                                                                                                            
  # Check if old cluster has data checksums enabled                                                                                                                 
  CHECKSUM_VERSION=$("$PGBINOLD/pg_controldata" "$PGDATAOLD" | grep -i checksum | awk '{print $NF}')                                                                
  if [ "$CHECKSUM_VERSION" != "0" ]; then                                                                                                                           
      CHECKSUM_FLAG="--data-checksums"                                                                                                                              
  else                                                                                                                                                              
      CHECKSUM_FLAG=""                                                                                                                                              
  fi                                                                                                                                                                
                                                                                                                                                                    
  Update all three initdb calls to use $CHECKSUM_FLAG:                                                                                                              
                                                                                                                                                                    
  - Line 470 (NIX upgrade, PG16+):                                                                                                                                  
  $PGBINNEW/initdb $CHECKSUM_FLAG --encoding=$SERVER_ENCODING --locale-provider=icu ...                                                                             
  - Line 472 (NIX upgrade, pre-PG16):                                                                                                                               
  $PGBINNEW/initdb $CHECKSUM_FLAG --encoding=$SERVER_ENCODING --lc-collate=...                                                                                      
  - Line 475 (non-NIX upgrade):                                                                                                                                     
  $PGBINNEW/initdb $CHECKSUM_FLAG -L $PGSHARENEW -D $PGDATANEW/ --username=supabase_admin                                                                           
                                                                                                   

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Database upgrades now detect and preserve source-cluster data checksum settings, carrying them through initialization during upgrade.

* **Chores**
  * Updated PostgreSQL releases: postgresorioledb-17 → 17.6.0.032, postgres17 → 17.6.1.075, postgres15 → 15.14.1.075.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->