### PR TITLE
revert: stop using conf.d directory for generated-optimizations

### DIFF
--- a/ansible/files/database-optimizations.service
+++ b/ansible/files/database-optimizations.service
@@ -4,7 +4,7 @@ Description=Postgresql optimizations
 [Service]
 Type=oneshot
 # we do not want failures from these commands to cause downstream service startup to fail
-ExecStart=-/opt/supabase-admin-api optimize db --destination-config-file-path /etc/postgresql-custom/conf.d/generated-optimizations.conf
+ExecStart=-/opt/supabase-admin-api optimize db --destination-config-file-path /etc/postgresql-custom/generated-optimizations.conf
 ExecStart=-/opt/supabase-admin-api optimize pgbouncer --destination-config-file-path /etc/pgbouncer-custom/generated-optimizations.ini
 User=adminapi
 


### PR DESCRIPTION
We need to roll this change back until the other bits are updated to also use this dir or we'll keep having issues similar to inc-419

