### PR TITLE
chore: remove unused env

### DIFF
--- a/Dockerfile-15
+++ b/Dockerfile-15
@@ -166,7 +166,6 @@ RUN mkdir -p /usr/share/postgresql/extension/ && \
 # Environment variables
 ENV PATH="/nix/var/nix/profiles/default/bin:/usr/lib/postgresql/bin:${PATH}"
 ENV PGDATA=/var/lib/postgresql/data
-ENV POSTGRES_HOST=/var/run/postgresql
 ENV POSTGRES_USER=supabase_admin
 ENV POSTGRES_DB=postgres
 ENV LANG=en_US.UTF-8

--- a/Dockerfile-17
+++ b/Dockerfile-17
@@ -172,7 +172,6 @@ RUN mkdir -p /usr/share/postgresql/extension/ && \
 # Environment variables
 ENV PATH="/nix/var/nix/profiles/default/bin:/usr/lib/postgresql/bin:${PATH}"
 ENV PGDATA=/var/lib/postgresql/data
-ENV POSTGRES_HOST=/var/run/postgresql
 ENV POSTGRES_USER=supabase_admin
 ENV POSTGRES_DB=postgres
 ENV POSTGRES_INITDB_ARGS="--allow-group-access --locale-provider=icu --encoding=UTF-8 --icu-locale=en_US.UTF-8"

--- a/Dockerfile-multigres
+++ b/Dockerfile-multigres
@@ -162,7 +162,6 @@ COPY ansible/files/pgbouncer_config/pgbouncer_auth_schema.sql /docker-entrypoint
 COPY ansible/files/stat_extension.sql /docker-entrypoint-initdb.d/migrations/00-extension.sql
 
 ENV PGDATA=/var/lib/postgresql/data
-ENV POSTGRES_HOST=/var/run/postgresql
 ENV POSTGRES_USER=supabase_admin
 ENV POSTGRES_DB=postgres
 ENV POSTGRES_INITDB_ARGS="--allow-group-access --locale-provider=icu --encoding=UTF-8 --icu-locale=en_US.UTF-8"

--- a/Dockerfile-orioledb-17
+++ b/Dockerfile-orioledb-17
@@ -180,7 +180,6 @@ RUN mkdir -p /usr/share/postgresql/extension/ && \
 # Environment variables
 ENV PATH="/nix/var/nix/profiles/default/bin:/usr/lib/postgresql/bin:${PATH}"
 ENV PGDATA=/var/lib/postgresql/data
-ENV POSTGRES_HOST=/var/run/postgresql
 ENV POSTGRES_USER=supabase_admin
 ENV POSTGRES_DB=postgres
 ENV POSTGRES_INITDB_ARGS="--allow-group-access --locale-provider=icu --encoding=UTF-8 --icu-locale=en_US.UTF-8"

--- a/migrations/db/migrate.sh
+++ b/migrations/db/migrate.sh
@@ -5,7 +5,6 @@ set -eu
 # Used by both ami and docker builds to initialise database schema.
 # Env vars:
 #   POSTGRES_DB        defaults to postgres
-#   POSTGRES_HOST      defaults to localhost
 #   POSTGRES_PORT      defaults to 5432
 #   POSTGRES_PASSWORD  defaults to ""
 #   USE_DBMATE         defaults to ""
@@ -14,7 +13,7 @@ set -eu
 #######################################
 
 export PGDATABASE="${POSTGRES_DB:-postgres}"
-export PGHOST="${POSTGRES_HOST:-localhost}"
+export PGHOST=/var/run/postgresql
 export PGPORT="${POSTGRES_PORT:-5432}"
 export PGPASSWORD="${POSTGRES_PASSWORD:-}"
 

--- a/nix/packages/docker-image-test.nix
+++ b/nix/packages/docker-image-test.nix
@@ -404,7 +404,6 @@ writeShellApplication {
         docker exec \
             -e POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
             -e POSTGRES_DB="$POSTGRES_DB" \
-            -e POSTGRES_HOST=/var/run/postgresql \
             -e POSTGRES_PORT=5432 \
             "$container" \
             sh /docker-entrypoint-initdb.d/migrate.sh

--- a/nix/packages/start-client.nix
+++ b/nix/packages/start-client.nix
@@ -95,7 +95,6 @@ writeShellApplication {
     # Set up environment for psql
     export PATH="$BINDIR/bin:$PATH"
     export POSTGRES_DB=postgres
-    export POSTGRES_HOST=localhost
 
     # Start interactive psql session
     exec psql -U "$PSQL_USER" -p "$PORTNO" -h localhost postgres

--- a/tests/pg_upgrade/.env
+++ b/tests/pg_upgrade/.env
@@ -1,5 +1,4 @@
 POSTGRES_PASSWORD=postgres
-POSTGRES_HOST=/var/run/postgresql
 POSTGRES_INITDB_ARGS=--lc-ctype=C.UTF-8
 PG_MAJOR_VERSION=15
 IS_CI=true


### PR DESCRIPTION
`POSTGRES_HOST` is unused by the docker entrypoint and the postgres server. Remove it to prevent confusion.

[thread](https://supabase.slack.com/archives/C09HZMQDAKD/p1774603330745419)