### PR TITLE
fix: fix and restore issues with release workflows

### DIFF
--- a/.github/workflows/ami-release-nix.yml
+++ b/.github/workflows/ami-release-nix.yml
@@ -89,13 +89,13 @@ jobs:
           GIT_SHA=${{github.sha}}
           nix run github:supabase/postgres/${GIT_SHA}#packer -- init amazon-arm64-nix.pkr.hcl
           # why is postgresql_major defined here instead of where the _three_ other postgresql_* variables are defined?
-          nix run github:supabase/postgres/${GIT_SHA}#packer -- build -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${EXECUTION_ID}"  -var-file="development-arm.vars.pkr.hcl" -var-file="common-nix.vars.pkr.hcl" -var "ansible_arguments=-e postgresql_major=${POSTGRES_MAJOR_VERSION}"  amazon-arm64-nix.pkr.hcl
+          nix run github:supabase/postgres/${GIT_SHA}#packer -- build -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${EXECUTION_ID}"  -var-file="development-arm.vars.pkr.hcl" -var-file="common-nix.vars.pkr.hcl" -var "ansible_arguments=-e postgresql_major=${POSTGRES_MAJOR_VERSION}" -var "region=us-east-1" -var 'ami_regions=["us-east-1"]' amazon-arm64-nix.pkr.hcl
 
       - name: Find stage 1 AMI
         run: |
           GIT_SHA=${{github.sha}}
           PG_VERSION=$(sed -n 's/postgres-version = "\(.*\)"/\1/p' common-nix.vars.pkr.hcl)
-          REGION=$(grep '^region=' development-arm.vars.pkr.hcl | cut -d'=' -f2 | tr -d ' "')
+          REGION="us-east-1"
 
           echo "Looking for stage 1 AMI with postgresVersion=${PG_VERSION}-stage1 and sourceSha=${GIT_SHA} in region ${REGION}"
 
@@ -124,7 +124,7 @@ jobs:
           GIT_SHA=${{github.sha}}
           nix run github:supabase/postgres/${GIT_SHA}#packer -- init stage2-nix-psql.pkr.hcl
           POSTGRES_MAJOR_VERSION=${{ env.POSTGRES_MAJOR_VERSION }}
-          nix run github:supabase/postgres/${GIT_SHA}#packer -- build -var "git_sha=${GIT_SHA}" -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${EXECUTION_ID}" -var "postgres_major_version=${POSTGRES_MAJOR_VERSION}" -var "source_ami=${STAGE1_AMI_ID}" -var-file="development-arm.vars.pkr.hcl" -var-file="common-nix.vars.pkr.hcl" stage2-nix-psql.pkr.hcl
+          nix run github:supabase/postgres/${GIT_SHA}#packer -- build -var "git_sha=${GIT_SHA}" -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${EXECUTION_ID}" -var "postgres_major_version=${POSTGRES_MAJOR_VERSION}" -var "source_ami=${STAGE1_AMI_ID}" -var-file="development-arm.vars.pkr.hcl" -var-file="common-nix.vars.pkr.hcl" -var "region=us-east-1" -var 'ami_regions=["us-east-1"]' stage2-nix-psql.pkr.hcl
 
       - name: Grab release version
         id: process_release_version

--- a/.github/workflows/ami-release-nix.yml
+++ b/.github/workflows/ami-release-nix.yml
@@ -124,7 +124,7 @@ jobs:
           GIT_SHA=${{github.sha}}
           nix run github:supabase/postgres/${GIT_SHA}#packer -- init stage2-nix-psql.pkr.hcl
           POSTGRES_MAJOR_VERSION=${{ env.POSTGRES_MAJOR_VERSION }}
-          nix run github:supabase/postgres/${GIT_SHA}#packer -- build -var "git_sha=${GIT_SHA}" -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${EXECUTION_ID}" -var "postgres_major_version=${POSTGRES_MAJOR_VERSION}" -var "source_ami=${STAGE1_AMI_ID}" -var-file="development-arm.vars.pkr.hcl" -var-file="common-nix.vars.pkr.hcl" -var "region=us-east-1" -var 'ami_regions=["us-east-1"]' stage2-nix-psql.pkr.hcl
+          nix run github:supabase/postgres/${GIT_SHA}#packer -- build -var "git_sha=${GIT_SHA}" -var "git-head-version=${GIT_SHA}" -var "packer-execution-id=${EXECUTION_ID}" -var "postgres_major_version=${POSTGRES_MAJOR_VERSION}" -var "source_ami=${STAGE1_AMI_ID}" -var-file="development-arm.vars.pkr.hcl" -var-file="common-nix.vars.pkr.hcl" -var "region=us-east-1" stage2-nix-psql.pkr.hcl
 
       - name: Grab release version
         id: process_release_version

