### PR TITLE
perf(tuned): activate and configure zswap for postgresql tuned profile

### DIFF
--- a/ansible/tasks/setup-tuned.yml
+++ b/ansible/tasks/setup-tuned.yml
@@ -106,8 +106,7 @@
         params: 'zpool=zsmalloc compressor=zstd enabled=1'
         persistent: 'present'
         state: 'present'
-      when:
-        - ansible_facts['distribution'] == 'Ubuntu'  # AWS runners don't have this module
+      failed_when: false  # AWS runners don't have this module
 
     - name: Activate the tuned service
       ansible.builtin.systemd_service:

--- a/ansible/tasks/setup-tuned.yml
+++ b/ansible/tasks/setup-tuned.yml
@@ -124,20 +124,13 @@
             state: 'present'
 
         - name: tuned - Configure and enable zswap
-          ansible.builtin.lineinfile:
-            group: 'root'
-            line: "{{ zswap_item['value'] }}"
-            mode: '0644'
-            owner: 'root'
-            path: "/sys/module/zswap/parameters/{{ zswap_item['param'] }}"
-            search_string: "{{ zswap_item['orig_value'] }}"
-            state: 'present'
-          become: true
+          ansible.builtin.shell:
+            cmd: "echo {{ zswap_item['value'] }}  > /sys/module/zswap/parameters/{{ zswap_item['param'] }}"
           loop:
-            - { param: 'compressor',       value: 'zstd',     orig_value: 'lzo' }
-            - { param: 'max_pool_percent', value: '10',       orig_value: 20 }
-            - { param: 'zpool',            value: 'zsmalloc', orig_value: 'zbud' }
-            - { param: 'enabled',          value: 'Y',        orig_value: 'N' }
+            - { param: 'compressor',       value: 'zstd' }
+            - { param: 'max_pool_percent', value: '10' }
+            - { param: 'zpool',            value: 'zsmalloc' }
+            - { param: 'enabled',          value: 'Y' }
           loop_control:
             loop_var: 'zswap_item'
 

--- a/ansible/tasks/setup-tuned.yml
+++ b/ansible/tasks/setup-tuned.yml
@@ -111,7 +111,8 @@
         section: 'bootloader'
         state: 'present'
         value: 'zswap.enabled=1 zswap.zpool=zsmalloc zswap.compressor=zstd'
-    - name: Activate the tuned service
+
+- name: Activate the tuned service
       ansible.builtin.systemd_service:
         daemon_reload: true
         enabled: true

--- a/ansible/tasks/setup-tuned.yml
+++ b/ansible/tasks/setup-tuned.yml
@@ -99,14 +99,55 @@
       when:
         - ansible_facts['processor'][0] is search("GenuineIntel", ignorecase=True)
 
-    - name: tuned - Load the zswap module
-      become: true
-      community.general.modprobe:
-        name: 'zswap'
-        params: 'zpool=zsmalloc compressor=zstd enabled=1'
-        persistent: 'present'
-        state: 'present'
-      failed_when: false  # AWS runners don't have this module
+    - name: tuned - Enable zswap if swap is present
+      when:
+        - ansible_facts['swaptotal_mb'] > 0
+      block:
+        - name: tuned - Decrease the kernel swappiness
+          become: true
+          community.general.ini_file:
+            create: true
+            group: 'root'
+            mode: '0644'
+            no_extra_spaces: true
+            option: 'vm.swappiness'
+            path: '/etc/tuned/profiles/postgresql/tuned.conf'
+            section: 'sysctl'
+            state: 'present'
+            value: 10
+
+        - name: tuned - Load zstd compressor module
+          become: true
+          community.general.modprobe:
+            name: 'zstd'
+            persistent: 'present'
+            state: 'present'
+
+        - name: tuned - Configure and enable zswap
+          ansible.builtin.copy:
+            content: "{{ zswap_item['value']' }}\n"
+            dest: "/sys/module/zswap/parameters/{{ zswap_item['param']' }}"
+          become: true
+          loop:
+            - { param: 'compressor',       value: 'zstd' }
+            - { param: 'max_pool_percent', value: '10' }
+            - { param: 'zpool',            value: 'zsmalloc' }
+            - { param: 'enabled',          value: 'Y' }
+          loop_control:
+            loop_var: 'zswap_item'
+
+        - name: tuned - Enable zswap at boot
+          become: true
+          community.general.ini_file:
+            create: true
+            group: 'root'
+            mode: '0644'
+            no_extra_spaces: true
+            option: 'cmdline_zswap'
+            path: '/etc/tuned/profiles/postgresql/tuned.conf'
+            section: 'bootloader'
+            state: 'present'
+            value: 'zswap.enabled=1 zswap.zpool=zsmalloc zswap.compressor=zstd zswap.max_pool_percent=10'
 
     - name: Activate the tuned service
       ansible.builtin.systemd_service:

