### PR TITLE
fix: create AWS config file to suppress post-build-hook errors

### DIFF
--- a/.github/actions/nix-install-ephemeral/action.yml
+++ b/.github/actions/nix-install-ephemeral/action.yml
@@ -27,6 +27,7 @@ runs:
         sudo -H aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
         sudo -H aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
         sudo -H aws configure set aws_session_token $AWS_SESSION_TOKEN
+        sudo -H aws configure set region ${{ inputs.aws-region }}
         sudo mkdir -p /etc/nix
         sudo -E python -c "import os; file = open('/etc/nix/nix-secret-key', 'w'); file.write(os.environ['NIX_SIGN_SECRET_KEY']); file.close()"
         cat << 'EOF' | sudo tee /etc/nix/upload-to-cache.sh > /dev/null

--- a/.github/actions/nix-install-ephemeral/action.yml
+++ b/.github/actions/nix-install-ephemeral/action.yml
@@ -43,7 +43,7 @@ runs:
         NIX_SIGN_SECRET_KEY: ${{ env.NIX_SIGN_SECRET_KEY }}
     - uses: NixOS/nix-installer-action@d6ef7ecd8f685af89869e5aca0580a33e3e3150c
       with:
-        installer-version: 2.33.1
+        installer-version: 2.33.2
         extra-conf: |
           substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com
           trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=

--- a/Dockerfile-15
+++ b/Dockerfile-15
@@ -106,7 +106,7 @@ extra-experimental-features = nix-command flakes
 extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
 extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=
 EOF
-RUN curl -L https://releases.nixos.org/nix/nix-2.33.1/install | sh -s -- --daemon --no-channel-add --yes --nix-extra-conf-file /tmp/extra-nix.conf
+RUN curl -L https://releases.nixos.org/nix/nix-2.33.2/install | sh -s -- --daemon --no-channel-add --yes --nix-extra-conf-file /tmp/extra-nix.conf
 ENV PATH="${PATH}:/nix/var/nix/profiles/default/bin"
 
 COPY . /nixpg

--- a/Dockerfile-17
+++ b/Dockerfile-17
@@ -108,7 +108,7 @@ extra-experimental-features = nix-command flakes
 extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
 extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=
 EOF
-RUN curl -L https://releases.nixos.org/nix/nix-2.33.1/install | sh -s -- --daemon --no-channel-add --yes --nix-extra-conf-file /tmp/extra-nix.conf
+RUN curl -L https://releases.nixos.org/nix/nix-2.33.2/install | sh -s -- --daemon --no-channel-add --yes --nix-extra-conf-file /tmp/extra-nix.conf
 
 ENV PATH="${PATH}:/nix/var/nix/profiles/default/bin"
 

--- a/Dockerfile-orioledb-17
+++ b/Dockerfile-orioledb-17
@@ -108,7 +108,7 @@ extra-experimental-features = nix-command flakes
 extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
 extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=
 EOF
-RUN curl -L https://releases.nixos.org/nix/nix-2.33.1/install | sh -s -- --daemon --no-channel-add --yes --nix-extra-conf-file /tmp/extra-nix.conf
+RUN curl -L https://releases.nixos.org/nix/nix-2.33.2/install | sh -s -- --daemon --no-channel-add --yes --nix-extra-conf-file /tmp/extra-nix.conf
 
 ENV PATH="${PATH}:/nix/var/nix/profiles/default/bin"
 

--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
@@ -297,7 +297,7 @@ function initiate_upgrade {
                         --extra-conf "trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
                     else
                         echo "1.1.1. Installing Nix using the official installer"
-                        sh <(curl -L https://releases.nixos.org/nix/nix-2.33.1/install) --yes --daemon --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
+                        sh <(curl -L https://releases.nixos.org/nix/nix-2.33.2/install) --yes --daemon --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
 extra-experimental-features = nix-command flakes
 extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
 extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=

--- a/ebssurrogate/scripts/qemu-bootstrap-nix.sh
+++ b/ebssurrogate/scripts/qemu-bootstrap-nix.sh
@@ -82,7 +82,7 @@ execute_playbook
 ####################
 
 function install_nix() {
-    sudo su -c "sh <(curl -L https://releases.nixos.org/nix/nix-2.33.1/install) --yes --daemon --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
+    sudo su -c "sh <(curl -L https://releases.nixos.org/nix/nix-2.33.2/install) --yes --daemon --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
 extra-experimental-features = nix-command flakes
 extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
 extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=

--- a/nix/docs/start-here.md
+++ b/nix/docs/start-here.md
@@ -88,7 +88,7 @@ extra-substituters =
 Run the following command to install Nix 2.33.1 (the version used in CI) with the custom configuration:
 
 ```bash
-curl -L https://releases.nixos.org/nix/nix-2.33.1/install | sh -s -- --daemon --yes --nix-extra-conf-file ./nix.conf
+curl -L https://releases.nixos.org/nix/nix-2.33.2/install | sh -s -- --daemon --yes --nix-extra-conf-file ./nix.conf
 ```
 
 This will install Nix with our build caches pre-configured, which should eliminate substituter-related errors.

--- a/scripts/nix-provision.sh
+++ b/scripts/nix-provision.sh
@@ -28,7 +28,7 @@ function install_packages {
 
 
 function install_nix() {
-    sudo su -c "sh <(curl -L https://releases.nixos.org/nix/nix-2.33.1/install) --yes --daemon --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
+    sudo su -c "sh <(curl -L https://releases.nixos.org/nix/nix-2.33.2/install) --yes --daemon --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
 extra-experimental-features = nix-command flakes
 extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
 extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=


### PR DESCRIPTION
The post-build-hook runs `nix copy --to s3://...` which now uses libcurl AWS authentication since the last 2.33 release (see https://releases.nixos.org/nix/nix-2.33.0/manual/release-notes/rl-2.33.html#s3-improvements). It attempts to read /root/.aws/config for profile configuration, but only /root/.aws/credentials was created by `aws configure set` (credential keys write to the credentials file, not the config file). This produced errors in CI logs:

```
[ERROR] static: Failed to open file. path:'/root/.aws/config'
[ERROR] Failed to build config profile collection from file at (/root/.aws/config) : Invalid file path
```

Setting the region via `aws configure set region` creates the config file, resolving the missing file errors.

We also upgrade nix to 2.33.2 to benefit the AWS log improvement made in https://github.com/NixOS/nix/pull/15059