### PR TITLE
feat: tagging pg 17 with cli on actual release

### DIFF
--- a/.github/workflows/ami-release-nix.yml
+++ b/.github/workflows/ami-release-nix.yml
@@ -229,6 +229,17 @@ jobs:
           tag_name: ${{ steps.process_release_version.outputs.version }}
           target_commitish: ${{github.sha}}
 
+      - name: Create CLI tag for PG 17
+        if: matrix.postgres_version == '17' && github.event_name != 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ steps.process_release_version.outputs.version }}"
+          CLI_TAG="v${VERSION}-cli"
+          echo "Creating CLI tag: ${CLI_TAG}"
+          git tag "${CLI_TAG}" "${{ github.sha }}"
+          git push origin "${CLI_TAG}"
+
       - name: Trigger pg_upgrade_scripts workflow
         env:
           GH_TOKEN: ${{ github.token }}

--- a/nix/hooks.nix
+++ b/nix/hooks.nix
@@ -12,7 +12,7 @@ in
 {
   imports = [ inputs.git-hooks.flakeModule ];
   perSystem =
-    { config, ... }:
+    { config, pkgs, ... }:
     {
       pre-commit = {
         check.enable = true;
@@ -28,6 +28,27 @@ in
               enable = true;
               package = config.treefmt.build.wrapper;
               pass_filenames = false;
+              verbose = true;
+            };
+
+            no-cli-in-postgres-release = {
+              enable = true;
+              name = "no-cli-in-postgres-release";
+              description = "Prevent -cli suffix in postgres_release values in ansible/vars.yml";
+              entry = builtins.toString (
+                pkgs.writeShellScript "no-cli-in-postgres-release" ''
+                  if [ -f ansible/vars.yml ]; then
+                    if ${pkgs.gnugrep}/bin/grep -E '^\s+postgres(orioledb-)?[0-9]+:.*-cli' ansible/vars.yml; then
+                      echo ""
+                      echo "ERROR: postgres_release values in ansible/vars.yml must not contain '-cli' suffix."
+                      echo "The -cli tag is generated automatically by the AMI release workflow."
+                      exit 1
+                    fi
+                  fi
+                ''
+              );
+              files = "^ansible/vars\\.yml$";
+              language = "system";
               verbose = true;
             };
           };


### PR DESCRIPTION
The AMI release workflow now automatically creates a v{version}-cli tag alongside the regular release tag whenever a PG 17 AMI is built from a push to develop or release branches, which in turn triggers the existing CLI release workflow. This tag is skipped on manual workflow dispatch runs to avoid unintended CLI releases. A new pre-commit hook using the project's existing git-hooks.nix infrastructure prevents anyone from accidentally adding a -cli suffix to the postgres_release values in ansible/vars.yml, since those tags are meant to be generated  automatically by the workflow rather than set manually, and could create a conflict with the release as the "suffix" approach uses git tags as well.