### PR TITLE
docs: update with correct annotation

### DIFF
--- a/nix/docs/adding-new-package.md
+++ b/nix/docs/adding-new-package.md
@@ -148,7 +148,7 @@ A few things about `buildPgrxExtension_x`:
 
 * It doesn't support `buildPhase`, `installPhase` and those are implemented directly in the builder already
 * It mostly just allows `cargo build` to do it's thing, but you may need to set env vars for the build process as seen above 
-* It caclulates a special `cargoHash` that will be generated after the first in `src` is generated, when running `nix build .#psql_15.exts.<yourname>` to build the extension
+* It calculates a special `cargoHash` that will be generated after the first in `src` is generated, when running `nix build .#psql_15.exts.<yourname>` to build the extension
 
 
 ## Post Nix derivation release steps

--- a/nix/docs/adding-new-package.md
+++ b/nix/docs/adding-new-package.md
@@ -56,7 +56,7 @@ Your build should produce all of the sql and control files needed for the instal
 1. Once you have created this file, you can add it to `nix/ext/<yourname>.nix` and edit `nix/packages/postgres.nix` and add it to the `ourExtensions` list.
 2. `git add .` as nix uses git to track changes 
 3. In your package file, temporarily empty the `hash = "sha256<...>=";` to `hash = "";` and save and `git add .`
-4. Run `nix build .#psql_15/exts/<yourname>`  to try to trigger a build, nix will print the calculated sha256 value that you can add back the the `hash` variable, save the file again, and re-run `nix build .#psql_15/exts/<yourname>`. 
+4. Run `nix build .#psql_15.exts.<yourname>`  to try to trigger a build, nix will print the calculated sha256 value that you can add back the the `hash` variable, save the file again, and re-run `nix build .#psql_15.exts.<yourname>`. 
 5. Add any needed migrations into the `supabase/postgres` migrations directory.
 6. You can then run tests locally to verify that the update of the package succeeded. 
 7. Now it's ready for PR review!
@@ -148,7 +148,7 @@ A few things about `buildPgrxExtension_x`:
 
 * It doesn't support `buildPhase`, `installPhase` and those are implemented directly in the builder already
 * It mostly just allows `cargo build` to do it's thing, but you may need to set env vars for the build process as seen above 
-* It caclulates a special `cargoHash` that will be generated after the first in `src` is generated, when running `nix build .#psql_15/exts/<yourname>` to build the extension
+* It caclulates a special `cargoHash` that will be generated after the first in `src` is generated, when running `nix build .#psql_15.exts.<yourname>` to build the extension
 
 
 ## Post Nix derivation release steps
@@ -157,7 +157,7 @@ A few things about `buildPgrxExtension_x`:
 1. You can add and run tests as described in https://github.com/supabase/postgres/blob/develop/nix/docs/adding-tests.md 
 2. You may need to add tests to our test.yml gh action workflow as well.
 3. You can add the package and name and version to `ansible/vars.yml` it is not necessary to add the sha256 hash here, as the package is already built and cached in our release process before these vars are ever run.
-4. to check that all your files will land in the overall build correctly, you can run `nix profile install .#psql_15/bin` on your machine, and check in `~/.nix-profile/bin, ~/.nix-profile/lib, ~/.nix-profile/share/postgresql/*` and you should see your lib, .control and sql files there. 
+4. to check that all your files will land in the overall build correctly, you can run `nix profile install .#psql_15.bin` on your machine, and check in `~/.nix-profile/bin, ~/.nix-profile/lib, ~/.nix-profile/share/postgresql/*` and you should see your lib, .control and sql files there. 
 5. You can also run `nix run .#start-server 15` and in a new terminal window run `nix run .#star-client-and-migrate 15` and try to `CREATE EXTENSION <yourname>` and work with it there
 6. Check that your extension works with the `pg_upgrade` process (TODO documentation forthcoming)
 7. Now you are ready to PR the extension

