### PR TITLE
feat: update pgctld, resolve version in pkg, update docs

### DIFF
--- a/docs/multigres-image.md
+++ b/docs/multigres-image.md
@@ -216,3 +216,25 @@ cp /tmp/tmp.<id>/regression_output/results/z_multigres-orioledb-17_*.out nix/tes
 > `pgmq.out`, `http.out`) from multigres test runs back to `nix/tests/expected/`.
 > Those files are patched at runtime by the test harness and will break other
 > image tests if overwritten with patched content.
+
+
+## Updating multigres
+
+1. run `nix flake update multigres` from root of repo (it should only change `flake.lock` file)
+2. `git add flake.lock`
+3. `nix build .#pgctld` and update `nix/packages/pgctld.nix`  `vendorHash` with returned value
+   example `vendorHash = "sha256-cqSd6Dv0WYOVwg7AE1tZPh9uzsjDG32gF6eJzARsHo8=";`
+4. `git add nix/packages/pgctld.nix`
+5. run the tests locally with 
+  a. `nix run .#docker-image-test -- --target variant-17 Dockerfile-multigres`
+  b. `nix run .#docker-image-test -- --target variant-orioledb-17 Dockerfile-multigres`
+6. release the images by incrementing these values in `ansible/vars.yaml` by 1 
+
+# Full version strings for each major version
+```
+postgres_release:
+  postgresorioledb-17: "17.6.0.054-orioledb"
+  postgres17: "17.6.1.097"
+  postgres15: "15.14.1.097"     
+```
+Then you can push the changes if the images pass those tests

--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
     "multigres": {
       "flake": false,
       "locked": {
-        "lastModified": 1773158276,
-        "narHash": "sha256-qKa6770V3FCznqj8lPB0dfXsytiw1l3ddJfuoQ1WlaE=",
+        "lastModified": 1773763606,
+        "narHash": "sha256-ceShYR1Ocgt+glEzipF/l6Bje+sxuxDbDttaUfUAe44=",
         "owner": "multigres",
         "repo": "multigres",
-        "rev": "33528ddea63872fbd7047f7989a3d164d2dffeac",
+        "rev": "2a0b08680a95e5108bd7d33fe55c832bef3b90bb",
         "type": "github"
       },
       "original": {

--- a/nix/packages/pgctld.nix
+++ b/nix/packages/pgctld.nix
@@ -5,7 +5,7 @@
 }:
 buildGoModule {
   pname = "pgctld";
-  version = "0.1.0";
+  version = multigres-src.rev;
   src = multigres-src;
   subPackages = [ "go/cmd/pgctld" ];
   env.CGO_ENABLED = "0";
@@ -17,7 +17,7 @@ buildGoModule {
   '';
   # Tests require a running PostgreSQL instance (integration tests); skip in sandbox.
   doCheck = false;
-  vendorHash = "sha256-HesmA96WVxnBvspLc9FZ5M4m5J/T5r6ymaui8g58yMM=";
+  vendorHash = "sha256-cqSd6Dv0WYOVwg7AE1tZPh9uzsjDG32gF6eJzARsHo8=";
 
   meta = {
     description = "PostgreSQL control daemon for Multigres cluster lifecycle management";


### PR DESCRIPTION
Here's a summary of all changes on this branch:
                                                                                                                                                                                           
  3 files changed across 1 commit:                                                                                                                                                         
   
  1. nix/packages/pgctld.nix — pgctld version now uses multigres-src.rev (the git SHA) instead of hardcoded "0.1.0", and vendorHash updated for the new multigres source.                  
  2. flake.lock — multigres input updated from 33528dd to 2a0b086.
  3. docs/multigres-image.md — Added "Updating multigres" section documenting the step-by-step process: update flake input, rebuild pgctld with new vendorHash, run image tests, bump      
  release versions in ansible/vars.yaml, then push.    