### PR TITLE
feat(ansible): Install tuned for performance tuning

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -26,6 +26,9 @@
     - set_fact:
         parallel_jobs: 16
 
+    - name: Install tuned
+      import_tasks: tasks/setup-tuned.yml
+
     - name: Install Postgres from source
       import_tasks: tasks/setup-postgres.yml
 

--- a/ansible/tasks/setup-tuned.yml
+++ b/ansible/tasks/setup-tuned.yml
@@ -1,0 +1,10 @@
+- name: Install tuned
+  ansible.builtin.apt:
+    force_apt_get: true
+    name: tuned
+    policy_rc_d: 101
+    state: 'present'
+    update_cache: true
+  become: true
+  when:
+    - stage2_nix


### PR DESCRIPTION
  This commit introduces the tuned service to the Ansible playbook to enable dynamic system performance optimization.

  The changes include:
   - A new task ansible/tasks/setup-tuned.yml is created to handle the installation of the tuned package via apt.
   - The main ansible/playbook.yml is updated to import and execute this new task.
   - The installation is conditional and only runs when the stage2_nix variable is true, allowing for flexibility in different build stages.

  By installing tuned, the system can be better optimized for various workloads, which is particularly beneficial for database performance.

**note** that tuned is _not_ enabled _nor_ configured in this PR. that'll come later.