### PR TITLE
fix: turning off review by popular demand

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,7 +2,7 @@
 # configuration reference: https://docs.coderabbit.ai/reference/configuration
 reviews:
   auto_review:
-    enabled: true
+    enabled: false
     drafts: false
     base_branches:
       - develop


### PR DESCRIPTION
A number of pg team requests for turning off review from coderabbit, which tends to be consistently wrong . It also creates noise when humans are trying to interact in PR. 

Leaving the high level summary on. 