### PR TITLE
fix(docker): move template out of mount point

### DIFF
--- a/Dockerfile-multigres
+++ b/Dockerfile-multigres
@@ -191,11 +191,12 @@ RUN for f in /nix/var/nix/profiles/default/bin/*; do \
 RUN chown -R postgres:postgres /usr/lib/postgresql && \
     chown -R postgres:postgres /usr/share/postgresql
 
-COPY docker/pgctld/postgresql.conf.tmpl /etc/pgctld/postgresql.conf.tmpl
+# Can't use /etc/pgctld because it's a mount point
+COPY docker/pgctld/postgresql.conf.tmpl /etc/pgctld-custom/postgresql.conf.tmpl
 
 # Wrapper: injects --postgres-config-template on every pgctld call so the team's
 # unmodified k8s manifests and local provisioner commands work without extra flags.
-RUN printf '#!/bin/sh\nexec /nix/var/nix/profiles/default/bin/pgctld --postgres-config-template /etc/pgctld/postgresql.conf.tmpl "$@"\n' \
+RUN printf '#!/bin/sh\nexec /nix/var/nix/profiles/default/bin/pgctld --postgres-config-template /etc/pgctld-custom/postgresql.conf.tmpl "$@"\n' \
     > /usr/local/bin/pgctld && \
     chmod +x /usr/local/bin/pgctld
 
@@ -257,11 +258,12 @@ ENV LANG=C
 ENV LC_ALL=C
 ENV LANGUAGE=C
 
-COPY docker/pgctld/orioledb-postgresql.conf.tmpl /etc/pgctld/orioledb-postgresql.conf.tmpl
+# Can't use /etc/pgctld because it's a mount point
+COPY docker/pgctld/orioledb-postgresql.conf.tmpl /etc/pgctld-custom/orioledb-postgresql.conf.tmpl
 
 # Wrapper: injects --postgres-config-template on every pgctld call so the team's
 # unmodified k8s manifests and local provisioner commands work without extra flags.
-RUN printf '#!/bin/sh\nexec /nix/var/nix/profiles/default/bin/pgctld --postgres-config-template /etc/pgctld/orioledb-postgresql.conf.tmpl "$@"\n' \
+RUN printf '#!/bin/sh\nexec /nix/var/nix/profiles/default/bin/pgctld --postgres-config-template /etc/pgctld-custom/orioledb-postgresql.conf.tmpl "$@"\n' \
     > /usr/local/bin/pgctld && \
     chmod +x /usr/local/bin/pgctld
 

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.059-orioledb"
-  postgres17: "17.6.1.102"
-  postgres15: "15.14.1.102"
+  postgresorioledb-17: "17.6.0.060-orioledb"
+  postgres17: "17.6.1.103"
+  postgres15: "15.14.1.103"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1


### PR DESCRIPTION
[thread](https://supabase.slack.com/archives/C09HZMQDAKD/p1774525469143029)

`/etc/pgctld` is a mount point - files put in it in the Dockerfile will get shadowed. Put files in `/etc/pgctld-custom` instead.

Tested using `supabase/postgres:17.6.1.102-pgctld-1-multigres`