--- a/ansible/tasks/setup-tuned.yml
+++ b/ansible/tasks/setup-tuned.yml
@@ -111,7 +111,6 @@
         section: 'bootloader'
         state: 'present'
         value: 'zswap.enabled=1 zswap.zpool=zsmalloc zswap.compressor=zstd'
-    
     - name: Activate the tuned service
       ansible.builtin.systemd_service:
         daemon_reload: true

--- a/ansible/tasks/setup-tuned.yml
+++ b/ansible/tasks/setup-tuned.yml
@@ -106,11 +106,11 @@
         group: 'root'
         mode: '0644'
         no_extra_spaces: true
-        option: 'zswap'
+        option: 'cmdline_zswap'
         path: '/etc/tuned/profiles/postgresql/tuned.conf'
-        section: 'modules'
+        section: 'bootloader'
         state: 'present'
-        value: '+r,enabled=1,zpool=zsmalloc,compressor=zstd'
+        value: 'zswap.enabled=1 zswap.zpool=zsmalloc zswap.compressor=zstd'
     
     - name: Activate the tuned service
       ansible.builtin.systemd_service:

--- a/ansible/tasks/setup-tuned.yml
+++ b/ansible/tasks/setup-tuned.yml
@@ -124,15 +124,20 @@
             state: 'present'
 
         - name: tuned - Configure and enable zswap
-          ansible.builtin.copy:
-            content: "{{ zswap_item['value'] }}\n"
-            dest: "/sys/module/zswap/parameters/{{ zswap_item['param'] }}"
+          ansible.builtin.lineinfile:
+            group: 'root'
+            line: "{{ zswap_item['value'] }}"
+            mode: '0644'
+            owner: 'root'
+            path: "/sys/module/zswap/parameters/{{ zswap_item['param'] }}"
+            search_string: "{{ zswap_item['orig_value'] }}"
+            state: 'present'
           become: true
           loop:
-            - { param: 'compressor',       value: 'zstd' }
-            - { param: 'max_pool_percent', value: '10' }
-            - { param: 'zpool',            value: 'zsmalloc' }
-            - { param: 'enabled',          value: 'Y' }
+            - { param: 'compressor',       value: 'zstd',     orig_value: 'lzo' }
+            - { param: 'max_pool_percent', value: '10',       orig_value: 20 }
+            - { param: 'zpool',            value: 'zsmalloc', orig_value: 'zbud' }
+            - { param: 'enabled',          value: 'Y',        orig_value: 'N' }
           loop_control:
             loop_var: 'zswap_item'
 

--- a/ansible/tasks/setup-tuned.yml
+++ b/ansible/tasks/setup-tuned.yml
@@ -99,18 +99,13 @@
       when:
         - ansible_facts['processor'][0] is search("GenuineIntel", ignorecase=True)
 
-    - name: tuned - Activate and configure zswap
+    - name: tuned - Load the zswap module
       become: true
-      community.general.ini_file:
-        create: true
-        group: 'root'
-        mode: '0644'
-        no_extra_spaces: true
-        option: 'cmdline_zswap'
-        path: '/etc/tuned/profiles/postgresql/tuned.conf'
-        section: 'bootloader'
+      community.general.modprobe:
+        name: 'zswap'
+        params: 'zpool=zsmalloc compressor=zstd enabled=1'
+        persistent: 'present'
         state: 'present'
-        value: 'zswap.enabled=1 zswap.zpool=zsmalloc zswap.compressor=zstd'
 
     - name: Activate the tuned service
       ansible.builtin.systemd_service:

--- a/ansible/tasks/setup-tuned.yml
+++ b/ansible/tasks/setup-tuned.yml
@@ -112,7 +112,7 @@
         state: 'present'
         value: 'zswap.enabled=1 zswap.zpool=zsmalloc zswap.compressor=zstd'
 
-- name: Activate the tuned service
+    - name: Activate the tuned service
       ansible.builtin.systemd_service:
         daemon_reload: true
         enabled: true

--- a/ansible/tasks/setup-tuned.yml
+++ b/ansible/tasks/setup-tuned.yml
@@ -106,6 +106,8 @@
         params: 'zpool=zsmalloc compressor=zstd enabled=1'
         persistent: 'present'
         state: 'present'
+      when:
+        - ansible_facts['distribution'] == 'Ubuntu'  # AWS runners don't have this module
 
     - name: Activate the tuned service
       ansible.builtin.systemd_service:

--- a/ansible/tasks/setup-tuned.yml
+++ b/ansible/tasks/setup-tuned.yml
@@ -125,8 +125,8 @@
 
         - name: tuned - Configure and enable zswap
           ansible.builtin.copy:
-            content: "{{ zswap_item['value']' }}\n"
-            dest: "/sys/module/zswap/parameters/{{ zswap_item['param']' }}"
+            content: "{{ zswap_item['value'] }}\n"
+            dest: "/sys/module/zswap/parameters/{{ zswap_item['param'] }}"
           become: true
           loop:
             - { param: 'compressor',       value: 'zstd' }

