### PR TITLE
fix: update nix to 2.34.6 for GHSA-g3g9-5vj6-r3gj

### DIFF
--- a/.github/actions/nix-install-ephemeral/action.yml
+++ b/.github/actions/nix-install-ephemeral/action.yml
@@ -56,7 +56,7 @@ runs:
           echo "post-build-hook = /etc/nix/upload-to-cache.sh" | sudo tee -a /tmp/nix-extra.conf > /dev/null
         fi
 
-        curl -L https://releases.nixos.org/nix/nix-2.33.4/install | sh -s -- --daemon --yes --nix-extra-conf-file /tmp/nix-extra.conf
+        curl -L https://releases.nixos.org/nix/nix-2.34.6/install | sh -s -- --daemon --yes --nix-extra-conf-file /tmp/nix-extra.conf
 
         # Add nix to PATH for subsequent steps
         echo "/nix/var/nix/profiles/default/bin" >> "$GITHUB_PATH"

--- a/.github/actions/nix-install-ephemeral/action.yml
+++ b/.github/actions/nix-install-ephemeral/action.yml
@@ -43,7 +43,7 @@ runs:
         NIX_SIGN_SECRET_KEY: ${{ env.NIX_SIGN_SECRET_KEY }}
     - uses: NixOS/nix-installer-action@d6ef7ecd8f685af89869e5aca0580a33e3e3150c
       with:
-        installer-version: 2.33.2
+        installer-version: 2.33.4
         extra-conf: |
           substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com
           trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=

--- a/.github/actions/nix-install-ephemeral/action.yml
+++ b/.github/actions/nix-install-ephemeral/action.yml
@@ -41,21 +41,22 @@ runs:
         sudo chmod +x /etc/nix/upload-to-cache.sh
       env:
         NIX_SIGN_SECRET_KEY: ${{ env.NIX_SIGN_SECRET_KEY }}
-    - name: Set Nix package URL
+    - name: Install Nix
       shell: bash
       run: |
-        ARCH="$(uname -m)"
-        OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
-        echo "NIX_INSTALLER_NIX_PACKAGE_URL=https://releases.nixos.org/nix/nix-2.33.4/nix-2.33.4-${ARCH}-${OS}.tar.xz" >> "$GITHUB_ENV"
-    - uses: NixOS/nix-installer-action@d6ef7ecd8f685af89869e5aca0580a33e3e3150c
-      with:
-        installer-version: 2.33.3
-        extra-conf: |
-          substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com
-          trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-          ${{ inputs.push-to-cache == 'true' && 'post-build-hook = /etc/nix/upload-to-cache.sh' || '' }}
-          max-jobs = 4
-          extra-system-features = kvm
+        sudo tee /tmp/nix-extra.conf > /dev/null <<'NIXCONF'
+        extra-experimental-features = nix-command flakes
+        substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com
+        trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+        max-jobs = 4
+        extra-system-features = kvm
+        NIXCONF
+
+        if [ "${{ inputs.push-to-cache }}" = "true" ]; then
+          echo "post-build-hook = /etc/nix/upload-to-cache.sh" | sudo tee -a /tmp/nix-extra.conf > /dev/null
+        fi
+
+        curl -L https://releases.nixos.org/nix/nix-2.33.4/install | sh -s -- --daemon --yes --nix-extra-conf-file /tmp/nix-extra.conf
     - name: Print Nix version
       shell: bash
       run: nix --version

--- a/.github/actions/nix-install-ephemeral/action.yml
+++ b/.github/actions/nix-install-ephemeral/action.yml
@@ -56,6 +56,9 @@ runs:
           ${{ inputs.push-to-cache == 'true' && 'post-build-hook = /etc/nix/upload-to-cache.sh' || '' }}
           max-jobs = 4
           extra-system-features = kvm
+    - name: Print Nix version
+      shell: bash
+      run: nix --version
     - name: Setup KVM permissions
       shell: bash
       run: |

--- a/.github/actions/nix-install-ephemeral/action.yml
+++ b/.github/actions/nix-install-ephemeral/action.yml
@@ -41,9 +41,15 @@ runs:
         sudo chmod +x /etc/nix/upload-to-cache.sh
       env:
         NIX_SIGN_SECRET_KEY: ${{ env.NIX_SIGN_SECRET_KEY }}
