### PR TITLE
feat: add /etc/supabase-release with ami version file

### DIFF
--- a/ebssurrogate/scripts/surrogate-bootstrap-nix.sh
+++ b/ebssurrogate/scripts/surrogate-bootstrap-nix.sh
@@ -275,6 +275,10 @@ function setup_chroot_environment {
 	rm -f /mnt/tmp/chroot-bootstrap-nix.sh
 	echo "${POSTGRES_SUPABASE_VERSION}" > /mnt/root/supabase-release
 
+	# Copy the AMI version into the /etc/supabase-release file
+	echo "${POSTGRES_SUPABASE_VERSION}" > /mnt/etc/supabase-release
+	chmod 644 /mnt/etc/supabase-release
+
 	# Copy the nvme identification script into /sbin inside the chroot
 	mkdir -p /mnt/sbin
 	cp /tmp/ebsnvme-id /mnt/sbin/ebsnvme-id


### PR DESCRIPTION
Currently we write the AMI version to /root/supabase-release which requires root access to read. Here we add /root/supabase-release so local unprivileged services can determine the configuration of the system they are running on.

I noticed there were additional files for /root/supabase-release in the `audit-specs/` dir. I can include that in this PR if needed.