### PR TITLE
 feat: INDATA-552 add pg_class-based table size metrics to postgres_exporter

### DIFF
--- a/ansible/files/queries.yml
+++ b/ansible/files/queries.yml
@@ -1,0 +1,34 @@
+pg_table_size:
+  query: |
+    SELECT
+      n.nspname AS schema,
+      c.relname AS table,
+      c.reltuples AS row_estimate,
+      pg_total_relation_size(c.oid) AS total_bytes,
+      pg_relation_size(c.oid) AS table_bytes,
+      pg_indexes_size(c.oid) AS index_bytes,
+      pg_total_relation_size(c.reltoastrelid) AS toast_bytes
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'r'
+      AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+  metrics:
+    - schema:
+        usage: LABEL
+    - table:
+        usage: LABEL
+    - row_estimate:
+        usage: GAUGE
+        description: "Estimated row count from pg_class.reltuples"
+    - total_bytes:
+        usage: GAUGE
+        description: "Total size including indexes and toast"
+    - table_bytes:
+        usage: GAUGE
+        description: "Table data size"
+    - index_bytes:
+        usage: GAUGE
+        description: "Total index size"
+    - toast_bytes:
+        usage: GAUGE
+        description: "Toast size"

--- a/ansible/files/queries.yml
+++ b/ansible/files/queries.yml
@@ -7,7 +7,7 @@ pg_table_size:
       pg_total_relation_size(c.oid) AS total_bytes,
       pg_relation_size(c.oid) AS table_bytes,
       pg_indexes_size(c.oid) AS index_bytes,
-      pg_total_relation_size(c.reltoastrelid) AS toast_bytes
+      COALESCE(pg_total_relation_size(NULLIF(c.reltoastrelid, 0)), 0) AS toast_bytes
     FROM pg_class c
     JOIN pg_namespace n ON n.oid = c.relnamespace
     WHERE c.relkind = 'r'

--- a/ansible/tasks/internal/postgres-exporter.yml
+++ b/ansible/tasks/internal/postgres-exporter.yml
@@ -35,6 +35,15 @@
     extra_opts: [--strip-components=1]
   become: yes
 
+- name: deploy queries.yml for custom metrics
+  copy:
+    src: files/queries.yml
+    dest: /opt/postgres_exporter/queries.yml
+    owner: root
+    group: root
+    mode: '0644'
+  become: yes
+
 - name: exporter create a service
   template:
     src: files/postgres_exporter.service.j2


### PR DESCRIPTION
Deploy a custom queries.yml that exposes per-table row estimates and sizes (table, index, toast) via pg_class.reltuples and pg_relation_size(), as a cheap alternative to the disabled stat_user_tables collectors.

https://linear.app/supabase/issue/INDATA-552/investigate-reltuples-based-table-stats-for-exporter

Please go the the `Preview` tab and select the appropriate sub-template:

* [Default](?expand=1&template=default.md)

## Staging test results (2026-03-27)

Manually deployed queries.yml to `/opt/postgres_exporter/` on a staging DB and verified via `curl -s http://localhost:9187/metrics | grep pg_table_size`.

All 5 metric families scraped correctly:
- `pg_table_size_row_estimate` — shows `-1` for empty tables (expected, autovacuum hasn't run), real values for populated ones (e.g. `schema_migrations: 76`)
- `pg_table_size_total_bytes`, `table_bytes`, `index_bytes` — all returning correct values
- `pg_table_size_toast_bytes` — initially had `NaN` for tables without a toast table (`reltoastrelid = 0`). Fixed with `COALESCE(pg_total_relation_size(NULLIF(c.reltoastrelid, 0)), 0)`, now returns `0` cleanly.

Metrics cover `auth`, `storage`, and `vault` schemas. No errors in the exporter, no `NaN` values after the fix.