+    - name: Set Nix package URL
+      shell: bash
+      run: |
+        ARCH="$(uname -m)"
+        OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+        echo "NIX_INSTALLER_NIX_PACKAGE_URL=https://releases.nixos.org/nix/nix-2.33.4/nix-2.33.4-${ARCH}-${OS}.tar.xz" >> "$GITHUB_ENV"
     - uses: NixOS/nix-installer-action@d6ef7ecd8f685af89869e5aca0580a33e3e3150c
       with:
-        installer-version: 2.33.4
+        installer-version: 2.33.3
         extra-conf: |
           substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com
           trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=

--- a/.github/actions/nix-install-ephemeral/action.yml
+++ b/.github/actions/nix-install-ephemeral/action.yml
@@ -57,6 +57,11 @@ runs:
         fi
 
         curl -L https://releases.nixos.org/nix/nix-2.33.4/install | sh -s -- --daemon --yes --nix-extra-conf-file /tmp/nix-extra.conf
+
+        # Add nix to PATH for subsequent steps
+        echo "/nix/var/nix/profiles/default/bin" >> "$GITHUB_PATH"
+        # Source the daemon profile so nix works in this step too
+        . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
     - name: Print Nix version
       shell: bash
       run: nix --version

--- a/.github/actions/nix-install-self-hosted/action.yml
+++ b/.github/actions/nix-install-self-hosted/action.yml
@@ -18,6 +18,9 @@ runs:
         role-session-name: gha-oidc-${{ github.run_id }}
         role-duration-seconds: ${{ inputs.aws-role-duration }}
 
+    - name: Print Nix version
+      shell: bash
+      run: nix --version
     - name: Write creds files
       shell: bash
       run: |

--- a/Dockerfile-15
+++ b/Dockerfile-15
@@ -27,7 +27,7 @@ extra-experimental-features = nix-command flakes
 extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
 extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=
 EOF
-RUN curl -L https://releases.nixos.org/nix/nix-2.33.4/install | sh -s -- --daemon --no-channel-add --yes --nix-extra-conf-file /tmp/extra-nix.conf
+RUN curl -L https://releases.nixos.org/nix/nix-2.34.6/install | sh -s -- --daemon --no-channel-add --yes --nix-extra-conf-file /tmp/extra-nix.conf
 ENV PATH="${PATH}:/nix/var/nix/profiles/default/bin"
 RUN nix --version
 

--- a/Dockerfile-15
+++ b/Dockerfile-15
@@ -29,6 +29,7 @@ extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7V
 EOF
 RUN curl -L https://releases.nixos.org/nix/nix-2.33.4/install | sh -s -- --daemon --no-channel-add --yes --nix-extra-conf-file /tmp/extra-nix.conf
 ENV PATH="${PATH}:/nix/var/nix/profiles/default/bin"
+RUN nix --version
 
 WORKDIR /nixpg
 COPY . .

--- a/Dockerfile-15
+++ b/Dockerfile-15
@@ -27,7 +27,7 @@ extra-experimental-features = nix-command flakes
 extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
 extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=
 EOF
-RUN curl -L https://releases.nixos.org/nix/nix-2.33.2/install | sh -s -- --daemon --no-channel-add --yes --nix-extra-conf-file /tmp/extra-nix.conf
+RUN curl -L https://releases.nixos.org/nix/nix-2.33.4/install | sh -s -- --daemon --no-channel-add --yes --nix-extra-conf-file /tmp/extra-nix.conf
 ENV PATH="${PATH}:/nix/var/nix/profiles/default/bin"
 
 WORKDIR /nixpg

--- a/Dockerfile-17
+++ b/Dockerfile-17
@@ -27,7 +27,7 @@ extra-experimental-features = nix-command flakes
 extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
 extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=
 EOF
-RUN curl -L https://releases.nixos.org/nix/nix-2.33.4/install | sh -s -- --daemon --no-channel-add --yes --nix-extra-conf-file /tmp/extra-nix.conf
+RUN curl -L https://releases.nixos.org/nix/nix-2.34.6/install | sh -s -- --daemon --no-channel-add --yes --nix-extra-conf-file /tmp/extra-nix.conf
 ENV PATH="${PATH}:/nix/var/nix/profiles/default/bin"
 RUN nix --version
 

--- a/Dockerfile-17
+++ b/Dockerfile-17
@@ -28,8 +28,8 @@ extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
 extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=
 EOF
 RUN curl -L https://releases.nixos.org/nix/nix-2.33.4/install | sh -s -- --daemon --no-channel-add --yes --nix-extra-conf-file /tmp/extra-nix.conf
