### PR TITLE
fix: look up and pass stage 1 name

### DIFF
--- a/.github/workflows/ami-release-nix.yml
+++ b/.github/workflows/ami-release-nix.yml
@@ -91,6 +91,32 @@ jobs:
           # why is postgresql_major defined here instead of where the _three_ other postgresql_* variables are defined?
           nix run github:supabase/postgres/${GIT_SHA}#packer -- build -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${EXECUTION_ID}"  -var-file="development-arm.vars.pkr.hcl" -var-file="common-nix.vars.pkr.hcl" -var "ansible_arguments=-e postgresql_major=${POSTGRES_MAJOR_VERSION}"  amazon-arm64-nix.pkr.hcl
 
+      - name: Find stage 1 AMI
+        run: |
+          GIT_SHA=${{github.sha}}
+          PG_VERSION=$(sed -n 's/postgres-version = "\(.*\)"/\1/p' common-nix.vars.pkr.hcl)
+          REGION=$(grep '^region=' development-arm.vars.pkr.hcl | cut -d'=' -f2 | tr -d ' "')
+
+          echo "Looking for stage 1 AMI with postgresVersion=${PG_VERSION}-stage1 and sourceSha=${GIT_SHA} in region ${REGION}"
+
+          STAGE1_AMI_ID=$(aws ec2 describe-images \
+            --region "$REGION" \
+            --owners self \
+            --filters \
+              "Name=tag:postgresVersion,Values=${PG_VERSION}-stage1" \
+              "Name=tag:sourceSha,Values=${GIT_SHA}" \
+              "Name=state,Values=available" \
+            --query 'Images[0].ImageId' \
+            --output text)
+
+          if [ -z "$STAGE1_AMI_ID" ] || [ "$STAGE1_AMI_ID" = "None" ]; then
+            echo "ERROR: Failed to find stage 1 AMI"
+            exit 1
+          fi
+
+          echo "Found stage 1 AMI: $STAGE1_AMI_ID"
+          echo "STAGE1_AMI_ID=$STAGE1_AMI_ID" >> "$GITHUB_ENV"
+
       - name: Build AMI stage 2
         env:
           POSTGRES_MAJOR_VERSION: ${{ env.POSTGRES_MAJOR_VERSION }}
@@ -98,7 +124,7 @@ jobs:
           GIT_SHA=${{github.sha}}
           nix run github:supabase/postgres/${GIT_SHA}#packer -- init stage2-nix-psql.pkr.hcl
           POSTGRES_MAJOR_VERSION=${{ env.POSTGRES_MAJOR_VERSION }}
-          nix run github:supabase/postgres/${GIT_SHA}#packer -- build -var "git_sha=${GIT_SHA}" -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${EXECUTION_ID}" -var "postgres_major_version=${POSTGRES_MAJOR_VERSION}" -var-file="development-arm.vars.pkr.hcl" -var-file="common-nix.vars.pkr.hcl" stage2-nix-psql.pkr.hcl
+          nix run github:supabase/postgres/${GIT_SHA}#packer -- build -var "git_sha=${GIT_SHA}" -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${EXECUTION_ID}" -var "postgres_major_version=${POSTGRES_MAJOR_VERSION}" -var "source_ami=${STAGE1_AMI_ID}" -var-file="development-arm.vars.pkr.hcl" -var-file="common-nix.vars.pkr.hcl" stage2-nix-psql.pkr.hcl
 
       - name: Grab release version
         id: process_release_version

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.035-orioledb"
-  postgres17: "17.6.1.078"
-  postgres15: "15.14.1.078"
+  postgresorioledb-17: "17.6.0.036-orioledb"
+  postgres17: "17.6.1.079"
+  postgres15: "15.14.1.079"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1


### PR DESCRIPTION
1. After stage 1 completes, a new "Find stage 1 AMI" step queries AWS for the AMI by:                                           
    - postgresVersion tag = ${version}-stage1                                                                                     
    - sourceSha tag = ${GIT_SHA} (unique to this build)                                                                           
  2. Exports STAGE1_AMI_ID to the environment for the next step                                                                   
  3. Stage 2 now receives -var "source_ami=${STAGE1_AMI_ID}"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pipeline now automatically discovers and validates the appropriate base image for stage 2 builds, reducing manual configuration and improving build reliability.
  * Postgres platform mappings updated to newer patch releases for 17 and 15 series (including the OrioleDB variant), ensuring deployments use up-to-date minor/patch versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->