### PR TITLE
feat: mo update critical flake inputs auto pr

### DIFF
--- a/.github/workflows/update-flake-lock-non-critical.yml
+++ b/.github/workflows/update-flake-lock-non-critical.yml
@@ -1,0 +1,53 @@
+name: Update Flake Lock (Non-Critical)
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 */2 *'
+
+jobs:
+  update-flake-lock-non-critical:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Install Nix
+        uses: ./.github/actions/nix-install-ephemeral
+
+      - name: Update non-critical flake inputs
+        run: |
+          nix flake update \
+            devshell \
+            flake-parts \
+            flake-utils \
+            git-hooks \
+            nix-darwin \
+            nix-editor \
+            nix2container \
+            treefmt-nix
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update flake.lock non-critical inputs (bimonthly)"
+          title: "chore: update flake.lock non-critical inputs (bimonthly)"
+          body: |
+            Automated bimonthly update of non-critical flake inputs:
+            - `devshell`
+            - `flake-parts`
+            - `flake-utils`
+            - `git-hooks`
+            - `nix-darwin`
+            - `nix-editor`
+            - `nix2container`
+            - `treefmt-nix`
+          branch: auto-update-flake-lock-non-critical
+          base: develop
+          labels: |
+            dependencies
+            automated

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -1,0 +1,45 @@
+name: Update Flake Lock
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+  update-flake-lock:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Install Nix
+        uses: ./.github/actions/nix-install-ephemeral
+
+      - name: Update critical flake inputs
+        run: |
+          nix flake update \
+            nixpkgs \
+            rust-overlay \
+            multigres \
+            nix-eval-jobs
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update flake.lock (monthly)"
+          title: "chore: update flake.lock (monthly)"
+          body: |
+            Automated monthly update of critical flake inputs:
+            - `nixpkgs` (nixos-unstable channel)
+            - `rust-overlay`
+            - `multigres`
+            - `nix-eval-jobs`
+          branch: auto-update-flake-lock
+          base: develop
+          labels: |
+            dependencies
+            automated

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,7 @@
     nix-editor.inputs.utils.follows = "flake-utils";
     nix-editor.url = "github:snowfallorg/nix-editor";
     nix-eval-jobs.inputs.flake-parts.follows = "flake-parts";
+    nix-eval-jobs.inputs.nixpkgs.follows = "nixpkgs";
     nix-eval-jobs.inputs.treefmt-nix.follows = "treefmt-nix";
     nix-eval-jobs.url = "github:nix-community/nix-eval-jobs";
     nix2container.inputs.nixpkgs.follows = "nixpkgs";

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,6 @@
     nix-editor.inputs.utils.follows = "flake-utils";
     nix-editor.url = "github:snowfallorg/nix-editor";
     nix-eval-jobs.inputs.flake-parts.follows = "flake-parts";
-    nix-eval-jobs.inputs.nixpkgs.follows = "nixpkgs";
     nix-eval-jobs.inputs.treefmt-nix.follows = "treefmt-nix";
     nix-eval-jobs.url = "github:nix-community/nix-eval-jobs";
     nix2container.inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
 Summary         
                                                                                                                                                                                                                    
  This PR adds automated monthly and bimonthly workflows to keep flake inputs up to date
  Changes

  Monthly workflow for critical inputs (update-flake-lock.yml)

  - Runs on the 1st of every month (and via manual dispatch)
  - Updates the four inputs that track fast-moving upstream targets:
    - nixpkgs (nixos-unstable channel)
    - rust-overlay (Rust toolchain releases)
    - multigres (upstream project, flake = false)
    - nix-eval-jobs (build tooling)
  - Opens a PR against develop using peter-evans/create-pull-request
  - No GitHub App required, uses the built-in GITHUB_TOKEN

  Bimonthly workflow for non-critical inputs (update-flake-lock-non-critical.yml)

  - Runs on the 1st of every other month (and via manual dispatch)
  - Updates stable utility libraries that change infrequently:
    - devshell
    - flake-parts
    - flake-utils
    - git-hooks
    - nix-darwin
    - nix-editor
    - nix2container
    - treefmt-nix
  - Opens a separate PR against develop on its own branch to avoid conflicts with the monthly updates

  

  - nix-eval-jobs was the only input with a nixpkgs dependency that did not follow this flake's nixpkgs
  - Adding nix-eval-jobs.inputs.nixpkgs.follows = "nixpkgs" ensures it uses the same package set as everything else
  - Eliminates a redundant nixpkgs copy from the lock file

  Inputs not updated by either workflow

  - nixpkgs-oldstable is intentionally pinned to a specific commit for extensions requiring older package versions and must not be updated automatically