### PR TITLE
feat: add portable CLI binaries for multi-platform Supabase CLI distribution

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -1,0 +1,446 @@
+name: CLI Release
+
+on:
+  push:
+    tags:
+      - "v*-cli"
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version tag (e.g., v1.0.0-cli)"
+        required: true
+        type: string
+
+jobs:
+  build-native:
+    name: Build ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - system: aarch64-darwin
+            runner: macos-14
+            arch: darwin-arm64
+          - system: x86_64-linux
+            runner: ubuntu-latest
+            arch: linux-x64
+          - system: aarch64-linux
+            runner: ubuntu-24.04-arm
+            arch: linux-arm64
+    steps:
+      - name: Checkout repository
+        uses: supabase/postgres/.github/actions/shared-checkout@HEAD
+
+      - name: Install Nix
+        uses: ./.github/actions/nix-install-ephemeral
+
+      - name: Run portability check
+        run: |
+          nix build .#checks.${{ matrix.system }}.psql_17_cli_portable --system ${{ matrix.system }} -L --accept-flake-config
+
+      - name: Build portable CLI bundle
+        run: |
+          nix build .#psql_17_cli_portable --system ${{ matrix.system }} -L --accept-flake-config
+
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+          else
+            VERSION="${{ github.ref_name }}"
+          fi
+          # Sanitize version by replacing slashes with dashes
+          VERSION="${VERSION//\//-}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare build directory
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          ARCH="${{ matrix.arch }}"
+          BUILD_DIR="supabase-postgres-${VERSION}-${ARCH}"
+
+          mkdir -p "${BUILD_DIR}"
+          shopt -s dotglob
+          cp -rL result/* "${BUILD_DIR}/"
+          shopt -u dotglob
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: supabase-postgres-${{ matrix.arch }}
+          path: supabase-postgres-${{ steps.version.outputs.version }}-${{ matrix.arch }}
+          retention-days: 90
+          include-hidden-files: true
+
+  test-portability:
+    name: ${{ matrix.arch }} without Nix
+    needs: [build-native]
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-14
+            arch: darwin-arm64
+          - runner: ubuntu-latest
+            arch: linux-x64
+          - runner: ubuntu-24.04-arm
+            arch: linux-arm64
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: supabase-postgres-${{ matrix.arch }}
+          path: .
+
+      - name: Test binaries work without Nix
+        run: |
+          cd bin
+          find . -maxdepth 1 -type f -exec chmod +x {} +
+          ls -la
+
+          echo "Testing postgres --version..."
+          ./postgres --version
+
+          echo "Testing pg_config --version..."
+          ./pg_config --version
+
+          echo "Testing psql --version..."
+          ./psql --version
+
+          echo "Testing initdb --version..."
+          ./initdb --version
+
+      - name: Test initialization script
+        run: |
+          set -e
+
+          echo "=========================================="
+          echo "Testing supabase-postgres-init.sh"
+          echo "=========================================="
+
+          # Make init script executable
+          chmod +x ./share/supabase-cli/bin/supabase-postgres-init.sh
+
+          # Test 1: Initialize database with init script
+          export PGDATA="$(pwd)/pgdata-init-test"
+          export POSTGRES_USER="test_user"
+          export POSTGRES_PASSWORD="test_password"
+          export POSTGRES_DB="test_db"
+
+          echo "Starting PostgreSQL with init script..."
+          ./share/supabase-cli/bin/supabase-postgres-init.sh -p 54321 > init.log 2>&1 &
+          INIT_PID=$!
+
+          # Wait for PostgreSQL to be ready
+          for i in {1..30}; do
+            if ./bin/pg_isready -p 54321 -h 127.0.0.1 -U test_user > /dev/null 2>&1; then
+              echo "PostgreSQL is ready"
+              break
+            fi
+            if [ $i -eq 30 ]; then
+              echo "PostgreSQL failed to start"
+              cat init.log
+              exit 1
+            fi
+            sleep 1
+          done
+
+          echo ""
+          echo "=========================================="
+          echo "Testing password authentication"
+          echo "=========================================="
+
+          # Test password authentication (should work with scram-sha-256)
+          PGPASSWORD="test_password" ./bin/psql -p 54321 -h 127.0.0.1 -U test_user -d test_db -c "SELECT version();" > /dev/null
+          if [ $? -eq 0 ]; then
+            echo "✓ Password authentication successful"
+          else
+            echo "✗ Password authentication failed"
+            exit 1
+          fi
+
+          # Test wrong password (should fail) - temporarily disable set -e
+          set +e
+          PGPASSWORD="wrong_password" ./bin/psql -p 54321 -h 127.0.0.1 -U test_user -d test_db -c "SELECT 1;" > /dev/null 2>&1
+          WRONG_PW_STATUS=$?
+          set -e
+          if [ $WRONG_PW_STATUS -ne 0 ]; then
+            echo "✓ Wrong password correctly rejected"
+          else
+            echo "✗ Wrong password was accepted (security issue!)"
+            exit 1
+          fi
+
+          echo ""
+          echo "=========================================="
+          echo "Testing database initialization"
+          echo "=========================================="
+
+          # Verify database exists
+          PGPASSWORD="test_password" ./bin/psql -p 54321 -h 127.0.0.1 -U test_user -d test_db -v ON_ERROR_STOP=1 -c "SELECT current_database();" | grep "test_db"
+          if [ $? -eq 0 ]; then
+            echo "✓ Custom database created"
+          else
+            echo "✗ Custom database not found"
+            exit 1
+          fi
+
+          # Verify configuration files were set up
+          if [ -f "$PGDATA/postgresql.conf" ] && [ -f "$PGDATA/pg_hba.conf" ]; then
+            echo "✓ Configuration files created"
+          else
+            echo "✗ Configuration files missing"
+            exit 1
+          fi
+
+          # Verify pgsodium/vault getkey scripts are configured
+          if grep -q "pgsodium.getkey_script" "$PGDATA/postgresql.conf" && grep -q "vault.getkey_script" "$PGDATA/postgresql.conf"; then
+            echo "✓ Getkey scripts configured"
+          else
+            echo "✗ Getkey scripts not configured"
+            exit 1
+          fi
+
+          echo ""
+          echo "=========================================="
+          echo "Testing idempotency"
+          echo "=========================================="
+
+          # Stop PostgreSQL
+          ./bin/pg_ctl -D "$PGDATA" stop -m fast
+          wait $INIT_PID 2>/dev/null || true
+
+          # Run init script again (should skip initialization)
+          ./share/supabase-cli/bin/supabase-postgres-init.sh -p 54321 > init2.log 2>&1 &
+          INIT_PID2=$!
+
+          # Wait for PostgreSQL to be ready
+          for i in {1..30}; do
+            if ./bin/pg_isready -p 54321 -h 127.0.0.1 -U test_user > /dev/null 2>&1; then
+              echo "PostgreSQL is ready after re-init"
+              break
+            fi
+            if [ $i -eq 30 ]; then
+              echo "PostgreSQL failed to start on second run"
+              cat init2.log
+              exit 1
+            fi
+            sleep 1
+          done
+
+          # Verify we can still connect with same password
+          PGPASSWORD="test_password" ./bin/psql -p 54321 -h 127.0.0.1 -U test_user -d test_db -c "SELECT 1;" > /dev/null
+          if [ $? -eq 0 ]; then
+            echo "✓ Idempotency verified - database not re-initialized"
+          else
+            echo "✗ Failed to connect after re-running init script"
+            exit 1
+          fi
+
+          # Check log to verify it skipped initialization
+          if grep -q "already initialized" init2.log; then
+            echo "✓ Init script correctly detected existing database"
+          else
+            echo "⚠ Warning: Init script may have re-initialized (check init2.log)"
+          fi
+
+          # Stop PostgreSQL
+          ./bin/pg_ctl -D "$PGDATA" stop -m fast
+          wait $INIT_PID2 2>/dev/null || true
+
+          echo ""
+          echo "=========================================="
+          echo "Init script tests completed successfully"
+          echo "=========================================="
+          echo ""
+
+      - name: Test migrations with CLI variant
+        run: |
+          set -e
+
+          # Use bundled pgsodium getkey script
+          GETKEY_SCRIPT="$(pwd)/share/supabase-cli/config/pgsodium_getkey.sh"
+          chmod +x "$GETKEY_SCRIPT"
+
+          # Initialize test database
+          PGDATA="$(pwd)/pgdata-test"
+          ./bin/initdb -D "$PGDATA" -U supabase_admin --no-instructions
+
+          # Copy CLI config and add pgsodium/vault getkey scripts
+          cp share/supabase-cli/config/postgresql.conf.template "$PGDATA/postgresql.conf"
+          cat >> "$PGDATA/postgresql.conf" << EOF
+
+          # pgsodium and vault configuration for testing
+          pgsodium.getkey_script = '$GETKEY_SCRIPT'
+          vault.getkey_script = '$GETKEY_SCRIPT'
+          EOF
+
+          # Start PostgreSQL
+          ./bin/postgres -D "$PGDATA" -p 54322 > postgres.log 2>&1 &
+          PG_PID=$!
+
+          # Wait for PostgreSQL to be ready
+          for i in {1..30}; do
+            if ./bin/pg_isready -p 54322 -h 127.0.0.1 -U supabase_admin > /dev/null 2>&1; then
+              echo "PostgreSQL is ready"
+              break
+            fi
+            if [ $i -eq 30 ]; then
+              echo "PostgreSQL failed to start"
+              cat postgres.log
+              exit 1
+            fi
+            sleep 1
+          done
+
+          # Run migrations
+          cd share/supabase-cli/migrations
+          chmod +x migrate.sh
+          echo "=========================================="
+          echo "Running migrations..."
+          echo "=========================================="
+          PATH="$(pwd)/../../../bin:$PATH" \
+          POSTGRES_PASSWORD=postgres \
+          POSTGRES_PORT=54322 \
+          POSTGRES_DB=postgres \
+          POSTGRES_USER=supabase_admin \
+          ./migrate.sh 2>&1 | tee migration.log
+          MIGRATION_STATUS=${PIPESTATUS[0]}
+
+          echo ""
+          echo "=========================================="
+          echo "Migration output complete"
+          echo "=========================================="
+
+          # Check migration results - all migrations must succeed
+          if [ $MIGRATION_STATUS -ne 0 ]; then
+            echo "Migrations failed"
+            cat migration.log
+            exit 1
+          fi
+
+          echo "All migrations applied successfully"
+
+          # Verify extensions are installed
+          cd ../../..
+          ./bin/psql -p 54322 -h 127.0.0.1 -U supabase_admin -d postgres -v ON_ERROR_STOP=1 -c "\dx" | tee extensions.log
+
+          # Check for required extensions
+          for ext in pg_graphql pgcrypto uuid-ossp supabase_vault; do
+            if ! grep -q "$ext" extensions.log; then
+              echo "Required extension $ext not found"
+              exit 1
+            fi
+          done
+
+          echo ""
+          echo "=========================================="
+          echo "Testing timezone functionality with bundled timezone data"
+          echo "=========================================="
+
+          cat > timezone_test.sql << 'EOF'
+          -- Test basic timezone conversion
+          SELECT now() AT TIME ZONE 'America/New_York' AS ny_time;
+          SELECT now() AT TIME ZONE 'Europe/London' AS london_time;
+          SELECT now() AT TIME ZONE 'Asia/Tokyo' AS tokyo_time;
+
+          -- Verify timezone database is accessible
+          SELECT COUNT(*) AS timezone_count FROM pg_timezone_names;
+
+          -- Test that we have reasonable number of timezones (should be 500+)
+          DO $$
+          DECLARE
+            tz_count INTEGER;
+          BEGIN
+            SELECT COUNT(*) INTO tz_count FROM pg_timezone_names;
+            IF tz_count < 500 THEN
+              RAISE EXCEPTION 'Insufficient timezones: found %, expected 500+', tz_count;
+            END IF;
+            RAISE NOTICE 'Timezone test passed: found % timezones', tz_count;
+          END $$;
+
+          -- Show current timezone setting
+          SHOW timezone;
+          EOF
+
+          # Run timezone tests from file
+          ./bin/psql -p 54322 -h 127.0.0.1 -U supabase_admin -d postgres -v ON_ERROR_STOP=1 -f timezone_test.sql | tee timezone.log
+          TIMEZONE_STATUS=${PIPESTATUS[0]}
+
+          if [ $TIMEZONE_STATUS -ne 0 ]; then
+            echo "Timezone tests failed"
+            cat timezone.log
+            exit 1
+          fi
+
+          echo "Timezone tests passed successfully"
+          echo ""
+
+          # Stop PostgreSQL
+          ./bin/pg_ctl -D "$PGDATA" stop -m fast
+
+          echo "Migration test completed successfully"
+
+  release:
+    name: Create GitHub Release
+    needs: [build-native, test-portability]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Prepare release assets
+        run: |
+          mkdir -p release temp
+
+          # Determine version
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+          else
+            VERSION="${{ github.ref_name }}"
+          fi
+          VERSION="${VERSION//\//-}"
+
+          # Create tarballs from each artifact directory
+          for dir in artifacts/*; do
+            if [ -d "$dir" ]; then
+              ARTIFACT_NAME=$(basename "$dir")
+              # Extract arch from artifact name (e.g., "supabase-postgres-darwin-arm64" -> "darwin-arm64")
+              ARCH="${ARTIFACT_NAME#supabase-postgres-}"
+              BUILD_DIR="supabase-postgres-${VERSION}-${ARCH}"
+
+              echo "Creating tarball for ${BUILD_DIR}..."
+
+              # Create temp directory with proper structure
+              mkdir -p "temp/${BUILD_DIR}"
+              cp -r "$dir"/* "temp/${BUILD_DIR}/"
+
+              # Create tarball with directory structure
+              tar -czhf "release/${BUILD_DIR}.tar.gz" -C temp "${BUILD_DIR}"
+
+              # Generate checksum
+              sha256sum "release/${BUILD_DIR}.tar.gz" > "release/${BUILD_DIR}.tar.gz.sha256"
+
+              # Cleanup temp directory for this artifact
+              rm -rf "temp/${BUILD_DIR}"
+
+              echo "✓ Created release/${BUILD_DIR}.tar.gz"
+            fi
+          done
+
+          ls -lh release/
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: release/*
+          generate_release_notes: true

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -27,6 +27,9 @@
           # deadnix: skip
           makeCheckHarness =
             pgpkg:
+            {
+              isCliVariant ? false,
+            }:
             let
               pg_prove = pkgs.perlPackages.TAPParserSourceHandlerpgTAP;
               inherit (self'.packages) pg_regress;
@@ -96,6 +99,45 @@
                   "5536"
                 else
                   "5537";
+
+              # Script to generate shared_preload_libraries dynamically based on receipt.json
+              generatePreloadLibs = pkgs.writeShellScript "generate-preload-libs" ''
+                RECEIPT_FILE="$1"
+
+                # Define which extensions should be preloaded (in order of priority)
+                WANTED_EXTS=(
+                  "pg_stat_statements"
+                  "pgaudit"
+                  "plpgsql"
+                  "plpgsql_check"
+                  "pg_cron"
+                  "pg_net"
+                  "pgsodium"
+                  "timescaledb"
+                  "auto_explain"
+                  "pg_tle"
+                  "plan_filter"
+                  "supabase_vault"
+                  "supautils"
+                )
+
+                # Extract available extensions from receipt
+                AVAILABLE_EXTS=$(${pkgs.jq}/bin/jq -r '.extensions[].name' "$RECEIPT_FILE")
+
+                # Build the preload list (comma-separated, no individual quotes)
+                PRELOAD_LIST=""
+                for ext in "''${WANTED_EXTS[@]}"; do
+                  if echo "$AVAILABLE_EXTS" | grep -q "^$ext\$"; then
+                    if [ -z "$PRELOAD_LIST" ]; then
+                      PRELOAD_LIST="$ext"
+                    else
+                      PRELOAD_LIST="$PRELOAD_LIST, $ext"
+                    fi
+                  fi
+                done
+
+                echo "$PRELOAD_LIST"
+              '';
 
               # Use the shared setup but with a test-specific name
               start-postgres-server-bin = pkgs-lib.makePostgresDevSetup {
@@ -170,11 +212,51 @@
               # Filter SQL test files
               filteredSqlTests = filterTestFiles majorVersion ./tests/sql;
 
+              # Tests to skip for CLI variants (require extensions not in CLI)
+              cliSkipTests = [
+                # Extension-specific tests
+                "evtrigs"
+                "http"
+                "hypopg"
+                "index_advisor"
+                "pg_hashids"
+                "pg_jsonschema"
+                "pg_partman"
+                "pg_repack"
+                "pg_tle"
+                "pgtap"
+                "pgmq"
+                "pgroonga"
+                "pgrouting"
+                "plpgsql-check"
+                "plv8"
+                "postgis"
+                "postgres_fdw"
+                # Tests that depend on extensions not in CLI
+                "security" # depends on various extensions
+                "extensions_schema" # tests extension loading
+                "roles" # includes roles/schemas from extensions not in CLI (pgtle, pgmq, repack, topology)
+                # Version-specific extension tests
+                "z_17_ext_interface"
+                "z_17_pg_stat_monitor"
+                "z_17_pgvector"
+                "z_17_rum"
+                "z_17_roles" # version-specific roles test, includes pgtle_admin
+              ];
+
               # Convert filtered tests to a sorted list of basenames (without extension)
               testList = pkgs.lib.mapAttrsToList (
                 name: _: builtins.substring 0 (pkgs.lib.stringLength name - 4) name
               ) filteredSqlTests;
-              sortedTestList = builtins.sort (a: b: a < b) testList;
+
+              # Filter out CLI-incompatible tests if this is a CLI variant
+              filteredTestList =
+                if isCliVariant then
+                  builtins.filter (test: !(builtins.elem test cliSkipTests)) testList
+                else
+                  testList;
+
+              sortedTestList = builtins.sort (a: b: a < b) filteredTestList;
             in
             pkgs.writeShellApplication rec {
               name = "postgres-${pgpkg.version}-check-harness";
@@ -283,19 +365,19 @@
                 PGTAP_CLUSTER=$(mktemp -d)
                 log info "Creating temporary PostgreSQL cluster at $PGTAP_CLUSTER"
                 log_cmd initdb --locale=C --username=supabase_admin -D "$PGTAP_CLUSTER"
+
+                # Generate preload libraries list dynamically from receipt.json
+                PRELOAD_LIBRARIES=$(${generatePreloadLibs} ${pgpkg}/receipt.json)
+                log info "Generated preload libraries: $PRELOAD_LIBRARIES"
+
                 substitute ${./tests/postgresql.conf.in} "$PGTAP_CLUSTER"/postgresql.conf \
-                  --subst-var-by PGSODIUM_GETKEY_SCRIPT "${getkey-script}/bin/pgsodium-getkey"
+                  --subst-var-by PGSODIUM_GETKEY_SCRIPT "${getkey-script}/bin/pgsodium-getkey" \
+                  --subst-var-by PRELOAD_LIBRARIES "$PRELOAD_LIBRARIES"
                 echo "listen_addresses = '127.0.0.1'" >> "$PGTAP_CLUSTER"/postgresql.conf
                 echo "port = ${pgPort}" >> "$PGTAP_CLUSTER"/postgresql.conf
                 echo "host all all 127.0.0.1/32 trust" >> "$PGTAP_CLUSTER/pg_hba.conf"
                 log info "Checking shared_preload_libraries setting:"
                 log info "$(grep -rn "shared_preload_libraries" "$PGTAP_CLUSTER"/postgresql.conf)"
-                # Remove timescaledb if running orioledb-17 check
-                log info "pgpkg.version is: ${pgpkg.version}"
-                #shellcheck disable=SC2193
-                if [[ "${pgpkg.version}" == *"17"* ]]; then
-                  perl -pi -e 's/ timescaledb,//g' "$PGTAP_CLUSTER/postgresql.conf"
-                fi
                 # Configure OrioleDB if running orioledb-17 check
                 #shellcheck disable=SC2193
                 if [[ "${pgpkg.version}" == *"_"* ]]; then
@@ -337,12 +419,23 @@
                   log_cmd psql -p ${pgPort} -h localhost --username=supabase_admin -d testing -c "CREATE EXTENSION IF NOT EXISTS orioledb;"
                 fi
 
-                log info "Loading prime SQL file"
-                if ! log_cmd psql -p ${pgPort} -h localhost --username=supabase_admin -d testing -v ON_ERROR_STOP=1 -Xf ${./tests/prime.sql}; then
-                  log error "Error executing SQL file. PostgreSQL log content:"
-                  cat "$PGTAP_CLUSTER"/postgresql.log
-                  pg_ctl -D "$PGTAP_CLUSTER" stop
-                  exit 1
+                # Check if this is a CLI variant (passed as parameter)
+                if ${lib.boolToString isCliVariant}; then
+                  log info "CLI variant detected - loading CLI prime SQL file"
+                  if ! log_cmd psql -p ${pgPort} -h localhost --username=supabase_admin -d testing -v ON_ERROR_STOP=1 -Xf ${./tests/prime-cli.sql}; then
+                    log error "Error executing CLI prime SQL file. PostgreSQL log content:"
+                    cat "$PGTAP_CLUSTER"/postgresql.log
+                    pg_ctl -D "$PGTAP_CLUSTER" stop
+                    exit 1
+                  fi
+                else
+                  log info "Loading prime SQL file (full extension set)"
+                  if ! log_cmd psql -p ${pgPort} -h localhost --username=supabase_admin -d testing -v ON_ERROR_STOP=1 -Xf ${./tests/prime.sql}; then
+                    log error "Error executing SQL file. PostgreSQL log content:"
+                    cat "$PGTAP_CLUSTER"/postgresql.log
+                    pg_ctl -D "$PGTAP_CLUSTER" stop
+                    exit 1
+                  fi
                 fi
 
                 # Create a table to store test configuration
@@ -383,10 +476,19 @@
                   log_cmd psql -p ${pgPort} -h localhost --no-password --username=supabase_admin -d postgres -c "CREATE EXTENSION IF NOT EXISTS orioledb;"
                 fi
 
-                log info "Loading prime SQL file"
-                if ! log_cmd psql -p ${pgPort} -h localhost --no-password --username=supabase_admin -d postgres -v ON_ERROR_STOP=1 -Xf ${./tests/prime.sql} 2>&1; then
-                  log error "Error executing SQL file"
-                  exit 1
+                # Check if this is a CLI variant (passed as parameter)
+                if ${lib.boolToString isCliVariant}; then
+                  log info "CLI variant detected - loading CLI prime SQL file"
+                  if ! log_cmd psql -p ${pgPort} -h localhost --no-password --username=supabase_admin -d postgres -v ON_ERROR_STOP=1 -Xf ${./tests/prime-cli.sql} 2>&1; then
+                    log error "Error executing CLI prime SQL file"
+                    exit 1
+                  fi
+                else
+                  log info "Loading prime SQL file (full extension set)"
+                  if ! log_cmd psql -p ${pgPort} -h localhost --no-password --username=supabase_admin -d postgres -v ON_ERROR_STOP=1 -Xf ${./tests/prime.sql} 2>&1; then
+                    log error "Error executing SQL file"
+                    exit 1
+                  fi
                 fi
 
                 # Create a table to store test configuration for pg_regress tests
@@ -399,7 +501,14 @@
 
                 #shellcheck disable=SC2154
                 mkdir -p "$out/regression_output"
-                log info "Running pg_regress tests"
+
+                # Check if this is a CLI variant and log appropriately
+                if ${lib.boolToString isCliVariant}; then
+                  log info "CLI variant detected - running subset of pg_regress tests (${builtins.toString (builtins.length sortedTestList)} tests)"
+                else
+                  log info "Running pg_regress tests (${builtins.toString (builtins.length sortedTestList)} tests)"
+                fi
+
                 if ! log_cmd pg_regress \
                   --use-existing \
                   --dbname=postgres \
@@ -415,22 +524,318 @@
                 fi
                 log info "pg_regress tests completed successfully"
 
-                log info "Running migrations tests"
-                log_cmd pg_prove -p ${pgPort} -U supabase_admin -h localhost -d postgres -v ${../migrations/tests}/test.sql
-                log info "Migrations tests completed successfully"
+                # Skip migrations tests for CLI variants (they may depend on extensions)
+                if ${lib.boolToString isCliVariant}; then
+                  log info "CLI variant detected - skipping migrations tests"
+                else
+                  log info "Running migrations tests"
+                  log_cmd pg_prove -p ${pgPort} -U supabase_admin -h localhost -d postgres -v ${../migrations/tests}/test.sql
+                  log info "Migrations tests completed successfully"
+                fi
               '';
             };
         in
         {
           psql_15 = pkgs.runCommand "run-check-harness-psql-15" { } (
-            lib.getExe (makeCheckHarness self'.packages."psql_15/bin")
+            lib.getExe (makeCheckHarness self'.packages."psql_15/bin" { })
           );
           psql_17 = pkgs.runCommand "run-check-harness-psql-17" { } (
-            lib.getExe (makeCheckHarness self'.packages."psql_17/bin")
+            lib.getExe (makeCheckHarness self'.packages."psql_17/bin" { })
           );
           psql_orioledb-17 = pkgs.runCommand "run-check-harness-psql-orioledb-17" { } (
-            lib.getExe (makeCheckHarness self'.packages."psql_orioledb-17/bin")
+            lib.getExe (makeCheckHarness self'.packages."psql_orioledb-17/bin" { })
           );
+          # CLI variant checks
+          psql_17_cli = pkgs.runCommand "run-check-harness-psql-17-cli" { } (
+            lib.getExe (makeCheckHarness self'.packages."psql_17_cli/bin" { isCliVariant = true; })
+          );
+          # Portable CLI bundle portability checks
+          psql_17_cli_portable =
+            pkgs.runCommand "psql_17_cli_portable-portability-check"
+              {
+                nativeBuildInputs = [
+                  pkgs.file
+                ]
+                ++ (
+                  if pkgs.stdenv.isDarwin then
+                    [ pkgs.darwin.cctools ]
+                  else
+                    [
+                      pkgs.patchelf
+                      pkgs.binutils
+                    ]
+                );
+              }
+              ''
+                cd ${self'.packages.psql_17_cli_portable}
+
+                echo "=== Section 1: Checking binaries for /nix/store references ==="
+                for bin in bin/.*-wrapped; do
+                  if [ -f "$bin" ]; then
+                    ${
+                      if pkgs.stdenv.isDarwin then
+                        ''
+                          if otool -L "$bin" 2>/dev/null | grep -q '/nix/store'; then
+                            echo "ERROR: Found /nix/store reference in $bin:"
+                            otool -L "$bin"
+                            exit 1
+                          fi
+                        ''
+                      else
+                        ''
+                          if readelf -d "$bin" 2>/dev/null | grep -q '/nix/store'; then
+                            echo "ERROR: Found /nix/store reference in $bin:"
+                            readelf -d "$bin"
+                            exit 1
+                          fi
+                        ''
+                    }
+                    echo "  ✓ $bin has no /nix/store references"
+                  fi
+                done
+
+                echo ""
+                echo "=== Section 2: Checking libraries for /nix/store references ==="
+                for lib in lib/*.${if pkgs.stdenv.isDarwin then "dylib*" else "so*"}; do
+                  if [ -f "$lib" ]; then
+                    ${
+                      if pkgs.stdenv.isDarwin then
+                        ''
+                          if otool -L "$lib" 2>/dev/null | grep -q '/nix/store'; then
+                            echo "ERROR: Found /nix/store reference in $lib:"
+                            otool -L "$lib"
+                            exit 1
+                          fi
+                        ''
+                      else
+                        ''
+                          if readelf -d "$lib" 2>/dev/null | grep -q '/nix/store'; then
+                            echo "ERROR: Found /nix/store reference in $lib:"
+                            readelf -d "$lib"
+                            exit 1
+                          fi
+                        ''
+                    }
+                    echo "  ✓ $lib has no /nix/store references"
+                  fi
+                done
+
+                echo ""
+                echo "=== Section 3: Checking extension libraries for /nix/store references ==="
+                for extlib in lib/postgresql/*.${if pkgs.stdenv.isDarwin then "dylib" else "so"}; do
+                  if [ -f "$extlib" ]; then
+                    ${
+                      if pkgs.stdenv.isDarwin then
+                        ''
+                          if otool -L "$extlib" 2>/dev/null | grep -q '/nix/store'; then
+                            echo "ERROR: Found /nix/store reference in $extlib:"
+                            otool -L "$extlib"
+                            exit 1
+                          fi
+                        ''
+                      else
+                        ''
+                          if readelf -d "$extlib" 2>/dev/null | grep -q '/nix/store'; then
+                            echo "ERROR: Found /nix/store reference in $extlib:"
+                            readelf -d "$extlib"
+                            exit 1
+                          fi
+                        ''
+                    }
+                    echo "  ✓ $extlib has no /nix/store references"
+                  fi
+                done
+
+                echo ""
+                echo "=== Section 4: Verifying bundled libraries include transitive dependencies ==="
+                ${
+                  if pkgs.stdenv.isDarwin then
+                    ''
+                      # Check for ICU transitive dependencies
+                      if [ ! -f "lib/libicuuc.75.1.dylib" ]; then
+                        echo "ERROR: Missing transitive dependency libicuuc.75.1.dylib"
+                        exit 1
+                      fi
+                      echo "  ✓ Found lib/libicuuc.75.1.dylib"
+
+                      if [ ! -f "lib/libicudata.75.1.dylib" ]; then
+                        echo "ERROR: Missing transitive dependency libicudata.75.1.dylib"
+                        exit 1
+                      fi
+                      echo "  ✓ Found lib/libicudata.75.1.dylib"
+                    ''
+                  else
+                    ''
+                      # Check for ICU transitive dependencies (Linux uses .so.75 without patch version)
+                      if [ ! -f "lib/libicuuc.so.75" ]; then
+                        echo "ERROR: Missing transitive dependency libicuuc.so.75"
+                        exit 1
+                      fi
+                      echo "  ✓ Found lib/libicuuc.so.75"
+
+                      if [ ! -f "lib/libicudata.so.75" ]; then
+                        echo "ERROR: Missing transitive dependency libicudata.so.75"
+                        exit 1
+                      fi
+                      echo "  ✓ Found lib/libicudata.so.75"
+                    ''
+                }
+
+                echo ""
+                echo "=== Section 5: Checking binary RPATH configuration ==="
+                for bin in bin/.*-wrapped; do
+                  if [ -f "$bin" ]; then
+                    ${
+                      if pkgs.stdenv.isDarwin then
+                        ''
+                          if ! otool -l "$bin" 2>/dev/null | grep -q '@executable_path/../lib'; then
+                            echo "ERROR: Binary $bin missing correct RPATH"
+                            otool -l "$bin"
+                            exit 1
+                          fi
+                        ''
+                      else
+                        ''
+                          if ! readelf -d "$bin" 2>/dev/null | grep -q 'ORIGIN/../lib'; then
+                            echo "ERROR: Binary $bin missing correct RPATH"
+                            readelf -d "$bin"
+                            exit 1
+                          fi
+                        ''
+                    }
+                    echo "  ✓ $bin has correct RPATH"
+                  fi
+                done
+
+                echo ""
+                echo "=== Section 6: Checking library RPATH configuration ==="
+                for lib in lib/*.${if pkgs.stdenv.isDarwin then "dylib*" else "so*"}; do
+                  if [ -f "$lib" ] && file "$lib" | grep -q "${
+                    if pkgs.stdenv.isDarwin then "Mach-O" else "ELF"
+                  }"; then
+                    ${
+                      if pkgs.stdenv.isDarwin then
+                        ''
+                          if ! otool -l "$lib" 2>/dev/null | grep -q '@loader_path'; then
+                            echo "ERROR: Library $lib missing correct RPATH"
+                            otool -l "$lib"
+                            exit 1
+                          fi
+                        ''
+                      else
+                        ''
+                          if ! readelf -d "$lib" 2>/dev/null | grep -q 'ORIGIN'; then
+                            echo "ERROR: Library $lib missing correct RPATH"
+                            readelf -d "$lib"
+                            exit 1
+                          fi
+                        ''
+                    }
+                    echo "  ✓ $lib has correct RPATH"
+                  fi
+                done
+
+                echo ""
+                ${lib.optionalString pkgs.stdenv.isLinux ''
+                  echo "=== Section 7: Checking ELF interpreter for portability ==="
+
+                  # Determine expected interpreter based on architecture
+                  ARCH=$(uname -m)
+                  if [ "$ARCH" = "x86_64" ]; then
+                    EXPECTED_INTERP="/lib64/ld-linux-x86-64.so.2"
+                  elif [ "$ARCH" = "aarch64" ]; then
+                    EXPECTED_INTERP="/lib/ld-linux-aarch64.so.1"
+                  else
+                    echo "ERROR: Unsupported architecture $ARCH"
+                    exit 1
+                  fi
+
+                  for bin in bin/.*-wrapped; do
+                    if [ -f "$bin" ] && file "$bin" | grep -q ELF; then
+                      # Check that interpreter is set to system path, not Nix store
+                      INTERP=$(readelf -l "$bin" | grep "program interpreter" | sed -n 's/.*\[requesting: \(.*\)\]/\1/p' | tr -d ']')
+                      if [ -z "$INTERP" ]; then
+                        # Try alternative readelf output format
+                        INTERP=$(readelf -l "$bin" | grep "interpreter" | sed -n 's/.*interpreter: \(.*\)]/\1/p')
+                      fi
+
+                      if echo "$INTERP" | grep -q '/nix/store'; then
+                        echo "ERROR: Binary $bin has Nix store interpreter: $INTERP"
+                        readelf -l "$bin" | grep -A 2 "program interpreter"
+                        exit 1
+                      fi
+
+                      # Verify it's using the expected system dynamic linker for this architecture
+                      if [ "$INTERP" != "$EXPECTED_INTERP" ]; then
+                        echo "ERROR: Binary $bin has unexpected interpreter: $INTERP (expected: $EXPECTED_INTERP)"
+                        readelf -l "$bin" | grep -A 2 "program interpreter"
+                        exit 1
+                      fi
+
+                      echo "  ✓ $bin uses system interpreter: $INTERP"
+                    fi
+                  done
+                  echo ""
+                ''}
+                echo "=== Section 8: Verifying wrapper scripts ==="
+                for bin in bin/postgres bin/pg_config bin/pg_ctl bin/initdb bin/psql bin/pg_dump bin/pg_restore bin/createdb bin/dropdb; do
+                  if [ -f "$bin" ]; then
+                    if ! grep -q "#!/bin/bash" "$bin"; then
+                      echo "ERROR: Wrapper $bin missing proper shebang"
+                      head -n 1 "$bin"
+                      exit 1
+                    fi
+                    if ! grep -q "NIX_PGLIBDIR" "$bin"; then
+                      echo "ERROR: Wrapper $bin missing NIX_PGLIBDIR"
+                      cat "$bin"
+                      exit 1
+                    fi
+                    ${
+                      if pkgs.stdenv.isDarwin then
+                        ''
+                          if ! grep -q "DYLD_LIBRARY_PATH" "$bin"; then
+                            echo "ERROR: Wrapper $bin missing DYLD_LIBRARY_PATH"
+                            cat "$bin"
+                            exit 1
+                          fi
+                        ''
+                      else
+                        ''
+                          if ! grep -q "LD_LIBRARY_PATH" "$bin"; then
+                            echo "ERROR: Wrapper $bin missing LD_LIBRARY_PATH"
+                            cat "$bin"
+                            exit 1
+                          fi
+                        ''
+                    }
+                    echo "  ✓ $bin is a valid wrapper script"
+                  fi
+                done
+
+                echo ""
+                ${lib.optionalString pkgs.stdenv.isLinux ''
+                  echo "=== Section 9: Verify system libraries are NOT bundled ==="
+                  # Check that glibc and other core system libraries are NOT in lib/
+                  SYSTEM_LIBS="libc.so libc-2 ld-linux libdl.so libpthread.so libm.so libresolv.so librt.so"
+                  FOUND_SYSTEM_LIB=0
+                  for syslib in $SYSTEM_LIBS; do
+                    if find lib -name "$syslib*" 2>/dev/null | grep -q .; then
+                      echo "ERROR: System library $syslib should NOT be bundled"
+                      find lib -name "$syslib*" -ls
+                      FOUND_SYSTEM_LIB=1
+                    fi
+                  done
+
+                  if [ $FOUND_SYSTEM_LIB -eq 1 ]; then
+                    exit 1
+                  fi
+
+                  echo "  ✓ No system libraries bundled (glibc, libdl, libpthread, libm)"
+                  echo ""
+                ''}
+                echo "=== All portability checks passed! ==="
+                touch $out
+              '';
           inherit (self'.packages)
             wal-g-2
             pg_regress

--- a/nix/packages/cli-config/pg_hba.conf.template
+++ b/nix/packages/cli-config/pg_hba.conf.template
@@ -1,0 +1,9 @@
+# Supabase CLI Host-Based Authentication
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+
+# Local connections
+local   all             all                                     scram-sha-256
+# IPv4 local connections
+host    all             all             127.0.0.1/32            scram-sha-256
+# IPv6 local connections
+host    all             all             ::1/128                 scram-sha-256

--- a/nix/packages/cli-config/pg_ident.conf.template
+++ b/nix/packages/cli-config/pg_ident.conf.template
@@ -1,0 +1,2 @@
+# Supabase CLI Ident Map Configuration
+# MAPNAME       SYSTEM-USERNAME         PG-USERNAME

--- a/nix/packages/cli-config/pgsodium_getkey.sh
+++ b/nix/packages/cli-config/pgsodium_getkey.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -euo pipefail
+
+KEY_FILE="${PGSODIUM_KEY_FILE:-$HOME/.supabase/pgsodium_root.key}"
+KEY_DIR="$(dirname "$KEY_FILE")"
+
+# Create directory if it doesn't exist
+mkdir -p "$KEY_DIR"
+
+if [[ ! -f "${KEY_FILE}" ]]; then
+    head -c 32 /dev/urandom | od -A n -t x1 | tr -d ' \n' > "${KEY_FILE}"
+fi
+cat "$KEY_FILE"

--- a/nix/packages/cli-config/postgresql.conf.template
+++ b/nix/packages/cli-config/postgresql.conf.template
@@ -1,0 +1,43 @@
+# Supabase CLI PostgreSQL Configuration
+# Minimal configuration for local development
+
+# Connection Settings
+listen_addresses = '127.0.0.1'
+port = 54322
+max_connections = 100
+unix_socket_directories = '/tmp'
+
+# Memory Settings (conservative for local dev)
+shared_buffers = 128MB
+effective_cache_size = 256MB
+work_mem = 4MB
+maintenance_work_mem = 64MB
+
+# Write Ahead Log
+wal_level = replica
+max_wal_senders = 0
+
+# Logging
+log_destination = 'stderr'
+logging_collector = off
+log_min_messages = warning
+log_min_error_statement = error
+
+# Locale
+lc_messages = 'C'
+lc_monetary = 'C'
+lc_numeric = 'C'
+lc_time = 'C'
+
+# Extensions
+shared_preload_libraries = 'pg_stat_statements, pg_cron, pg_net, pgsodium, supabase_vault, supautils'
+
+# pgsodium and vault configuration
+# Set the path to your pgsodium_getkey.sh script
+# Default location when using portable bundle: share/supabase-cli/config/pgsodium_getkey.sh
+#pgsodium.getkey_script = '/path/to/pgsodium_getkey.sh'
+#vault.getkey_script = '/path/to/pgsodium_getkey.sh'
+
+# Supautils configuration
+supautils.reserved_roles = 'supabase_admin,supabase_auth_admin,supabase_storage_admin,supabase_read_only_user,supabase_replication_admin,supabase_realtime_admin,supabase_functions_admin'
+supautils.reserved_memberships = 'pg_read_server_files,pg_write_server_files,pg_execute_server_program'

--- a/nix/packages/cli-config/supabase-postgres-init.sh
+++ b/nix/packages/cli-config/supabase-postgres-init.sh
@@ -1,0 +1,191 @@
+#!/bin/bash
+set -Eeo pipefail
+
+# Supabase PostgreSQL Initialization Script
+# Similar to docker-entrypoint.sh from official postgres image
+# Handles database initialization, password setup, and configuration
+
+# Default values
+PGDATA="${PGDATA:-./data}"
+POSTGRES_USER="${POSTGRES_USER:-supabase_admin}"
+POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-postgres}"
+POSTGRES_DB="${POSTGRES_DB:-postgres}"
+
+# Get the directory where this script lives
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Script is at share/supabase-cli/bin/, so go up 3 levels to reach bundle root
+BUNDLE_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+PGBIN="$BUNDLE_DIR/bin"
+
+# Logging functions
+postgres_log() {
+    local type="$1"; shift
+    printf '%s [%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$type" "$*"
+}
+
+postgres_note() {
+    postgres_log Note "$@"
+}
+
+postgres_error() {
+    postgres_log ERROR "$@" >&2
+}
+
+# Check if PGDATA is initialized
+postgres_is_initialized() {
+    [ -s "$PGDATA/PG_VERSION" ]
+}
+
+# Setup initial database
+postgres_setup_db() {
+    postgres_note "Initializing database in $PGDATA"
+
+    # Create PGDATA directory if it doesn't exist
+    mkdir -p "$PGDATA"
+
+    # Run initdb
+    "$PGBIN/initdb" \
+        -D "$PGDATA" \
+        -U "$POSTGRES_USER" \
+        --encoding=UTF8 \
+        --locale=C \
+        --no-instructions
+
+    postgres_note "Database initialized"
+}
+
+# Setup configuration files
+postgres_setup_config() {
+    postgres_note "Setting up configuration files"
+
+    # Copy config templates
+    cp "$BUNDLE_DIR/share/supabase-cli/config/postgresql.conf.template" "$PGDATA/postgresql.conf"
+    cp "$BUNDLE_DIR/share/supabase-cli/config/pg_hba.conf.template" "$PGDATA/pg_hba.conf"
+    cp "$BUNDLE_DIR/share/supabase-cli/config/pg_ident.conf.template" "$PGDATA/pg_ident.conf"
+
+    # Set absolute path to getkey script in postgresql.conf
+    GETKEY_SCRIPT="$BUNDLE_DIR/share/supabase-cli/config/pgsodium_getkey.sh"
+
+    # Ensure getkey script is executable
+    if [ -f "$GETKEY_SCRIPT" ]; then
+        chmod +x "$GETKEY_SCRIPT"
+    fi
+
+    cat >> "$PGDATA/postgresql.conf" << EOF
+
+# pgsodium and vault configuration (set by supabase-postgres-init)
+pgsodium.getkey_script = '$GETKEY_SCRIPT'
+vault.getkey_script = '$GETKEY_SCRIPT'
+EOF
+
+    postgres_note "Configuration files set up"
+}
+
+# Set password for superuser using single-user mode
+postgres_setup_password() {
+    if [ -n "$POSTGRES_PASSWORD" ]; then
+        postgres_note "Setting password for user: $POSTGRES_USER"
+
+        # Use single-user mode to set password before server starts
+        # This allows us to use scram-sha-256 authentication
+        # Must specify 'postgres' database as the target database
+        # -j flag allows natural multi-line SQL (terminated by semicolon + empty line)
+        "$PGBIN/postgres" --single -j -D "$PGDATA" postgres <<-EOSQL
+			ALTER USER "$POSTGRES_USER" WITH PASSWORD '$POSTGRES_PASSWORD';
+		EOSQL
+
+        postgres_note "Password set successfully"
+    fi
+}
+
+# Create additional database if specified and different from default
+postgres_create_db() {
+    if [ "$POSTGRES_DB" != "postgres" ]; then
+        postgres_note "Creating database: $POSTGRES_DB"
+
+        # Must specify 'postgres' database as the target database for single-user mode
+        # -j flag allows natural multi-line SQL (terminated by semicolon + empty line)
+        "$PGBIN/postgres" --single -j -D "$PGDATA" postgres <<-EOSQL
+			CREATE DATABASE "$POSTGRES_DB";
+		EOSQL
+
+        postgres_note "Database created"
+    fi
+}
+
+# Run initialization scripts from a directory
+postgres_process_init_files() {
+    local initdir="$1"
+
+    if [ -d "$initdir" ]; then
+        postgres_note "Running initialization scripts from $initdir"
+
+        # Process files in sorted order
+        for f in "$initdir"/*; do
+            if [ ! -f "$f" ]; then
+                continue
+            fi
+
+            case "$f" in
+                *.sh)
+                    if [ -x "$f" ]; then
+                        postgres_note "Running $f"
+                        "$f"
+                    else
+                        postgres_note "Sourcing $f"
+                        . "$f"
+                    fi
+                    ;;
+                *.sql)
+                    postgres_note "Running $f"
+                    "$PGBIN/postgres" --single -j -D "$PGDATA" postgres < "$f"
+                    ;;
+                *.sql.gz)
+                    postgres_note "Running $f"
+                    gunzip -c "$f" | "$PGBIN/postgres" --single -j -D "$PGDATA" postgres
+                    ;;
+                *)
+                    postgres_note "Ignoring $f"
+                    ;;
+            esac
+        done
+    fi
+}
+
+# Main initialization flow
+postgres_init() {
+    if postgres_is_initialized; then
+        postgres_note "Database already initialized, skipping setup"
+        return
+    fi
+
+    postgres_setup_db
+    postgres_setup_config
+    postgres_setup_password
+    postgres_create_db
+
+    # Process any initialization scripts in standard location
+    # This allows users to add custom init scripts similar to Docker
+    postgres_process_init_files "$BUNDLE_DIR/share/supabase-cli/init-scripts"
+
+    postgres_note "Initialization complete"
+}
+
+# Main entrypoint
+main() {
+    # Validate environment
+    if [ -z "$PGDATA" ]; then
+        postgres_error "PGDATA environment variable must be set"
+        exit 1
+    fi
+
+    # Initialize database if needed
+    postgres_init
+
+    # Start PostgreSQL server
+    postgres_note "Starting PostgreSQL server"
+    exec "$PGBIN/postgres" -D "$PGDATA" "$@"
+}
+
+# Run main function
+main "$@"

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -62,6 +62,9 @@
             psql_orioledb-17 = self'.packages."psql_orioledb-17/bin";
             inherit (self.supabase) defaults;
           };
+          psql_17_cli_portable = pkgs.callPackage ./postgres-portable.nix {
+            psql_17_cli = self'.legacyPackages.psql_17_cli;
+          };
           start-replica = pkgs.callPackage ./start-replica.nix {
             psql_15 = self'.packages."psql_15/bin";
             inherit pgsqlSuperuser;

--- a/nix/packages/postgres-portable.nix
+++ b/nix/packages/postgres-portable.nix
@@ -1,0 +1,355 @@
+{
+  lib,
+  stdenv,
+  writeTextFile,
+  patchelf,
+  psql_17_cli,
+}:
+let
+  configDir = ./cli-config;
+
+  receipt = writeTextFile {
+    name = "cli-receipt";
+    destination = "/receipt.json";
+    text = builtins.toJSON {
+      variant = "cli";
+      psql-version = psql_17_cli.bin.version;
+      extensions = [
+        "supautils"
+        "pg_graphql"
+        "pgsodium"
+        "supabase_vault"
+        "pg_net"
+        "pg_cron"
+        "safeupdate"
+      ];
+      receipt-version = "1";
+    };
+  };
+
+  migrationBundle = stdenv.mkDerivation {
+    name = "cli-migration-bundle";
+    src = ../../migrations/db;
+    dontPatchShebangs = true;
+    installPhase = ''
+      mkdir -p $out/share/supabase-cli/migrations
+      cp -r init-scripts $out/share/supabase-cli/migrations/
+      cp -r migrations $out/share/supabase-cli/migrations/
+      cp migrate.sh $out/share/supabase-cli/migrations/
+      chmod +x $out/share/supabase-cli/migrations/migrate.sh
+
+      # Add pgbouncer schema (same as Docker build does)
+      cp ${../../ansible/files/pgbouncer_config/pgbouncer_auth_schema.sql} \
+         $out/share/supabase-cli/migrations/init-scripts/00-schema.sql
+
+      # Add pg_stat_statements extension (same as Docker build does)
+      cp ${../../ansible/files/stat_extension.sql} \
+         $out/share/supabase-cli/migrations/migrations/00-extension.sql
+    '';
+  };
+
+  configBundle = stdenv.mkDerivation {
+    name = "cli-config-bundle";
+    src = configDir;
+    dontPatchShebangs = true;
+    installPhase = ''
+      mkdir -p $out/share/supabase-cli/config
+      mkdir -p $out/share/supabase-cli/bin
+      cp postgresql.conf.template $out/share/supabase-cli/config/
+      cp pg_hba.conf.template $out/share/supabase-cli/config/
+      cp pg_ident.conf.template $out/share/supabase-cli/config/
+      cp pgsodium_getkey.sh $out/share/supabase-cli/config/
+      cp supabase-postgres-init.sh $out/share/supabase-cli/bin/
+      chmod +x $out/share/supabase-cli/config/pgsodium_getkey.sh
+      chmod +x $out/share/supabase-cli/bin/supabase-postgres-init.sh
+    '';
+  };
+in
+stdenv.mkDerivation {
+  name = "psql_17_cli_portable";
+  version = psql_17_cli.bin.version;
+
+  dontUnpack = true;
+  dontPatchShebangs = true;
+  nativeBuildInputs = lib.optionals stdenv.isLinux [ patchelf ];
+
+  buildPhase = ''
+    mkdir -p $out/bin $out/lib $out/share
+
+    # List of PostgreSQL binaries to include in the Supabase CLI bundle
+    binaries="postgres pg_config pg_ctl initdb psql pg_dump pg_restore createdb dropdb pg_isready"
+
+    # Helper function to check if a library should be excluded (system libraries)
+    should_exclude_library() {
+      local libname="$1"
+      # Exclude core system libraries that must come from the host system
+      # These libraries are tightly coupled to the kernel and system configuration
+      case "$libname" in
+        libc.so*|libc-*.so*|ld-linux*.so*|libdl.so*|libpthread.so*|libm.so*|libresolv.so*|librt.so*)
+          return 0  # Exclude
+          ;;
+        *)
+          return 1  # Include
+          ;;
+      esac
+    }
+
+    # Helper function to get dependencies from a binary based on platform
+    # Returns empty string if no dependencies found (which is valid - not an error)
+    copy_deps_from_binary() {
+      local bin="$1"
+      local result=""
+      if [ "$(uname)" = "Darwin" ]; then
+        result=$(otool -L "$bin" 2>/dev/null | grep /nix/store | awk '{print $1}' | awk 'NF') || result=""
+      else
+        result=$(ldd "$bin" 2>/dev/null | grep /nix/store | awk '{print $3}' | awk 'NF') || result=""
+      fi
+      echo "$result"
+    }
+
+    # Helper function to get the library file pattern based on platform
+    get_lib_pattern() {
+      if [ "$(uname)" = "Darwin" ]; then
+        echo "*.dylib*"
+      else
+        echo "*.so*"
+      fi
+    }
+
+    # Function to recursively resolve symlinks and find actual binaries
+    # This is needed because PostgreSQL binaries in Nix are often wrapped scripts
+    # that reference the actual binary via .wrapped files. We need to extract
+    # the actual binary (not the wrapper script) for the Supabase CLI bundle.
+    resolve_binary() {
+      local path="$1"
+      local max_depth=10
+      local depth=0
+
+      while [ $depth -lt $max_depth ]; do
+        if [ -f "$path" ] && ! [ -L "$path" ]; then
+          # Check if it's a script or binary
+          if file "$path" | grep -q "script"; then
+            # It's a wrapper script, look for the wrapped binary
+            local wrapped=$(grep -o '/nix/store/[^"]*-wrapped[^"]*' "$path" | head -1)
+            if [ -n "$wrapped" ] && [ -f "$wrapped" ]; then
+              path="$wrapped"
+              depth=$((depth + 1))
+              continue
+            fi
+          fi
+          echo "$path"
+          return 0
+        elif [ -L "$path" ]; then
+          path=$(readlink -f "$path")
+          depth=$((depth + 1))
+        else
+          return 1
+        fi
+      done
+      return 1
+    }
+
+    # Copy binaries (resolve all wrappers to get actual binaries)
+    for bin in $binaries; do
+      if [ -f ${psql_17_cli.bin}/bin/$bin ] || [ -L ${psql_17_cli.bin}/bin/$bin ]; then
+        actual_binary=$(resolve_binary ${psql_17_cli.bin}/bin/$bin)
+        if [ -n "$actual_binary" ] && [ -f "$actual_binary" ]; then
+          cp "$actual_binary" $out/bin/.$bin-wrapped 2>/dev/null || true
+        fi
+      fi
+    done
+
+    # Copy all shared libraries from PostgreSQL
+    if [ -d ${psql_17_cli.bin}/lib ]; then
+      cp -rL ${psql_17_cli.bin}/lib/* $out/lib/ 2>/dev/null || true
+    fi
+
+    # Copy all runtime dependencies (shared libraries) from binaries
+    for bin in $out/bin/.*-wrapped; do
+      if [ -f "$bin" ]; then
+        deps=$(copy_deps_from_binary "$bin")
+        if [ -n "$deps" ]; then
+          echo "$deps" | while read dep; do
+            if [ -f "$dep" ]; then
+              libname=$(basename "$dep")
+              if ! should_exclude_library "$libname"; then
+                cp "$dep" $out/lib/ 2>/dev/null || true
+              else
+                echo "Skipping system library: $libname"
+              fi
+            fi
+          done
+        fi
+      fi
+    done
+
+    # Second pass: recursively check libraries for their dependencies (e.g., libicuuc -> libicudata -> libcharset)
+    # Run multiple iterations until no new libraries are found
+    lib_pattern=$(get_lib_pattern)
+    for iteration in {1..5}; do
+      before_count=$(ls $out/lib/$lib_pattern 2>/dev/null | wc -l || echo "0")
+      # Use find instead of glob to avoid bash errors when pattern doesn't match
+      libs=$(find $out/lib -name "$lib_pattern" -type f 2>/dev/null || true)
+      if [ -n "$libs" ]; then
+        echo "$libs" | while read lib; do
+          if [ -f "$lib" ]; then
+            deps=$(copy_deps_from_binary "$lib")
+            if [ -n "$deps" ]; then
+              echo "$deps" | while read dep; do
+                if [ -f "$dep" ]; then
+                  libname=$(basename "$dep")
+                  if [ ! -f "$out/lib/$libname" ]; then
+                    if ! should_exclude_library "$libname"; then
+                      echo "Iteration $iteration: Copying transitive dependency $libname"
+                      cp "$dep" $out/lib/ 2>/dev/null || true
+                    else
+                      echo "Iteration $iteration: Skipping system library $libname"
+                    fi
+                  fi
+                fi
+              done
+            fi
+          fi
+        done
+      fi
+      after_count=$(ls $out/lib/$lib_pattern 2>/dev/null | wc -l || echo "0")
+      if [ "$before_count" -eq "$after_count" ]; then
+        echo "No new dependencies found after $iteration iterations"
+        break
+      fi
+    done
+
+    # Copy share directory
+    if [ -d ${psql_17_cli.bin}/share ]; then
+      cp -rL ${psql_17_cli.bin}/share/* $out/share/ 2>/dev/null || true
+    fi
+
+    # Add config templates and initialization script
+    mkdir -p $out/share/supabase-cli/config
+    mkdir -p $out/share/supabase-cli/bin
+    cp ${configBundle}/share/supabase-cli/config/* $out/share/supabase-cli/config/
+    cp ${configBundle}/share/supabase-cli/bin/* $out/share/supabase-cli/bin/
+
+    # Add migration files
+    cp -r ${migrationBundle}/share/supabase-cli/migrations $out/share/supabase-cli/
+
+    # Add receipt
+    cp ${receipt}/receipt.json $out/cli-receipt.json
+  '';
+
+  installPhase = ''
+        # Create wrapper scripts for Supabase CLI that set up library paths
+        for bin in $binaries; do
+          if [ -f $out/bin/.$bin-wrapped ]; then
+            cat > $out/bin/$bin << 'WRAPPER_EOF'
+    #!/bin/bash
+    SCRIPT_DIR="$(cd "$(dirname "''${BASH_SOURCE[0]}")" && pwd)"
+    export NIX_PGLIBDIR="$SCRIPT_DIR/../lib"
+
+    # For Linux, set LD_LIBRARY_PATH to include bundled libraries
+    if [ "$(uname)" = "Linux" ]; then
+      export LD_LIBRARY_PATH="$SCRIPT_DIR/../lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+    fi
+
+    # For macOS, set DYLD_LIBRARY_PATH
+    if [ "$(uname)" = "Darwin" ]; then
+      export DYLD_LIBRARY_PATH="$SCRIPT_DIR/../lib''${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+    fi
+
+    exec "$SCRIPT_DIR/.BINNAME-wrapped" "$@"
+    WRAPPER_EOF
+            sed -i "s/BINNAME/$bin/g" $out/bin/$bin
+            chmod +x $out/bin/$bin
+          fi
+        done
+  '';
+
+  postFixup =
+    lib.optionalString stdenv.isLinux ''
+      # Determine the correct interpreter path based on architecture
+      if [ "$(uname -m)" = "x86_64" ]; then
+        INTERP="/lib64/ld-linux-x86-64.so.2"
+      elif [ "$(uname -m)" = "aarch64" ]; then
+        INTERP="/lib/ld-linux-aarch64.so.1"
+      else
+        echo "ERROR: Unsupported architecture $(uname -m)"
+        exit 1
+      fi
+
+      # On Linux, patch binaries to use system interpreter and relative library paths
+      # This makes the bundle portable across Linux systems for Supabase CLI
+      for bin in $out/bin/.*-wrapped; do
+        if [ -f "$bin" ] && file "$bin" | grep -q ELF; then
+          echo "Patching RPATH and interpreter for $bin"
+          # Set interpreter to system dynamic linker for portability
+          patchelf --set-interpreter "$INTERP" "$bin" 2>/dev/null || true
+          # Set RPATH to $ORIGIN/../lib so binaries find libraries relative to their location
+          patchelf --set-rpath '$ORIGIN/../lib' "$bin" 2>/dev/null || true
+          # Shrink RPATH to remove any unused paths
+          patchelf --shrink-rpath "$bin" 2>/dev/null || true
+        fi
+      done
+
+      # Patch shared libraries to use relative RPATH
+      for lib in $out/lib/*.so*; do
+        if [ -f "$lib" ] && file "$lib" | grep -q ELF; then
+          echo "Patching RPATH for $lib"
+          # Set RPATH to $ORIGIN so libraries find other libraries in same directory
+          patchelf --set-rpath '$ORIGIN' "$lib" 2>/dev/null || true
+          # Shrink RPATH to remove any unused paths
+          patchelf --shrink-rpath "$lib" 2>/dev/null || true
+        fi
+      done
+    ''
+    + lib.optionalString stdenv.isDarwin ''
+      # On macOS, patch binaries to use relative library paths
+      # This makes the bundle portable across macOS systems for Supabase CLI
+      for bin in $out/bin/.*-wrapped; do
+        if [ -f "$bin" ] && file "$bin" | grep -q "Mach-O"; then
+          # Get all dylib dependencies from Nix store
+          otool -L "$bin" | grep /nix/store | awk '{print $1}' | while read dep; do
+            libname=$(basename "$dep")
+            # Check if we have this library in our lib directory
+            if [ -f "$out/lib/$libname" ]; then
+              echo "Patching $bin: $dep -> @rpath/$libname"
+              install_name_tool -change "$dep" "@rpath/$libname" "$bin" 2>/dev/null || true
+            fi
+          done
+          # Add @rpath to look in @executable_path/../lib
+          install_name_tool -add_rpath "@executable_path/../lib" "$bin" 2>/dev/null || true
+        fi
+      done
+
+      # Patch dylibs to use @rpath for their dependencies
+      for lib in $out/lib/*.dylib*; do
+        if [ -f "$lib" ] && file "$lib" | grep -q "Mach-O"; then
+          # First, fix the library's own ID to use @rpath
+          libname=$(basename "$lib")
+          install_name_tool -id "@rpath/$libname" "$lib" 2>/dev/null || true
+
+          # Add @rpath to the library itself so it can find other libraries
+          install_name_tool -add_rpath "@loader_path" "$lib" 2>/dev/null || true
+
+          # Then fix references to other libraries
+          otool -L "$lib" | grep /nix/store | awk '{print $1}' | while read dep; do
+            deplibname=$(basename "$dep")
+            if [ -f "$out/lib/$deplibname" ]; then
+              echo "Patching $lib: $dep -> @rpath/$deplibname"
+              install_name_tool -change "$dep" "@rpath/$deplibname" "$lib" 2>/dev/null || true
+            fi
+          done
+        fi
+      done
+    '';
+
+  meta = with lib; {
+    description = "Portable PostgreSQL bundle for the Supabase CLI";
+    longDescription = ''
+      A portable, self-contained PostgreSQL distribution designed for use
+      within the Supabase CLI. Includes minimal extensions (supautils only)
+      and is patched to run without Nix dependencies on target systems.
+    '';
+    platforms = platforms.unix;
+    license = licenses.postgresql;
+  };
+}

--- a/nix/postgresql/default.nix
+++ b/nix/postgresql/default.nix
@@ -23,6 +23,7 @@ let
           inherit (config) version hash revision;
           jitSupport = jitSupport;
           self = pkgs;
+          portable = false; # Default to non-portable, can be overridden
         }
       )
     ) supportedVersions;

--- a/nix/tests/postgresql.conf.in
+++ b/nix/tests/postgresql.conf.in
@@ -718,7 +718,7 @@ default_text_search_config = 'pg_catalog.english'
 
 #local_preload_libraries = ''
 #session_preload_libraries = ''
-shared_preload_libraries = 'pg_stat_statements, pgaudit, plpgsql, plpgsql_check, pg_cron, pg_net, pgsodium, timescaledb, auto_explain, pg_tle, plan_filter, supabase_vault'	# (change requires restart)
+shared_preload_libraries = '@PRELOAD_LIBRARIES@'	# (change requires restart)
 jit_provider = 'llvmjit'		# JIT library to use
 
 

--- a/nix/tests/prime-cli.sql
+++ b/nix/tests/prime-cli.sql
@@ -1,0 +1,17 @@
+-- Prime SQL file for CLI variant
+-- Only creates extensions included in the CLI portable bundle
+set client_min_messages = warning;
+
+/*
+pg_cron not created here - it requires cron.database_name config
+and can only be created in that database. Tests will handle this separately.
+*/
+
+-- Core extensions for Supabase migrations
+create extension if not exists pg_net;
+create extension if not exists pg_graphql;
+create extension if not exists pgsodium;
+create extension if not exists supabase_vault;
+
+-- Note: supautils is preloaded via shared_preload_libraries
+-- and doesn't require CREATE EXTENSION


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds a new, portable `psql_17_cli_portable` target.

