### PR TITLE
refactor: Adjust pgBackRest retention policy for repo1

### DIFF
--- a/ansible/files/pgbackrest_config/repo1.conf
+++ b/ansible/files/pgbackrest_config/repo1.conf
@@ -2,9 +2,7 @@
 repo1-block = y
 repo1-bundle = y
 # repo1-path = <foo>
-repo1-retention-diff = 1
-repo1-retention-full = 28
-repo1-retention-full-type = time
+repo1-retention-full = 7
 repo1-retention-history = 0
 # repo1-s3-bucket=  <foo>
 # repo1-s3-endpoint = <foo>


### PR DESCRIPTION
Update `repo1.conf` to modify the backup retention settings based on https://linear.app/supabase/issue/INDATA-415/admin-agent-add-backup-sub-command-for-pgbackrest#comment-6a00a3c1.

- Set `repo1-retention-full` to 7.
- Removed `repo1-retention-diff` setting.
- Removed `repo1-retention-full-type` setting.

This change simplifies the retention policy for repository `repo1` by specifying a full backup retention of 7 days and removing the differential and retention type configurations.

Note that we will be taking daily full backups.