--- a/nix/docs/build-postgres.md
+++ b/nix/docs/build-postgres.md
@@ -15,7 +15,7 @@ points to a path which contains an entire PostgreSQL 15 installation &mdash;
 extensions and all:
 
 ```
-nix build .#psql_15/bin
+nix build .#psql_15.bin
 ```
 
 ```
@@ -102,7 +102,7 @@ _content_, is a very powerful primitive, as we'll see later.
 What if we wanted PostgreSQL 16 and plugins? Just replace `_15` with `_16`:
 
 ```
-nix build .#psql_16/bin
+nix build .#psql_16.bin
 ```
 
 You're done:

--- a/nix/docs/creating-pgrx-extension.md
+++ b/nix/docs/creating-pgrx-extension.md
@@ -132,7 +132,7 @@ Edit `nix/ext/versions.json` and add your extension:
 
 **To calculate the hash:** Use a dummy hash first, then run:
 ```bash
-nix build .#psql_15/exts/my_extension -L
+nix build .#psql_15.exts.my_extension -L
 ```
 The error message will show the correct hash.
 
@@ -206,13 +206,13 @@ The pgrx dev shells provide:
 
 ```bash
 # Build extension for PostgreSQL 15
-nix build .#psql_15/exts/my_extension -L
+nix build .#psql_15.exts.my_extension -L
 
 # Build extension for PostgreSQL 17
-nix build .#psql_17/exts/my_extension -L
+nix build .#psql_17.exts.my_extension -L
 
 # Build all extensions (full PostgreSQL package)
-nix build .#psql_15/bin -L
+nix build .#psql_15.bin -L
 
 # Run tests
 nix flake check -L

--- a/nix/docs/flake-parts-architecture.md
+++ b/nix/docs/flake-parts-architecture.md
@@ -276,10 +276,10 @@ Demonstrates advanced functional composition:
 { psql_15.bin = <drv>; psql_15.exts.rum = <drv>; }
 
 # Output:
-{ "psql_15/bin" = <drv>; "psql_15/exts/rum" = <drv>; }
+{ "psql_15.bin" = <drv>; "psql_15.exts.rum" = <drv>; }
 ```
 
-This allows `nix build .#psql_15/bin` or `nix build .#psql_15/exts/rum`.
+This allows `nix build .#psql_15.bin` or `nix build .#psql_15.exts.rum`.
 
 #### nix/apps.nix
 
