### PR TITLE
fix: configure proper creds for cleanup

### DIFF
--- a/.github/workflows/ami-release-nix.yml
+++ b/.github/workflows/ami-release-nix.yml
@@ -255,6 +255,13 @@ jobs:
           SLACK_MESSAGE: 'Building Postgres AMI failed'
           SLACK_FOOTER: ''
 
+      - name: configure aws credentials for cleanup
+        if: ${{ always() }}
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: ${{ secrets.DEV_AWS_ROLE }}
+          aws-region: "us-east-1"
+
       - name: Cleanup resources after build
         if: ${{ always() }}
         run: |


### PR DESCRIPTION
Added a configure-aws-credentials step before both cleanup steps that
  re-assumes DEV_AWS_ROLE in us-east-1  the same role, action version (v4.3.1),
   and region used by the original aws-creds step at line 51 that has EC2       
  permissions. It uses if: `${{ always() }}` so it runs even on
  failure/cancellation, matching the cleanup steps it precedes. 