-
 ENV PATH="${PATH}:/nix/var/nix/profiles/default/bin"
+RUN nix --version
 
 WORKDIR /nixpg
 COPY . .

--- a/Dockerfile-17
+++ b/Dockerfile-17
@@ -27,7 +27,7 @@ extra-experimental-features = nix-command flakes
 extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
 extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=
 EOF
-RUN curl -L https://releases.nixos.org/nix/nix-2.33.2/install | sh -s -- --daemon --no-channel-add --yes --nix-extra-conf-file /tmp/extra-nix.conf
+RUN curl -L https://releases.nixos.org/nix/nix-2.33.4/install | sh -s -- --daemon --no-channel-add --yes --nix-extra-conf-file /tmp/extra-nix.conf
 
 ENV PATH="${PATH}:/nix/var/nix/profiles/default/bin"
 

--- a/Dockerfile-multigres
+++ b/Dockerfile-multigres
@@ -28,7 +28,7 @@ extra-experimental-features = nix-command flakes
 extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
 extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=
 EOF
-RUN curl -L https://releases.nixos.org/nix/nix-2.33.2/install | sh -s -- --daemon --no-channel-add --yes --nix-extra-conf-file /tmp/extra-nix.conf
+RUN curl -L https://releases.nixos.org/nix/nix-2.33.4/install | sh -s -- --daemon --no-channel-add --yes --nix-extra-conf-file /tmp/extra-nix.conf
 
 ENV PATH="${PATH}:/nix/var/nix/profiles/default/bin"
 

--- a/Dockerfile-multigres
+++ b/Dockerfile-multigres
@@ -29,8 +29,8 @@ extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
 extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=
 EOF
 RUN curl -L https://releases.nixos.org/nix/nix-2.33.4/install | sh -s -- --daemon --no-channel-add --yes --nix-extra-conf-file /tmp/extra-nix.conf
-
 ENV PATH="${PATH}:/nix/var/nix/profiles/default/bin"
+RUN nix --version
 
 WORKDIR /nixpg
 COPY . .

--- a/Dockerfile-multigres
+++ b/Dockerfile-multigres
@@ -28,7 +28,7 @@ extra-experimental-features = nix-command flakes
 extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
 extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=
 EOF
-RUN curl -L https://releases.nixos.org/nix/nix-2.33.4/install | sh -s -- --daemon --no-channel-add --yes --nix-extra-conf-file /tmp/extra-nix.conf
+RUN curl -L https://releases.nixos.org/nix/nix-2.34.6/install | sh -s -- --daemon --no-channel-add --yes --nix-extra-conf-file /tmp/extra-nix.conf
 ENV PATH="${PATH}:/nix/var/nix/profiles/default/bin"
 RUN nix --version
 

--- a/Dockerfile-orioledb-17
+++ b/Dockerfile-orioledb-17
@@ -27,7 +27,7 @@ extra-experimental-features = nix-command flakes
 extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
 extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=
 EOF
-RUN curl -L https://releases.nixos.org/nix/nix-2.33.4/install | sh -s -- --daemon --no-channel-add --yes --nix-extra-conf-file /tmp/extra-nix.conf
+RUN curl -L https://releases.nixos.org/nix/nix-2.34.6/install | sh -s -- --daemon --no-channel-add --yes --nix-extra-conf-file /tmp/extra-nix.conf
 ENV PATH="${PATH}:/nix/var/nix/profiles/default/bin"
 RUN nix --version
 

--- a/Dockerfile-orioledb-17
+++ b/Dockerfile-orioledb-17
@@ -28,8 +28,8 @@ extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
 extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=
 EOF
 RUN curl -L https://releases.nixos.org/nix/nix-2.33.4/install | sh -s -- --daemon --no-channel-add --yes --nix-extra-conf-file /tmp/extra-nix.conf
-
 ENV PATH="${PATH}:/nix/var/nix/profiles/default/bin"
+RUN nix --version
 
 WORKDIR /nixpg
 COPY . .

--- a/Dockerfile-orioledb-17
+++ b/Dockerfile-orioledb-17
@@ -27,7 +27,7 @@ extra-experimental-features = nix-command flakes
 extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
 extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=
 EOF
