### PR TITLE
feat(auth-deployments): bump auth version to v2.187.0

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -25,8 +25,8 @@ postgrest_release: 14.5
 postgrest_arm_release_checksum: sha256:70c07ff875710538903c9b6b6de00e126250e335da25b0ff7d1b13bb4c94bf41
 postgrest_x86_release_checksum: sha256:ab5cc7e974d4940447991804588cfb8b3f7b2c57b691f0905df04d51ede69470
 
-gotrue_release: 2.186.0
-gotrue_release_checksum: sha1:94cd063227e01dcc71811aa63ecdd996d0c0419c
+gotrue_release: 2.187.0
+gotrue_release_checksum: sha256:8d6a5325488caf05d5d07032f47537429942b46c3dab6eae1b4e21c88556e50f
 
 aws_cli_release: 2.23.11
 

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.045-orioledb"
-  postgres17: "17.6.1.088"
-  postgres15: "15.14.1.088"
+  postgresorioledb-17: "17.6.0.046-orioledb"
+  postgres17: "17.6.1.089"
+  postgres15: "15.14.1.089"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1
@@ -26,7 +26,7 @@ postgrest_arm_release_checksum: sha256:70c07ff875710538903c9b6b6de00e126250e335d
 postgrest_x86_release_checksum: sha256:ab5cc7e974d4940447991804588cfb8b3f7b2c57b691f0905df04d51ede69470
 
 gotrue_release: 2.187.0
-gotrue_release_checksum: sha256:8d6a5325488caf05d5d07032f47537429942b46c3dab6eae1b4e21c88556e50f
+gotrue_release_checksum: sha1:1827fa48fc1ce4cba78b869b4c0edc9c0677edf4
 
 aws_cli_release: 2.23.11
 


### PR DESCRIPTION
Bumps auth version to v2.187.0.

Auth v2.187.0 release information:
- date: 2026-02-24T16:00:43Z
- tag: v2.187.0
- url: https://github.com/supabase/auth/releases/tag/v2.187.0

A couple of additional notes about this PR:
* I've changed the checksum from sha1 to sha256
* I've omitted the postgres/oriole version bumps. This is often a source of conflicts / lost time when executing tests. If it's necessary though just let me know and I'll add it back in.
