### PR TITLE
feat: limit nix-eval-jobs max memory to 3 GiB per worker

### DIFF
--- a/nix/packages/github-matrix/github_matrix.py
+++ b/nix/packages/github-matrix/github_matrix.py
@@ -172,7 +172,7 @@ def run_nix_eval_jobs(
     Returns:
         Tuple of (packages, warnings_list, errors_list)
     """
-    debug(f"Running command: {' '.join(cmd)}")
+    print(f"Running: {' '.join(cmd)}", file=sys.stderr)
 
     # Disable colors in nix output
     env = os.environ.copy()

--- a/nix/packages/github-matrix/github_matrix.py
+++ b/nix/packages/github-matrix/github_matrix.py
@@ -89,7 +89,9 @@ BUILD_RUNNER_MAP: Dict[RunnerType, Dict[System, RunsOnConfig]] = {
 }
 
 
-def build_nix_eval_command(max_workers: int, flake_outputs: List[str]) -> List[str]:
+def build_nix_eval_command(
+    max_workers: int, max_memory_size: int, flake_outputs: List[str]
+) -> List[str]:
     """Build the nix-eval-jobs command with appropriate flags."""
     nix_eval_cmd = [
         "nix-eval-jobs",
@@ -104,6 +106,8 @@ def build_nix_eval_command(max_workers: int, flake_outputs: List[str]) -> List[s
         "--option",
         "accept-flake-config",
         "true",
+        "--max-memory-size",
+        str(max_memory_size),
         "--workers",
         str(max_workers),
         "--select",
@@ -281,6 +285,12 @@ def main() -> None:
         description="Generate GitHub Actions matrix for Nix builds"
     )
     parser.add_argument(
+        "--max-memory-size",
+        default=3072,
+        type=int,
+        help="Maximum memory per eval worker in MiB. Defaults to 3072 (3 GiB).",
+    )
+    parser.add_argument(
         "flake_outputs", nargs="+", help="Nix flake outputs to evaluate"
     )
 
@@ -288,7 +298,7 @@ def main() -> None:
 
     max_workers: int = os.cpu_count() or 1
 
-    cmd = build_nix_eval_command(max_workers, args.flake_outputs)
+    cmd = build_nix_eval_command(max_workers, args.max_memory_size, args.flake_outputs)
 
     # Run evaluation and collect packages, warnings, and errors
     packages, warnings_list, errors_list = run_nix_eval_jobs(cmd)


### PR DESCRIPTION
CI sometimes encounter nix eval jobs taking to much memory and being killed by OOM. We now limit the memory to 3 GiB per worker. 