--- a/ansible/tasks/setup-tuned.yml
+++ b/ansible/tasks/setup-tuned.yml
@@ -99,6 +99,19 @@
       when:
         - ansible_facts['processor'][0] is search("GenuineIntel", ignorecase=True)
 
+    - name: tuned - Activate and configure zswap
+      become: true
+      community.general.ini_file:
+        create: true
+        group: 'root'
+        mode: '0644'
+        no_extra_spaces: true
+        option: 'zswap'
+        path: '/etc/tuned/profiles/postgresql/tuned.conf'
+        section: 'modules'
+        state: 'present'
+        value: '+r,enabled=1,zpool=zsmalloc,compressor=zstd'
+    
     - name: Activate the tuned service
       ansible.builtin.systemd_service:
         daemon_reload: true

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.052-orioledb"
-  postgres17: "17.6.1.095"
-  postgres15: "15.14.1.095"
+  postgresorioledb-17: "17.6.0.052-orioledb-zswap-1"
+  postgres17: "17.6.1.095-zswap-1"
+  postgres15: "15.14.1.095-zswap-1"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.048-orioledb"
-  postgres17: "17.6.1.091"
-  postgres15: "15.14.1.091"
+  postgresorioledb-17: "17.6.0.049-orioledb"
+  postgres17: "17.6.1.092"
+  postgres15: "15.14.1.092"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.051-orioledb"
-  postgres17: "17.6.1.094"
-  postgres15: "15.14.1.094"
+  postgresorioledb-17: "17.6.0.052-orioledb"
+  postgres17: "17.6.1.095"
+  postgres15: "15.14.1.095"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.052-orioledb-zswap-1"
-  postgres17: "17.6.1.095-zswap-1"
-  postgres15: "15.14.1.095-zswap-1"
+  postgresorioledb-17: "17.6.0.052-orioledb"
+  postgres17: "17.6.1.095"
+  postgres15: "15.14.1.095"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1

--- a/audit-specs/baselines/ami-build/kernel-param.yml
+++ b/audit-specs/baselines/ami-build/kernel-param.yml
@@ -1,0 +1,11 @@
+# kernel-param baseline for AMI build
+# Checks that critical kernel parameters haven't changed
+kernel-param:
+  vm.page-cluster:
+    value: '3'        # kernel default; assert to catch if kernel upgrade changes it
+  kernel.panic:
+    value: '10'       # set by setup-system.yml
+  vm.panic_on_oom:
+    value: '1'        # set by setup-system.yml
+  vm.swappiness:
+    value: '10'       # intentionally lowered from kernel default (60) for DB + zswap


### PR DESCRIPTION
This change enables zswap with the zsmalloc allocator and zstd compression within the postgresql tuned profile to improve system responsiveness and database performance under memory pressure.

### Technical Overview: What is zswap?
zswap is a Linux kernel feature that provides a compressed write-back cache for swapped pages. Instead of immediately moving pages from RAM to the physical swap device (HDD/SSD) when memory is full, zswap intercepts them, compresses them, and stores them in a dynamically allocated RAM pool. This effectively increases the "perceived" amount of RAM available to the system.

### Why zsmalloc over zbud?
We have selected 'zsmalloc' as the zpool allocator instead of 'zbud' for several reasons:
- Density: zsmalloc is a slab-based allocator that can pack many compressed objects into a single physical page, whereas zbud is hard-coded to a maximum of 2 objects per page (2:1 ratio).
- Efficiency: On modern kernels (Linux 6.3+), zsmalloc supports proper eviction to disk, removing the primary historical advantage of zbud. It provides significantly better memory utilization and higher compression density.

### Why zstd over lz4?
While lz4 offers faster compression/decompression speeds, we have opted for 'zstd' for the following reasons:
- Compression Ratio: zstd provides a substantially higher compression ratio than lz4. In database workloads where memory density is critical, fitting more pages into the zswap pool is more beneficial than the marginal speed gains of lz4.
- Balance: zstd offers a superior balance between CPU overhead and compression efficiency, especially for the 4KB-8KB pages typically handled by the kernel and PostgreSQL.

### Benefits for PostgreSQL Performance
Implementing zswap is particularly beneficial for PostgreSQL workloads:
- Mitigation of Swap Thrashing: PostgreSQL performance degrades exponentially when active buffers are swapped to disk. zswap ensures that these pages stay in RAM (compressed), allowing "major page faults" to be resolved at RAM speeds rather than waiting for disk I/O.
- I/O Latency Stability: By reducing the frequency of physical writes to the swap partition, zswap prevents I/O contention between the kernel's swap subsystem and PostgreSQL's own WAL and data writes.
- Consistent Query Latency: Queries that access less-frequently used data that has been compressed into zswap will return much faster than if they had to be fetched from physical swap, leading to more predictable p99 latencies.