-RUN curl -L https://releases.nixos.org/nix/nix-2.33.2/install | sh -s -- --daemon --no-channel-add --yes --nix-extra-conf-file /tmp/extra-nix.conf
+RUN curl -L https://releases.nixos.org/nix/nix-2.33.4/install | sh -s -- --daemon --no-channel-add --yes --nix-extra-conf-file /tmp/extra-nix.conf
 
 ENV PATH="${PATH}:/nix/var/nix/profiles/default/bin"
 

--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
@@ -312,6 +312,7 @@ EXTRA_NIX_CONF
         echo "1.2. Fetching store path for flake revision: $NIX_FLAKE_VERSION"
         # shellcheck disable=SC1091
         source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+        nix --version
         nix-collect-garbage -d > /tmp/pg_upgrade-nix-gc.log 2>&1 || true
 
         # Determine system architecture

--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
@@ -297,7 +297,7 @@ function initiate_upgrade {
                         --extra-conf "trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
                     else
                         echo "1.1.1. Installing Nix using the official installer"
-                        sh <(curl -L https://releases.nixos.org/nix/nix-2.33.2/install) --yes --daemon --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
+                        sh <(curl -L https://releases.nixos.org/nix/nix-2.33.4/install) --yes --daemon --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
 extra-experimental-features = nix-command flakes
 extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
 extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=

--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
@@ -297,7 +297,7 @@ function initiate_upgrade {
                         --extra-conf "trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
                     else
                         echo "1.1.1. Installing Nix using the official installer"
-                        sh <(curl -L https://releases.nixos.org/nix/nix-2.33.4/install) --yes --daemon --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
+                        sh <(curl -L https://releases.nixos.org/nix/nix-2.34.6/install) --yes --daemon --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
 extra-experimental-features = nix-command flakes
 extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
 extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.064-orioledb-indata574-1"
-  postgres17: "17.6.1.107-indata574-1"
-  postgres15: "15.14.1.107-indata574-1"
+  postgresorioledb-17: "17.6.0.065-orioledb"
+  postgres17: "17.6.1.108"
+  postgres15: "15.14.1.108"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1

--- a/docs/multigres-image.md
+++ b/docs/multigres-image.md
@@ -108,12 +108,12 @@ extra-substituters =
 
 **Important**: Replace `YOUR_USERNAME` with your actual username in the `trusted-users` line.
 
-### Step 2: Install Nix 2.33.4
+### Step 2: Install Nix 2.34.6
 
-Run the following command to install Nix 2.33.4 (the version used in CI) with the custom configuration:
+Run the following command to install Nix 2.34.6 (the version used in CI) with the custom configuration:
 
 ```bash
-curl -L https://releases.nixos.org/nix/nix-2.33.4/install | sh -s -- --daemon --yes --nix-extra-conf-file ./nix.conf
+curl -L https://releases.nixos.org/nix/nix-2.34.6/install | sh -s -- --daemon --yes --nix-extra-conf-file ./nix.conf
 ```
 
 This will install Nix with our build caches pre-configured, which should eliminate substituter-related errors.
@@ -128,7 +128,7 @@ same commands on your machine:
 
 ```
 $ nix --version
-nix (Nix) 2.33.1
+nix (Nix) 2.34.6
 ```
 
 

--- a/docs/multigres-image.md
+++ b/docs/multigres-image.md
@@ -108,9 +108,9 @@ extra-substituters =
 
 **Important**: Replace `YOUR_USERNAME` with your actual username in the `trusted-users` line.
 
-### Step 2: Install Nix 2.33.1
+### Step 2: Install Nix 2.33.4
 
-Run the following command to install Nix 2.33.1 (the version used in CI) with the custom configuration:
+Run the following command to install Nix 2.33.4 (the version used in CI) with the custom configuration:
 
 ```bash
 curl -L https://releases.nixos.org/nix/nix-2.33.4/install | sh -s -- --daemon --yes --nix-extra-conf-file ./nix.conf

--- a/docs/multigres-image.md
+++ b/docs/multigres-image.md
@@ -113,7 +113,7 @@ extra-substituters =
 Run the following command to install Nix 2.33.1 (the version used in CI) with the custom configuration:
 
 ```bash
-curl -L https://releases.nixos.org/nix/nix-2.33.2/install | sh -s -- --daemon --yes --nix-extra-conf-file ./nix.conf
+curl -L https://releases.nixos.org/nix/nix-2.33.4/install | sh -s -- --daemon --yes --nix-extra-conf-file ./nix.conf
 ```
 
 This will install Nix with our build caches pre-configured, which should eliminate substituter-related errors.

--- a/ebssurrogate/scripts/qemu-bootstrap-nix.sh
+++ b/ebssurrogate/scripts/qemu-bootstrap-nix.sh
@@ -82,7 +82,7 @@ execute_playbook
 ####################
 
 function install_nix() {
-    sudo su -c "sh <(curl -L https://releases.nixos.org/nix/nix-2.33.4/install) --yes --daemon --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
+    sudo su -c "sh <(curl -L https://releases.nixos.org/nix/nix-2.34.6/install) --yes --daemon --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
 extra-experimental-features = nix-command flakes
 extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
 extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=

--- a/ebssurrogate/scripts/qemu-bootstrap-nix.sh
+++ b/ebssurrogate/scripts/qemu-bootstrap-nix.sh
@@ -82,7 +82,7 @@ execute_playbook
 ####################
 
 function install_nix() {
-    sudo su -c "sh <(curl -L https://releases.nixos.org/nix/nix-2.33.2/install) --yes --daemon --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
+    sudo su -c "sh <(curl -L https://releases.nixos.org/nix/nix-2.33.4/install) --yes --daemon --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
 extra-experimental-features = nix-command flakes
 extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
 extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=

--- a/ebssurrogate/scripts/qemu-bootstrap-nix.sh
+++ b/ebssurrogate/scripts/qemu-bootstrap-nix.sh
@@ -89,6 +89,7 @@ extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7V
 EXTRA_NIX_CONF" -s /bin/bash root
     #shellcheck disable=SC1091
     . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+    nix --version
 }
 
 function execute_stage2_playbook {

--- a/nix/docs/start-here.md
+++ b/nix/docs/start-here.md
@@ -83,9 +83,9 @@ extra-substituters =
 
 **Important**: Replace `YOUR_USERNAME` with your actual username in the `trusted-users` line.
 
-### Step 2: Install Nix 2.33.1
+### Step 2: Install Nix 2.33.4
 
-Run the following command to install Nix 2.33.1 (the version used in CI) with the custom configuration:
+Run the following command to install Nix 2.33.4 (the version used in CI) with the custom configuration:
 
 ```bash
 curl -L https://releases.nixos.org/nix/nix-2.33.4/install | sh -s -- --daemon --yes --nix-extra-conf-file ./nix.conf

--- a/nix/docs/start-here.md
+++ b/nix/docs/start-here.md
@@ -88,7 +88,7 @@ extra-substituters =
 Run the following command to install Nix 2.33.1 (the version used in CI) with the custom configuration:
 
 ```bash
-curl -L https://releases.nixos.org/nix/nix-2.33.2/install | sh -s -- --daemon --yes --nix-extra-conf-file ./nix.conf
+curl -L https://releases.nixos.org/nix/nix-2.33.4/install | sh -s -- --daemon --yes --nix-extra-conf-file ./nix.conf
 ```
 
 This will install Nix with our build caches pre-configured, which should eliminate substituter-related errors.

--- a/nix/docs/start-here.md
+++ b/nix/docs/start-here.md
@@ -83,12 +83,12 @@ extra-substituters =
 
 **Important**: Replace `YOUR_USERNAME` with your actual username in the `trusted-users` line.
 
-### Step 2: Install Nix 2.33.4
+### Step 2: Install Nix 2.34.6
 
-Run the following command to install Nix 2.33.4 (the version used in CI) with the custom configuration:
+Run the following command to install Nix 2.34.6 (the version used in CI) with the custom configuration:
 
 ```bash
-curl -L https://releases.nixos.org/nix/nix-2.33.4/install | sh -s -- --daemon --yes --nix-extra-conf-file ./nix.conf
+curl -L https://releases.nixos.org/nix/nix-2.34.6/install | sh -s -- --daemon --yes --nix-extra-conf-file ./nix.conf
 ```
 
 This will install Nix with our build caches pre-configured, which should eliminate substituter-related errors.
@@ -103,7 +103,7 @@ same commands on your machine:
 
 ```
 $ nix --version
-nix (Nix) 2.33.1
+nix (Nix) 2.34.6
 ```
 
 ```
@@ -112,7 +112,7 @@ $ nix run nixpkgs#nix-info -- -m
  - host os: `Linux 5.15.90.1-microsoft-standard-WSL2, Ubuntu, 22.04.2 LTS (Jammy Jellyfish), nobuild`
  - multi-user?: `yes`
  - sandbox: `yes`
- - version: `nix-env (Nix) 2.33.1`
+ - version: `nix-env (Nix) 2.34.6`
  - channels(root): `"nixpkgs"`
  - nixpkgs: `/nix/var/nix/profiles/per-user/root/channels/nixpkgs`
 ```

--- a/scripts/nix-provision.sh
+++ b/scripts/nix-provision.sh
@@ -35,6 +35,7 @@ extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7V
 EXTRA_NIX_CONF" -s /bin/bash root
     #shellcheck disable=SC1091
     . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+    nix --version
 }
 
 

--- a/scripts/nix-provision.sh
+++ b/scripts/nix-provision.sh
@@ -28,7 +28,7 @@ function install_packages {
 
 
 function install_nix() {
-    sudo su -c "sh <(curl -L https://releases.nixos.org/nix/nix-2.33.2/install) --yes --daemon --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
+    sudo su -c "sh <(curl -L https://releases.nixos.org/nix/nix-2.33.4/install) --yes --daemon --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
 extra-experimental-features = nix-command flakes
 extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
 extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=

--- a/scripts/nix-provision.sh
+++ b/scripts/nix-provision.sh
@@ -28,7 +28,7 @@ function install_packages {
 
 
 function install_nix() {
-    sudo su -c "sh <(curl -L https://releases.nixos.org/nix/nix-2.33.4/install) --yes --daemon --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
+    sudo su -c "sh <(curl -L https://releases.nixos.org/nix/nix-2.34.6/install) --yes --daemon --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
 extra-experimental-features = nix-command flakes
 extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
 extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=


### PR DESCRIPTION
## Summary

Updates Nix installer from 2.33.2 to **2.34.6** across all Dockerfiles, provisioning scripts, CI actions, and documentation to apply the nixpkgs-provided patch for [GHSA-g3g9-5vj6-r3gj](https://github.com/NixOS/nix/security/advisories/GHSA-g3g9-5vj6-r3gj).

**Vulnerability:** A bug in the original CVE-2024-27297 fix allowed arbitrary file overwrites by the Nix daemon (running as root) via symlink following during fixed-output derivation output registration. In multi-user installations, any user able to submit builds to the Nix daemon could escalate to root privileges.

**Why 2.34.6 and not 2.33.4:** Upstream nixpkgs [dropped the 2.33 series](https://github.com/NixOS/nixpkgs/commit/d01f32e3ada0) on 2026-04-01 and did not backport the CVE patch to that line. The patch was applied to `nix_2_34` on 2026-04-07 (see `7ca89c4ab606` "nixComponents_2_34: add patches for GHSA-g3g9-5vj6-r3gj"), and `nix_2_34` is now the actively-maintained nixpkgs stable. The self-hosted aarch64-darwin runners resolve their Nix version through nixpkgs, so to keep ephemeral CI and self-hosted runners on matching, patched versions we move everything to `2.34.6`.

### Why version parity matters (context on previous merge-queue failures)

Earlier attempts to land this PR targeted `2.33.4`, but the aarch64-darwin self-hosted runners continued to use the nixpkgs-pinned version (2.33.3). The mismatch between the ephemeral installer and the self-hosted builders produced cache misses that pushed `Nix CI` to 1h 43m – 4h 12m (vs. ~30 min for other PRs), causing the merge queue to time out before CI completed. A coordinated update of the self-hosted runner flake to `nix_2_34` lands alongside this change.

### Files changed

- `Dockerfile-15`, `Dockerfile-17`, `Dockerfile-orioledb-17`, `Dockerfile-multigres` — installer URL
- `.github/actions/nix-install-ephemeral/action.yml` — CI installer version
- `scripts/nix-provision.sh` — provisioning script
- `ebssurrogate/scripts/qemu-bootstrap-nix.sh` — AMI build script
- `ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh` — upgrade script
- `nix/docs/start-here.md`, `docs/multigres-image.md` — documentation

## Test plan

- [x] CI builds pass with Nix 2.34.6
- [x] Docker images build successfully
- [x] AMI build works with updated installer
- [x] Self-hosted Darwin runner bumped to matching `nix_2_34` before queueing