### PR TITLE
feat: automate artifact creation on cli native release

### DIFF
--- a/.github/workflows/ami-release-nix.yml
+++ b/.github/workflows/ami-release-nix.yml
@@ -275,6 +275,17 @@ jobs:
           git tag "${CLI_TAG}" "${{ github.sha }}"
           git push origin "${CLI_TAG}"
 
+      - name: Trigger CLI release workflow for PG 17
+        if: matrix.postgres_version == '17' && github.event_name != 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ steps.process_release_version.outputs.version }}"
+          CLI_TAG="v${VERSION}-cli"
+          gh workflow run cli-release.yml \
+            --ref "${CLI_TAG}" \
+            -f version="${CLI_TAG}"
+
       - name: Trigger pg_upgrade_scripts workflow
         if: matrix.arch.name == 'arm64'
         env:

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -393,7 +393,7 @@ jobs:
     name: Create GitHub Release
     needs: [build-native, test-portability]
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
     permissions:
       contents: write
     steps:
@@ -443,8 +443,18 @@ jobs:
 
           ls -lh release/
 
+      - name: Determine release tag
+        id: release_tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ steps.release_tag.outputs.tag }}
           files: release/*
           generate_release_notes: true


### PR DESCRIPTION
## Summary                                                                                                                                                                          
                                                                                                                                                                                      
  - Fix CLI release artifacts not being created when `-cli` tags are pushed automatically by the AMI release workflow                                                                 
  - The root cause is that GitHub Actions does not allow workflows triggered by the default `GITHUB_TOKEN` to trigger other workflows via tag push events                             
  - Add explicit `gh workflow run cli-release.yml` trigger in `ami-release-nix.yml` after creating the `-cli` tag, following the same pattern used for                                
  `publish-nix-pgupgrade-scripts.yml`                                                                                                                                                 
  - Update `cli-release.yml` to support `workflow_dispatch` for the release job, with explicit `tag_name` resolution so artifacts attach to the correct `-cli` tag                    
  - CLI tagging and release only happen on branch merges, not on `workflow_dispatch` of the AMI workflow (existing guard preserved)                                                   
  - Older `-cli` tags can be backfilled by manually running `cli-release.yml` via `workflow_dispatch`                                                                                 
                                                                                                                                                                                      