--- a/.github/workflows/ami-release-nix.yml
+++ b/.github/workflows/ami-release-nix.yml
@@ -72,15 +72,7 @@ jobs:
       - name: Generate common-nix.vars.pkr.hcl
         run: |
           PG_VERSION="$(nix run nixpkgs#yq -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]' ansible/vars.yml)"
-          BRANCH_NAME="$(echo "${{ github.ref }}" | sed 's|refs/heads/||')"
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "$BRANCH_NAME" != "develop" && "$BRANCH_NAME" != release/* ]]; then
-             SUFFIX="${BRANCH_NAME//[^a-zA-Z0-9._-]/-}-${{ github.run_id }}"
-             PG_VERSION="${PG_VERSION}-${SUFFIX}"
-             echo "Added branch suffix to version: $SUFFIX"
-          fi
           echo "postgres-version = \"$PG_VERSION\"" > common-nix.vars.pkr.hcl
-          # Ensure there's a newline at the end of the file
-          echo "" >> common-nix.vars.pkr.hcl
 
       - name: Build AMI stage 1
         env:

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -14,6 +14,10 @@ permissions:
   contents: write
   packages: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   nix-eval:
     uses: ./.github/workflows/nix-eval.yml

--- a/.github/workflows/publish-nix-pgupgrade-bin-flake-version.yml
+++ b/.github/workflows/publish-nix-pgupgrade-bin-flake-version.yml
@@ -24,12 +24,7 @@ jobs:
       - name: Set PostgreSQL versions
         id: set-versions
         run: |
-          if [[ "${{ inputs.postgresVersion }}" != "" ]]; then
-            MAJOR_VERSION=$(echo "${{ inputs.postgresVersion }}" | cut -d'.' -f1)
-            VERSIONS="[\"$MAJOR_VERSION\"]"
-          else
-            VERSIONS=$(nix run nixpkgs#yq --  '.postgres_major[]' ansible/vars.yml | nix run nixpkgs#jq -- -R -s -c 'split("\n")[:-1]')
-          fi
+          VERSIONS=$(nix run nixpkgs#yq --  '.postgres_major[]' ansible/vars.yml | nix run nixpkgs#jq -- -R -s -c 'split("\n")[:-1]')
           echo "postgres_versions=$VERSIONS" >> $GITHUB_OUTPUT
 
   publish-staging:
@@ -48,11 +43,7 @@ jobs:
       - name: Grab release version
         id: process_release_version
         run: |
-          if [[ "${{ inputs.postgresVersion }}" != "" ]]; then
-            VERSION="${{ inputs.postgresVersion }}"
-          else
-            VERSION=$(nix run nixpkgs#yq -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]' ansible/vars.yml)
-          fi
+          VERSION=$(nix run nixpkgs#yq -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]' ansible/vars.yml)
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "major_version=$(echo $VERSION | cut -d'.' -f1)" >> "$GITHUB_OUTPUT"
 
@@ -100,11 +91,7 @@ jobs:
       - name: Grab release version
         id: process_release_version
         run: |
-          if [[ "${{ inputs.postgresVersion }}" != "" ]]; then
-            VERSION="${{ inputs.postgresVersion }}"
-          else
-            VERSION=$(nix run nixpkgs#yq -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]' ansible/vars.yml)
-          fi
+          VERSION=$(nix run nixpkgs#yq -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]' ansible/vars.yml)
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "major_version=$(echo $VERSION | cut -d'.' -f1)" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/publish-nix-pgupgrade-bin-flake-version.yml
+++ b/.github/workflows/publish-nix-pgupgrade-bin-flake-version.yml
@@ -51,7 +51,7 @@ jobs:
           if [[ "${{ inputs.postgresVersion }}" != "" ]]; then
             VERSION="${{ inputs.postgresVersion }}"
           else
-            VERSION=$(nix run nixpkgs#yq -- '.postgres_release["postgres'${{ matrix.postgres_version }}'"]' ansible/vars.yml)
+            VERSION=$(nix run nixpkgs#yq -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]' ansible/vars.yml)
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "major_version=$(echo $VERSION | cut -d'.' -f1)" >> "$GITHUB_OUTPUT"
@@ -87,7 +87,7 @@ jobs:
 
   publish-prod:
     runs-on: large-linux-x86
-    if: github.ref_name == 'develop' || contains( github.ref, 'release' )
+    if: github.ref_name == 'develop' || startsWith(github.ref_name, 'release/')
     needs: prepare
     strategy:
       matrix:

--- a/.github/workflows/publish-nix-pgupgrade-scripts.yml
+++ b/.github/workflows/publish-nix-pgupgrade-scripts.yml
@@ -88,7 +88,7 @@ jobs:
   publish-prod:
     needs: prepare
     runs-on: large-linux-x86
-    if: github.ref_name == 'develop' || contains( github.ref, 'release' )
+    if: github.ref_name == 'develop' || startsWith(github.ref_name, 'release/')
 
     strategy:
       matrix:

--- a/.github/workflows/publish-nix-pgupgrade-scripts.yml
+++ b/.github/workflows/publish-nix-pgupgrade-scripts.yml
@@ -29,12 +29,7 @@ jobs:
       - name: Set PostgreSQL versions
         id: set-versions
         run: |
-          if [[ "${{ inputs.postgresVersion }}" != "" ]]; then
-            MAJOR_VERSION=$(echo "${{ inputs.postgresVersion }}" | cut -d'.' -f1)
-            VERSIONS="[\"$MAJOR_VERSION\"]"
-          else
-            VERSIONS=$(nix run nixpkgs#yq --  '.postgres_major[]' ansible/vars.yml | nix run nixpkgs#jq -- -R -s -c 'split("\n")[:-1]')
-          fi
+          VERSIONS=$(nix run nixpkgs#yq --  '.postgres_major[]' ansible/vars.yml | nix run nixpkgs#jq -- -R -s -c 'split("\n")[:-1]')
           echo "postgres_versions=$VERSIONS" >> $GITHUB_OUTPUT
 
   publish-staging:
@@ -53,11 +48,7 @@ jobs:
       - name: Grab release version
         id: process_release_version
         run: |
-          if [[ "${{ inputs.postgresVersion }}" != "" ]]; then
-            VERSION="${{ inputs.postgresVersion }}"
-          else
-            VERSION=$(nix run nixpkgs#yq -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]' ansible/vars.yml)
-          fi
+          VERSION=$(nix run nixpkgs#yq -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]' ansible/vars.yml)
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Create a tarball containing pg_upgrade scripts
@@ -104,11 +95,7 @@ jobs:
       - name: Grab release version
         id: process_release_version
         run: |
-          if [[ "${{ inputs.postgresVersion }}" != "" ]]; then
-            VERSION="${{ inputs.postgresVersion }}"
-          else
-            VERSION=$(nix run nixpkgs#yq -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]' ansible/vars.yml)
-          fi
+          VERSION=$(nix run nixpkgs#yq -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]' ansible/vars.yml)
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Create a tarball containing pg_upgrade scripts

--- a/ansible/tasks/setup-supabase-internal.yml
+++ b/ansible/tasks/setup-supabase-internal.yml
@@ -33,9 +33,20 @@
   ansible.builtin.command:
     cmd: aws configure set default.s3.use_dualstack_endpoint true
 
+- name: download Vector package
+  ansible.builtin.get_url:
+    url: "{{ vector_x86_deb if platform == 'amd64' else vector_arm_deb }}"
+    dest: /tmp/vector.deb
+    timeout: 120
+  become: true
+  retries: 3
+  delay: 10
+  register: vector_download
+  until: vector_download is success
+
 - name: install Vector for logging
   apt:
-    deb: "{{ vector_x86_deb if platform == 'amd64' else vector_arm_deb }}"
+    deb: /tmp/vector.deb
   become: true
 
 - name: add Vector to postgres group

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.037-orioledb-region-1"
-  postgres17: "17.6.1.080-region-1"
-  postgres15: "15.14.1.080-region-1"
+  postgresorioledb-17: "17.6.0.037-orioledb-region-2"
+  postgres17: "17.6.1.080-region-2"
+  postgres15: "15.14.1.080-region-2"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.037-orioledb-region-3"
-  postgres17: "17.6.1.080-region-3"
-  postgres15: "15.14.1.080-region-3"
+  postgresorioledb-17: "17.6.0.038-orioledb"
+  postgres17: "17.6.1.081"
+  postgres15: "15.14.1.081"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,15 +10,15 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.037-orioledb-region-2"
-  postgres17: "17.6.1.080-region-2"
-  postgres15: "15.14.1.080-region-2"
+  postgresorioledb-17: "17.6.0.037-orioledb-region-3"
+  postgres17: "17.6.1.080-region-3"
+  postgres15: "15.14.1.080-region-3"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1
 pgbouncer_release_checksum: sha256:6e566ae92fe3ef7f6a1b9e26d6049f7d7ca39c40e29e7b38f6d5500ae15d8465
 
-# The checksum can be found under "Assets", in the GitHub release page for each version.
+# The checksum can be found under "Assets", in the GitHub release page for each version.  
 # The binaries used are: ubuntu-aarch64 and linux-static.
 # https://github.com/PostgREST/postgrest/releases
 postgrest_release: 14.1

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.037-orioledb"
-  postgres17: "17.6.1.080"
-  postgres15: "15.14.1.080"
+  postgresorioledb-17: "17.6.0.037-orioledb-region-1"
+  postgres17: "17.6.1.080-region-1"
+  postgres15: "15.14.1.080-region-1"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1


### PR DESCRIPTION
  Historical behavior (from git):                                                                                                                                                                                 
  - From 2022 until Nov 2025: Published to us-east-1 (via vars file)
  - Nov 13, 2025 (ab990748): Explicit -var "region=us-east-1" override added after vars file changed                                                                                                              
  - Dec 2025 - Jan 22, 2026: Composite action with explicit us-east-1
  - Jan 27, 2026 (f77bfb93): Override lost when composite action removed

  Actual AWS state:
  - 17.6.1.079 is only in ap-southeast-1 (wrong region)

  Fix applied:
  - Stage 1 build: explicit -var "region=us-east-1" -var 'ami_regions=["us-east-1"]'
  - Find stage 1 AMI: REGION="us-east-1"
  - Stage 2 build: explicit -var "region=us-east-1" -var 'ami_regions=["us-east-1"]'

  This restores the intended behavior for both workflow_dispatch and merge-triggered releases.
  
  ansible/tasks/setup-supabase-internal.yml                                                                                                                                                     
  - Added separate download step for Vector package using get_url with 120s timeout, 3 retries, and 10s delay between attempts to fix intermittent download failures from packages.timber.io
                                                                                                                                                                                                
  publish-nix-pgupgrade-scripts.yml
  - Changed publish-prod condition from contains(github.ref, 'release') to startsWith(github.ref_name, 'release/') to prevent branches containing "release" in the name (like
  ami-release-regions) from triggering prod publishing

  publish-nix-pgupgrade-bin-flake-version.yml
  - Same publish-prod condition fix as above
  - Added missing -r flag to yq command in publish-staging job (line 54) to output raw strings without quotes, fixing shell parse error with quoted version numbers

  ami-release-nix.yml
  - Removed ami_regions variable from stage2 packer build command since stage2-nix-psql.pkr.hcl only defines region, not ami_regions
  - Removed branch-based versioning feature for workflow_dispatch builds (the logic that appended branch name and run_id suffix to versions for non-develop/non-release branches)

  nix-build.yml
  - Re-added concurrency block that was lost in PR #1745, enabling cancellation of previous workflow runs when new commits are pushed to a PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Builds and AMI releases now consistently target us-east-1 across stages.
  * Updated PostgreSQL package versions in deployment metadata.
  * CI publishing workflows always read versions from release metadata, tightened release-branch matching, and added workflow concurrency controls.
* **New Features**
  * Added a platform-aware download-and-install step for the Vector logging package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->