### PR TITLE
Fix supautils in authenticator session_preload_libraries

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.065-orioledb"
-  postgres17: "17.6.1.108"
-  postgres15: "15.14.1.108"
+  postgresorioledb-17: "17.6.0.066-orioledb"
+  postgres17: "17.6.1.109"
+  postgres15: "15.14.1.109"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1

--- a/migrations/db/migrations/20260413000000_fix-authenticator-session-preload-libraries.sql
+++ b/migrations/db/migrations/20260413000000_fix-authenticator-session-preload-libraries.sql
@@ -1,0 +1,8 @@
+-- migrate:up
+
+-- The original fix in 20220224211803 checked pg_available_extensions for
+-- supautils, but supautils is a preload library without a .control file,
+-- so it never appears in pg_available_extensions. That migration was a no-op.
+ALTER ROLE authenticator SET session_preload_libraries = 'supautils, safeupdate';
+
+-- migrate:down

--- a/migrations/db/migrations/20260413000000_fix-authenticator-session-preload-libraries.sql
+++ b/migrations/db/migrations/20260413000000_fix-authenticator-session-preload-libraries.sql
@@ -3,6 +3,6 @@
 -- The original fix in 20220224211803 checked pg_available_extensions for
 -- supautils, but supautils is a preload library without a .control file,
 -- so it never appears in pg_available_extensions. That migration was a no-op.
-ALTER ROLE authenticator SET session_preload_libraries = 'supautils, safeupdate';
+ALTER ROLE authenticator SET session_preload_libraries = supautils, safeupdate;
 
 -- migrate:down

--- a/nix/tests/expected/roles.out
+++ b/nix/tests/expected/roles.out
@@ -64,7 +64,7 @@ order by rolname;
 ----------------------------+---------------------------------------------------------------------------------
  anon                       | {statement_timeout=3s}
  authenticated              | {statement_timeout=8s}
- authenticator              | {session_preload_libraries=safeupdate,statement_timeout=8s,lock_timeout=8s}
+ authenticator              | {"session_preload_libraries=supautils, safeupdate",statement_timeout=8s,lock_timeout=8s}
  dashboard_user             | 
  pg_checkpoint              | 
  pg_database_owner          | 

--- a/nix/tests/expected/roles.out
+++ b/nix/tests/expected/roles.out
@@ -60,11 +60,11 @@ select
 from pg_roles r
 where rolname not in ('pg_create_subscription', 'pg_maintain', 'pg_use_reserved_connections')
 order by rolname;
-          rolname           |                                          rolconfig                                           
-----------------------------+----------------------------------------------------------------------------------------------
+          rolname           |                                        rolconfig                                         
+----------------------------+------------------------------------------------------------------------------------------
  anon                       | {statement_timeout=3s}
  authenticated              | {statement_timeout=8s}
- authenticator              | {"session_preload_libraries=\"supautils, safeupdate\"",statement_timeout=8s,lock_timeout=8s}
+ authenticator              | {"session_preload_libraries=supautils, safeupdate",statement_timeout=8s,lock_timeout=8s}
  dashboard_user             | 
  pg_checkpoint              | 
  pg_database_owner          | 

--- a/nix/tests/expected/roles.out
+++ b/nix/tests/expected/roles.out
@@ -60,11 +60,11 @@ select
 from pg_roles r
 where rolname not in ('pg_create_subscription', 'pg_maintain', 'pg_use_reserved_connections')
 order by rolname;
-          rolname           |                                    rolconfig                                    
-----------------------------+---------------------------------------------------------------------------------
+          rolname           |                                          rolconfig                                           
+----------------------------+----------------------------------------------------------------------------------------------
  anon                       | {statement_timeout=3s}
  authenticated              | {statement_timeout=8s}
- authenticator              | {"session_preload_libraries=supautils, safeupdate",statement_timeout=8s,lock_timeout=8s}
+ authenticator              | {"session_preload_libraries=\"supautils, safeupdate\"",statement_timeout=8s,lock_timeout=8s}
  dashboard_user             | 
  pg_checkpoint              | 
  pg_database_owner          | 

--- a/nix/tests/expected/z_multigres-orioledb-17_roles.out
+++ b/nix/tests/expected/z_multigres-orioledb-17_roles.out
@@ -61,7 +61,7 @@ order by rolname;
 ----------------------------+---------------------------------------------------------------------------------
  anon                       | {statement_timeout=3s}
  authenticated              | {statement_timeout=8s}
- authenticator              | {session_preload_libraries=safeupdate,statement_timeout=8s,lock_timeout=8s}
+ authenticator              | {"session_preload_libraries=supautils, safeupdate",statement_timeout=8s,lock_timeout=8s}
  dashboard_user             | 
  pg_checkpoint              | 
  pg_database_owner          | 

--- a/nix/tests/expected/z_multigres-orioledb-17_roles.out
+++ b/nix/tests/expected/z_multigres-orioledb-17_roles.out
@@ -57,11 +57,11 @@ select
 from pg_roles r
 where rolname not in ('pg_create_subscription', 'pg_maintain', 'pg_use_reserved_connections')
 order by rolname;
-          rolname           |                                          rolconfig                                           
-----------------------------+----------------------------------------------------------------------------------------------
+          rolname           |                                        rolconfig                                         
+----------------------------+------------------------------------------------------------------------------------------
  anon                       | {statement_timeout=3s}
  authenticated              | {statement_timeout=8s}
- authenticator              | {"session_preload_libraries=\"supautils, safeupdate\"",statement_timeout=8s,lock_timeout=8s}
+ authenticator              | {"session_preload_libraries=supautils, safeupdate",statement_timeout=8s,lock_timeout=8s}
  dashboard_user             | 
  pg_checkpoint              | 
  pg_database_owner          | 

--- a/nix/tests/expected/z_multigres-orioledb-17_roles.out
+++ b/nix/tests/expected/z_multigres-orioledb-17_roles.out
@@ -57,11 +57,11 @@ select
 from pg_roles r
 where rolname not in ('pg_create_subscription', 'pg_maintain', 'pg_use_reserved_connections')
 order by rolname;
-          rolname           |                                    rolconfig                                    
-----------------------------+---------------------------------------------------------------------------------
+          rolname           |                                          rolconfig                                           
+----------------------------+----------------------------------------------------------------------------------------------
  anon                       | {statement_timeout=3s}
  authenticated              | {statement_timeout=8s}
- authenticator              | {"session_preload_libraries=supautils, safeupdate",statement_timeout=8s,lock_timeout=8s}
+ authenticator              | {"session_preload_libraries=\"supautils, safeupdate\"",statement_timeout=8s,lock_timeout=8s}
  dashboard_user             | 
  pg_checkpoint              | 
  pg_database_owner          | 


### PR DESCRIPTION
## Summary

- The original migration (20220224211803) checked pg_available_extensions for supautils, but supautils is a preload library without a .control file, so it never appears in pg_available_extensions. That migration was effectively a no-op.
- This adds a new migration that sets session_preload_libraries to include both supautils and safeupdate for the authenticator role.
- Updates expected test output to reflect the corrected session_preload_libraries value.