## What is the current behavior?

All current builds are not portable (i.e. they have hard dependencies on the `/nix/store`), and they all include the full list of extensions.

## What is the new behavior?

The `psql_17_cli_portable` target can run without a `/nix/store` present, and only includes the `supautils` extension.

## Additional context

```
This commit implements portable, self-contained PostgreSQL binaries for the
Supabase CLI across macOS (ARM), Linux (x64), and Linux (ARM64), along with
automated CI/CD workflows for building and releasing these artifacts.

The Supabase CLI needs to ship PostgreSQL binaries that work on user machines
without requiring Nix or other system dependencies. This means extracting the
actual binaries from Nix's wrapper scripts, bundling all necessary shared
libraries, and patching them to use relative paths instead of hardcoded Nix
store paths.

A `variant` parameter was added to the postgres build pipeline to distinguish
between "full" (all extensions) and "cli" (minimal extensions for Supabase CLI).
The `cliExtensions` list contains 6 extensions required for running Supabase
migrations: supautils, pg_graphql, pgsodium, supabase_vault, pg_net, and pg_cron.
Built-in extensions (uuid-ossp, pgcrypto, pg_stat_statements) are included
automatically with PostgreSQL. `makeOurPostgresPkgs`/`makePostgresBin` were
modified to accept this parameter. A new `psql_17_cli` package is created using
`variant = "cli"`, while the full extension set is preserved for base packages
(`psql_15`, `psql_17`, `psql_orioledb-17`).

The portable CLI variant (`psql_17_cli_portable`) includes 6 extensions for
migration support while maintaining a significantly smaller size than the full
build. The implementation in `nix/packages/postgres-portable.nix` extracts
binaries from `psql_17_cli` using a `resolve_binary()` function that follows
wrapper layers to find the actual ELF/Mach-O binaries behind Nix's environment
setup scripts.

All Nix-provided libraries (ICU, readline, zlib, etc.) are bundled while
excluding system libraries (`libc`, `libpthread`, `libm`, `glibc`, `libdl`) that
must come from the host. This distinction is critical: Linux bundles must
exclude glibc due to kernel ABI dependencies, while macOS can include more libs
due to its different linking model. Dependency resolution runs multiple passes
to catch transitive deps (e.g., ICU → charset → etc.).

Platform-specific patching is applied: Linux binaries use the system interpreter
(`/lib64/ld-linux-*.so.2`) and `$ORIGIN`-based RPATHs, while macOS binaries use
`@rpath` with `@executable_path`. Wrapper scripts set `LD_LIBRARY_PATH` (Linux)
or `DYLD_LIBRARY_PATH` (macOS) to find bundled libraries. The bundle includes
PostgreSQL config templates (`postgresql.conf`, `pg_hba.conf`, `pg_ident.conf`)
tailored for CLI usage with minimal local dev settings, plus the complete
Supabase migration script (`migrate.sh`) with all init-scripts and migration
SQL files (55 files, 236KB).

A Docker-style initialization script (`supabase-postgres-init.sh`) provides
one-command database setup via environment variables (`POSTGRES_USER`,
`POSTGRES_PASSWORD`, `POSTGRES_DB`, `PGDATA`).

To achieve true portability, a `portable` parameter was added to the PostgreSQL
build in `nix/postgresql/generic.nix`. When `portable = true`, three critical
hardcoded paths are excluded from the build:

1. `--with-system-tzdata` is removed from configure flags, allowing PostgreSQL
to use bundled timezone data from the `share/` directory instead of a hardcoded
`/nix/store/.../tzdata` path;

2. the `locale-binary-path.patch` is excluded, so PostgreSQL calls `locale -a`
from system PATH rather than using an absolute path to glibc's locale command;

3. the `postFixup` initdb wrapper is disabled to avoid hardcoding glibc paths.
The `portable` parameter defaults to `false` in `nix/postgresql/default.nix` but
is overridden to `true` for the CLI variant in `nix/packages/postgres.nix` using
`.override { portable = true; }`.

This ensures standard PostgreSQL builds remain unchanged while the CLI variant
produces truly portable binaries without any `/nix/store` references.

A GitHub Actions workflow builds portable binaries across all three platforms
using a matrix strategy. Each build runs automated portability checks that
verify no `/nix/store` references remain, validate RPATH configuration, confirm
transitive dependencies are bundled, ensure system libraries are NOT bundled,
and check wrapper scripts contain proper library path setup. Post-build testing
validates binaries work without Nix (`postgres --version`, `psql --version`). On
tagged releases (`v*-cli`), the workflow creates GitHub releases with tarball
artifacts and checksums.

The test infrastructure needed significant changes to support variants with
different extension sets. An `isCliVariant` parameter was added to
`makeCheckHarness`, and the hardcoded `shared_preload_libraries` list in
`postgresql.conf.in` was replaced with a `@PRELOAD_LIBRARIES@` placeholder. A
`generatePreloadLibs` script now parses `receipt.json` at test time and
dynamically builds the preload list based on available extensions, removing the
previous timescaledb removal hack for OrioleDB.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Portable, multi-architecture PostgreSQL CLI bundles and a CLI runtime variant; lightweight local Postgres config/auth templates, CLI init SQL, and a pgsodium key-generation helper.
* **Tests**
  * CLI-specific init/test flow, dynamic preload library handling, and an extensive portability test harness validating binaries, libraries, tzdata, and extension/migration behavior.
* **Infrastructure**
  * CI workflow to build per-architecture bundles, run portability checks, package tarballs with checksums, and publish GitHub Releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->