@@ -351,9 +351,9 @@ Overlays are flake-level (not per-system):
   {
     checks = {
       psql_15 = pkgs.runCommand "run-check-harness-psql-15" { }
-        (lib.getExe (makeCheckHarness self'.packages."psql_15/bin"));
+        (lib.getExe (makeCheckHarness self'.packages."psql_15.bin"));
       psql_17 = pkgs.runCommand "run-check-harness-psql-17" { }
-        (lib.getExe (makeCheckHarness self'.packages."psql_17/bin"));
+        (lib.getExe (makeCheckHarness self'.packages."psql_17.bin"));
     }
     // pkgs.lib.optionalAttrs (system == "x86_64-linux") {
       devShell = self'.devShells.default;
@@ -463,7 +463,7 @@ Modules reference outputs from other modules:
 
 ```nix
 # Reference current system's packages
-self'.packages."psql_15/bin"
+self'.packages."psql_15.bin"
 
 # Reference flake-level config
 self.supabase.defaults
@@ -514,7 +514,7 @@ Allow building nested package paths:
 }
 ```
 
-**Effect**: Enables `nix build .#psql_15/exts/rum`.
+**Effect**: Enables `nix build .#psql_15.exts.rum`.
 
 ### Attribute Set Merging
 

--- a/nix/docs/flake-parts-nixpkgs-lib.md
+++ b/nix/docs/flake-parts-nixpkgs-lib.md
@@ -448,9 +448,9 @@ packages = inputs.flake-utils.lib.flattenTree basePackages;
 
 # Result
 {
-  "psql_15/bin" = <derivation>;
-  "psql_15/exts/rum" = <derivation>;
-  "psql_15/exts/pgsodium" = <derivation>;
+  "psql_15.bin" = <derivation>;
+  "psql_15.exts.rum" = <derivation>;
+  "psql_15.exts.pgsodium" = <derivation>;
 }
 ```
 
@@ -462,8 +462,8 @@ packages = inputs.flake-utils.lib.flattenTree basePackages;
 checks =
   {
     # Explicit checks
-    psql_15 = makeCheckHarness self'.packages."psql_15/bin";
-    psql_17 = makeCheckHarness self'.packages."psql_17/bin";
+    psql_15 = makeCheckHarness self'.packages."psql_15.bin";
+    psql_17 = makeCheckHarness self'.packages."psql_17.bin";
   }
   // pkgs.lib.optionalAttrs (system == "x86_64-linux") {
     # Debug packages (Linux only)

--- a/nix/docs/migration-tests.md
+++ b/nix/docs/migration-tests.md
@@ -44,7 +44,7 @@ OLD_GIT_VERSION=...
 NEW_GIT_VERSION=...
 
 nix run github:supabase/nix-postgres#migration-test \
-  $(nix build "github:supabase/nix-postgres/$OLD_GIT_VERSION#psql_14/bin") \
-  $(nix build "github:supabase/nix-postgres/$NEW_GIT_VERSION#psql_14/bin") \
+  $(nix build "github:supabase/nix-postgres/$OLD_GIT_VERSION#psql_14.bin") \
+  $(nix build "github:supabase/nix-postgres/$NEW_GIT_VERSION#psql_14.bin") \
   pg_upgrade
 ```

--- a/nix/docs/receipt-files.md
+++ b/nix/docs/receipt-files.md
@@ -15,11 +15,11 @@ upgrade mechanisms.
 For example:
 
 ```
-nix build .#psql_15/bin
+nix build .#psql_15.bin
 ```
 
 ```
-austin@GANON:~/work/nix-postgres$ nix build .#psql_15/bin
+austin@GANON:~/work/nix-postgres$ nix build .#psql_15.bin
 austin@GANON:~/work/nix-postgres$ ls result
 bin  include  lib  receipt.json  share
 ```

--- a/nix/docs/testing-pg-upgrade-scripts.md
+++ b/nix/docs/testing-pg-upgrade-scripts.md
@@ -97,7 +97,7 @@ If the upgrade fails:
 4. If you see an error about missing Nix flake attributes, make sure the flake version includes the PostgreSQL version you're testing
 
 Common Errors:
-- `error: flake 'github:supabase/postgres/...' does not provide attribute 'packages.aarch64-linux.psql_17/bin'`
+- `error: flake 'github:supabase/postgres/...' does not provide attribute 'packages.aarch64-linux.psql_17.bin'`
   - This means the Nix flake version doesn't include PostgreSQL 17 binaries
   - You need to specify a flake version that includes your target version
   - You can find valid flake versions by looking at the commit history of the publish-nix-pgupgrade-bin-flake-version.yml workflow

--- a/nix/docs/update-extension.md
+++ b/nix/docs/update-extension.md
@@ -45,14 +45,14 @@ These extensions use `stdenv.mkDerivation` and require only basic fields in `ver
 
 3. **Calculate the hash** - Run a nix build to get the correct hash:
    ```bash
-   nix build .#psql_15/exts/extension_name -L
+   nix build .#psql_15.exts.extension_name -L
    ```
 
    Nix will fail and print the correct hash. Copy it and update the `hash` field in `versions.json`.
 
 4. **Re-run the build** to verify:
    ```bash
-   nix build .#psql_15/exts/extension_name -L
+   nix build .#psql_15.exts.extension_name -L
    ```
 
 5. **Add any needed migrations** into the `supabase/postgres` migrations directory
@@ -102,7 +102,7 @@ These extensions use `mkPgrxExtension` and require additional Rust and pgrx vers
 3. **Calculate the hash**:
 
    ```bash
-   nix build .#psql_15/exts/extension_name -L
+   nix build .#psql_15.exts.extension_name -L
    ```
 
    Nix build will fail and print the correct hash. Update the `hash` field in `versions.json`.
@@ -125,7 +125,7 @@ These extensions use `mkPgrxExtension` and require additional Rust and pgrx vers
 
 5. **Re-run the build** to verify:
    ```bash
-   nix build .#psql_15/exts/extension_name -L
+   nix build .#psql_15.exts.extension_name -L
    ```
 
 6. **Add any needed migrations** into the `supabase/postgres` migrations directory
@@ -169,7 +169,7 @@ For extensions like `supautils.nix` that haven't been migrated to the new struct
 
 4. **Calculate the hash**:
    ```bash
-   nix build .#psql_15/exts/supautils -L
+   nix build .#psql_15.exts.supautils -L
    ```
 
    Nix will print the calculated sha256 value.
@@ -181,7 +181,7 @@ For extensions like `supautils.nix` that haven't been migrated to the new struct
 
 6. **Re-run the build**:
    ```bash
-   nix build .#psql_15/exts/supautils -L
+   nix build .#psql_15.exts.supautils -L
    ```
 
 7. **Add migrations** as needed

--- a/nix/docs/updating-pgrx-extensions.md
+++ b/nix/docs/updating-pgrx-extensions.md
@@ -95,7 +95,7 @@ Use this when the extension has a new release but uses the same pgrx and Rust ve
 4. **Build to get the hash**:
 
    ```bash
-   nix build .#psql_17/exts/wrappers-all -L
+   nix build .#psql_17.exts.wrappers-all -L
    ```
 
    The build will fail and print the correct hash. Copy it to `versions.json`.
@@ -103,7 +103,7 @@ Use this when the extension has a new release but uses the same pgrx and Rust ve
 5. **Rebuild to verify**:
 
    ```bash
-   nix build .#psql_17/exts/wrappers-all -L
+   nix build .#psql_17.exts.wrappers-all -L
    ```
 
 ---
@@ -178,7 +178,7 @@ Use this when the extension requires a newer pgrx version.
 
    ```bash
    git add .
-   nix build .#psql_17/exts/wrappers-all -L
+   nix build .#psql_17.exts.wrappers-all -L
    ```
 
    You'll need to run this multiple times, updating hashes as they're calculated:
@@ -291,11 +291,11 @@ For faster iteration, test just your extension before running full checks:
 
 ```bash
 # Build for one PostgreSQL version
-nix build .#psql_17/exts/wrappers-all -L
+nix build .#psql_17.exts.wrappers-all -L
 
 # Build for all PostgreSQL versions
-nix build .#psql_15/exts/wrappers-all -L
-nix build .#psql_17/exts/wrappers-all -L
+nix build .#psql_15.exts.wrappers-all -L
+nix build .#psql_17.exts.wrappers-all -L
 ```
 
 ---
@@ -361,7 +361,7 @@ If the build still fails after updating hashes:
 
 1. **Stage all changes**: `git add .`
 2. **Clean Nix cache** (if necessary): `nix store gc`
-3. **Rebuild**: `nix build .#psql_17/exts/<extension> -L`
+3. **Rebuild**: `nix build .#psql_17.exts.<extension> -L`
 
 ### CargoLock outputHashes
 


### PR DESCRIPTION
The annotation syntax for building attributes of packages has changed. This PR updates the docs to reflect the correct way to build packages going forward. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized Nix build command examples across multiple guides to use dot-separated attribute paths instead of slash-separated paths for consistency and clearer build targets.
  * Aligned related guidance and prompts, fixed a typographical error, and adjusted examples throughout the docs to reflect the updated attribute notation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->