### PR TITLE
chore: bump to release for internal rel

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.049-orioledb"
-  postgres17: "17.6.1.092"
-  postgres15: "15.14.1.092"
+  postgresorioledb-17: "17.6.0.050-orioledb"
+  postgres17: "17.6.1.093"
+  postgres15: "15.14.1.093"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.048-orioledb"
-  postgres17: "17.6.1.091"
-  postgres15: "15.14.1.091"
+  postgresorioledb-17: "17.6.0.049-orioledb"
+  postgres17: "17.6.1.092"
+  postgres15: "15.14.1.092"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1


### PR DESCRIPTION
We want to land the changes from https://github.com/supabase/postgres/pull/2040 into staging. The last attempt cut releas failed due to version collision. This will resolve version collision, and cut new release for internal target