### PR TITLE
fix: add limit to nix copy to avoid hitting s3 upload limits

### DIFF
--- a/.github/actions/nix-install-ephemeral/action.yml
+++ b/.github/actions/nix-install-ephemeral/action.yml
@@ -35,7 +35,7 @@ runs:
         set -f
 
         export IFS=' '
-        /nix/var/nix/profiles/default/bin/nix copy --to 's3://nix-postgres-artifacts?secret-key=/etc/nix/nix-secret-key' $OUT_PATHS
+        /nix/var/nix/profiles/default/bin/nix copy --max-jobs 5 --to 's3://nix-postgres-artifacts?secret-key=/etc/nix/nix-secret-key' $OUT_PATHS
         EOF
         sudo chmod +x /etc/nix/upload-to-cache.sh
       env:


### PR DESCRIPTION
in PR ci runs like https://github.com/supabase/postgres/actions/runs/21781372775/job/62845918939?pr=2028 we hit s3 upload limits since no max-jobs was set, nix copy has no limit.

We have multiple CI jobs potentially uploading concurrently to the same /nar/ prefix, a conservative per-job limit would be:

  - 5 concurrent uploads (nix copy --max-jobs 5)
  - Or roughly 50 requests/second per job

This should help with the fact that we have potential to launch 5-10 CI runs at once. 