### PR TITLE
feat(auth-deployments): bump auth version to v2.188.1

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.055-orioledb"
-  postgres17: "17.6.1.098"
-  postgres15: "15.14.1.098"
+  postgresorioledb-17: "17.6.0.056-orioledb"
+  postgres17: "17.6.1.099"
+  postgres15: "15.14.1.099"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1
@@ -25,8 +25,8 @@ postgrest_release: 14.5
 postgrest_arm_release_checksum: sha256:70c07ff875710538903c9b6b6de00e126250e335da25b0ff7d1b13bb4c94bf41
 postgrest_x86_release_checksum: sha256:ab5cc7e974d4940447991804588cfb8b3f7b2c57b691f0905df04d51ede69470
 
-gotrue_release: 2.187.0
-gotrue_release_checksum: sha1:1827fa48fc1ce4cba78b869b4c0edc9c0677edf4
+gotrue_release: 2.188.1
+gotrue_release_checksum: sha1:43518b6d5e97ed63eed292deac7ad3263d2c975b
 
 aws_cli_release: 2.23.11
 

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -26,7 +26,7 @@ postgrest_arm_release_checksum: sha256:70c07ff875710538903c9b6b6de00e126250e335d
 postgrest_x86_release_checksum: sha256:ab5cc7e974d4940447991804588cfb8b3f7b2c57b691f0905df04d51ede69470
 
 gotrue_release: 2.188.1
-gotrue_release_checksum: sha1:43518b6d5e97ed63eed292deac7ad3263d2c975b
+gotrue_release_checksum: sha1:236e8c7bb93e1246b3ff31dbda0fbebe6c3114ca
 
 aws_cli_release: 2.23.11
 


### PR DESCRIPTION
Bumps auth version to v2.188.1.

Auth v2.188.1 release information:
- date: 2026-03-19T16:20:57Z
- tag: v2.188.1
- url: https://github.com/supabase/auth/releases/tag/v2.188.1