### PR TITLE
Restore packer pkg

### DIFF
--- a/.github/workflows/ami-release-nix.yml
+++ b/.github/workflows/ami-release-nix.yml
@@ -87,18 +87,18 @@ jobs:
           POSTGRES_MAJOR_VERSION: ${{ env.POSTGRES_MAJOR_VERSION }}
         run: |
           GIT_SHA=${{github.sha}}
-          nix run nixpkgs#packer -- init amazon-arm64-nix.pkr.hcl
+          nix run github:supabase/postgres/${GIT_SHA}#packer -- init amazon-arm64-nix.pkr.hcl
           # why is postgresql_major defined here instead of where the _three_ other postgresql_* variables are defined?
-          nix run nixpkgs#packer -- build -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${EXECUTION_ID}"  -var-file="development-arm.vars.pkr.hcl" -var-file="common-nix.vars.pkr.hcl" -var "ansible_arguments=-e postgresql_major=${POSTGRES_MAJOR_VERSION}"  amazon-arm64-nix.pkr.hcl
+          nix run github:supabase/postgres/${GIT_SHA}#packer -- build -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${EXECUTION_ID}"  -var-file="development-arm.vars.pkr.hcl" -var-file="common-nix.vars.pkr.hcl" -var "ansible_arguments=-e postgresql_major=${POSTGRES_MAJOR_VERSION}"  amazon-arm64-nix.pkr.hcl
 
       - name: Build AMI stage 2
         env:
           POSTGRES_MAJOR_VERSION: ${{ env.POSTGRES_MAJOR_VERSION }}
         run: |
           GIT_SHA=${{github.sha}}
-          nix run nixpkgs#packer -- init stage2-nix-psql.pkr.hcl
+          nix run github:supabase/postgres/${GIT_SHA}#packer -- init stage2-nix-psql.pkr.hcl
           POSTGRES_MAJOR_VERSION=${{ env.POSTGRES_MAJOR_VERSION }}
-          nix run nixpkgs#packer -- build -var "git_sha=${GIT_SHA}" -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${EXECUTION_ID}" -var "postgres_major_version=${POSTGRES_MAJOR_VERSION}" -var-file="development-arm.vars.pkr.hcl" -var-file="common-nix.vars.pkr.hcl" stage2-nix-psql.pkr.hcl
+          nix run github:supabase/postgres/${GIT_SHA}#packer -- build -var "git_sha=${GIT_SHA}" -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${EXECUTION_ID}" -var "postgres_major_version=${POSTGRES_MAJOR_VERSION}" -var-file="development-arm.vars.pkr.hcl" -var-file="common-nix.vars.pkr.hcl" stage2-nix-psql.pkr.hcl
 
       - name: Grab release version
         id: process_release_version

--- a/.github/workflows/base-image-nightly.yml
+++ b/.github/workflows/base-image-nightly.yml
@@ -53,8 +53,8 @@ jobs:
           AWS_RETRY_MODE: adaptive
         run: |
           GIT_SHA=${{ github.sha }}
-          nix run nixpkgs#packer -- init amazon-arm64-nix.pkr.hcl
-          nix run nixpkgs#packer -- build \
+          nix run github:supabase/postgres/${GIT_SHA}#packer -- init amazon-arm64-nix.pkr.hcl
+          nix run github:supabase/postgres/${GIT_SHA}#packer -- build \
             -var "git-head-version=${GIT_SHA}" \
             -var "packer-execution-id=${EXECUTION_ID}" \
             -var-file="development-arm.vars.pkr.hcl" \

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.034-orioledb"
-  postgres17: "17.6.1.077"
-  postgres15: "15.14.1.077"
+  postgresorioledb-17: "17.6.0.035-orioledb"
+  postgres17: "17.6.1.078"
+  postgres15: "15.14.1.078"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -34,7 +34,7 @@
       packages = (
         {
           build-ami = pkgs.callPackage ./build-ami.nix { packer = self'.packages.packer; };
-          build-test-ami = pkgs.callPackage ./build-test-ami.nix { };
+          build-test-ami = pkgs.callPackage ./build-test-ami.nix { packer = self'.packages.packer; };
           cleanup-ami = pkgs.callPackage ./cleanup-ami.nix { };
           dbmate-tool = pkgs.callPackage ./dbmate-tool.nix { inherit (self.supabase) defaults; };
           docs = pkgs.callPackage ./docs.nix { };

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -33,7 +33,7 @@
     {
       packages = (
         {
-          build-ami = pkgs.callPackage ./build-ami.nix { };
+          build-ami = pkgs.callPackage ./build-ami.nix { packer = self'.packages.packer; };
           build-test-ami = pkgs.callPackage ./build-test-ami.nix { };
           cleanup-ami = pkgs.callPackage ./cleanup-ami.nix { };
           dbmate-tool = pkgs.callPackage ./dbmate-tool.nix { inherit (self.supabase) defaults; };
@@ -49,6 +49,7 @@
           mecab-naist-jdic = pkgs.callPackage ./mecab-naist-jdic.nix { };
           migrate-tool = pkgs.callPackage ./migrate-tool.nix { psql_15 = self'.packages."psql_15/bin"; };
           overlayfs-on-package = pkgs.callPackage ./overlayfs-on-package.nix { };
+          packer = pkgs.callPackage ./packer.nix { inherit inputs; };
           pg-backrest = inputs.nixpkgs.legacyPackages.${pkgs.stdenv.hostPlatform.system}.pgbackrest;
           pg-restore = pkgs.callPackage ./pg-restore.nix { psql_15 = self'.packages."psql_15/bin"; };
           pg_prove = pkgs.perlPackages.TAPParserSourceHandlerpgTAP;

--- a/nix/packages/packer.nix
+++ b/nix/packages/packer.nix
@@ -1,0 +1,43 @@
+{
+  pkgs,
+  lib,
+  fetchFromGitHub,
+  installShellFiles,
+  ...
+}:
+let
+  buildGoModule = pkgs.buildGoModule;
+in
+buildGoModule rec {
+  pname = "packer";
+  version = "1.14.1";
+
+  src = fetchFromGitHub {
+    owner = "hashicorp";
+    repo = "packer";
+    rev = "v${version}";
+    hash = "sha256-3g9hsmrfLzGhjcGvUza/L9PMGUFw+KLbg2pIK0CxlQI=";
+  };
+
+  vendorHash = "sha256-F6hn+pXPyPe70UTK8EF24lk7ArYz7ygUyVVsatW6+hI=";
+
+  subPackages = [ "." ];
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    installShellCompletion --zsh contrib/zsh-completion/_packer
+  '';
+
+  meta = {
+    description = "Tool for creating identical machine images for multiple platforms from a single source configuration";
+    homepage = "https://www.packer.io";
+    license = lib.licenses.bsl11;
+    changelog = "https://github.com/hashicorp/packer/blob/v${version}/CHANGELOG.md";
+  };
+}


### PR DESCRIPTION
We should not have removed packer package, so that we can control the version, and to avoid non-free license errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated PostgreSQL 17 to 17.6.1.078
  * Updated PostgreSQL 15 to 15.14.1.078
  * Updated PostgreSQL with OrioLeDB to 17.6.0.035-orioledb
* **New Features**
  * Added a packaged Packer tool to the build environment
  * Switched AMI and base-image workflows to use the new Packer packaging/source for builds

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->