### PR TITLE
feat: add tmux to base image and auto-launch it

### DIFF
--- a/ansible/files/tmux.conf.j2
+++ b/ansible/files/tmux.conf.j2
@@ -1,0 +1,64 @@
+# Keep the default prefix
+set-option -g prefix C-b
+
+# Add Ctrl-a as a second prefix
+set-option -g prefix2 C-a
+
+# Ensure that pressing Ctrl-a twice sends the prefix to the inner application
+# (Useful for nested tmux sessions or programs that use Ctrl-a)
+bind-key C-a send-prefix -2
+
+# split panes using | and -
+bind | split-window -h
+bind - split-window -v
+
+# switch panes using Alt-arrow without prefix
+bind -n M-Left select-pane -L
+bind -n M-Right select-pane -R
+bind -n M-Up select-pane -U
+bind -n M-Down select-pane -D
+
+# Enable mouse control (clickable windows, panes, resizable panes)
+set -g mouse on
+
+# DESIGN TWEAKS
+
+# don't do anything when a 'bell' rings
+set -g visual-activity off
+set -g visual-bell off
+set -g visual-silence off
+setw -g monitor-activity off
+set -g bell-action none
+
+# clock mode
+setw -g clock-mode-colour yellow
+
+# copy mode
+setw -g mode-style 'fg=black bg=red bold'
+
+# panes
+set -g pane-border-style 'fg=red'
+set -g pane-active-border-style 'fg=yellow'
+
+# statusbar
+set -g status-position bottom
+set -g status-justify left
+set -g status-style 'fg=red'
+
+set -g status-left ''
+set -g status-left-length 10
+
+set -g status-right-style 'fg=black bg=yellow'
+set -g status-right '%Y-%m-%d %H:%M '
+set -g status-right-length 50
+
+setw -g window-status-current-style 'fg=black bg=red'
+setw -g window-status-current-format ' #I #W #F '
+
+setw -g window-status-style 'fg=red bg=black'
+setw -g window-status-format ' #I #[fg=white]#W #[fg=yellow]#F '
+
+setw -g window-status-bell-style 'fg=yellow bg=red bold'
+
+# messages
+set -g message-style 'fg=yellow bg=red bold'

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -29,6 +29,9 @@
     - name: Install tuned
       import_tasks: tasks/setup-tuned.yml
 
+    - name: Install tmux
+      import_tasks: tasks/setup-tmux.yml
+
     - name: Install Postgres from source
       import_tasks: tasks/setup-postgres.yml
 

--- a/ansible/tasks/setup-tmux.yml
+++ b/ansible/tasks/setup-tmux.yml
@@ -8,9 +8,9 @@
 - name: tmux - Configure shell auto-logout
   ansible.builtin.copy:
     content: |
-case "$-" in
-  *i*) export TMOUT=600 ;;
-esac
+      case "$-" in
+        *i*) export TMOUT=600 ;;
+      esac
     dest: '/etc/profile.d/11-shell_timeout.sh'
     group: 'root'
     mode: '0644'
@@ -29,14 +29,14 @@ esac
 - name: tmux - Auto-launch tmux as needed
   ansible.builtin.copy:
     content: |
-case "$-" in
-  *i*)
-    case "$TERM" in
-      tmux*) ;;
-      *) tmux new-session -A -s supa ;;
-    esac
-    ;;
-esac
+      case "$-" in
+        *i*)
+          case "$TERM" in
+            tmux*) ;;
+            *) tmux new-session -A -s supa ;;
+          esac
+          ;;
+      esac
     dest: '/etc/profile.d/12-tmux.sh'
     group: 'root'
     mode: '0644'

--- a/ansible/tasks/setup-tmux.yml
+++ b/ansible/tasks/setup-tmux.yml
@@ -1,0 +1,33 @@
+- name: tmux - Install tmux
+  ansible.builtin.apt:
+    name: 'tmux'
+    state: 'present'
+    update_cache: true
+  become: true
+
+- name: tmux - Configure shell auto-logout
+  ansible.builtin.copy:
+    content: 'export TMOUT=600'
+    dest: '/etc/profile.d/11-shell_timeout.sh'
+    group: 'root'
+    mode: '0644'
+    owner: 'root'
+  become: true
+
+- name: tmux - Configure tmux
+  ansible.builtin.template:
+    dest: '/etc/tmux.conf'
+    group: 'root'
+    mode: '0644'
+    owner: 'root'
+    src: 'tmux.conf.j2'
+  become: true
+
+- name: tmux - Auto-launch tmux as needed
+  ansible.builtin.copy:
+    content: '[[ $- == *i* ]] && [[ $TERM == tmux* ]] || tmux'
+    dest: '/etc/profile.d/12-tmux.sh'
+    group: 'root'
+    mode: '0644'
+    owner: 'root'
+  become: true

--- a/ansible/tasks/setup-tmux.yml
+++ b/ansible/tasks/setup-tmux.yml
@@ -7,7 +7,10 @@
 
 - name: tmux - Configure shell auto-logout
   ansible.builtin.copy:
-    content: 'export TMOUT=600'
+    content: |
+case "$-" in
+  *i*) export TMOUT=600 ;;
+esac
     dest: '/etc/profile.d/11-shell_timeout.sh'
     group: 'root'
     mode: '0644'
@@ -25,7 +28,15 @@
 
 - name: tmux - Auto-launch tmux as needed
   ansible.builtin.copy:
-    content: '[[ $- == *i* ]] && [[ $TERM == tmux* ]] || tmux'
+    content: |
+case "$-" in
+  *i*)
+    case "$TERM" in
+      tmux*) ;;
+      *) tmux new-session -A -s supa ;;
+    esac
+    ;;
+esac
     dest: '/etc/profile.d/12-tmux.sh'
     group: 'root'
     mode: '0644'

--- a/ansible/tasks/setup-tmux.yml
+++ b/ansible/tasks/setup-tmux.yml
@@ -20,7 +20,7 @@
     group: 'root'
     mode: '0644'
     owner: 'root'
-    src: 'tmux.conf.j2'
+    src: 'files/tmux.conf.j2'
   become: true
 
 - name: tmux - Auto-launch tmux as needed

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.064-orioledb"
-  postgres17: "17.6.1.107"
-  postgres15: "15.14.1.107"
+  postgresorioledb-17: "17.6.0.064-orioledb-indata574-1"
+  postgres17: "17.6.1.107-indata574-1"
+  postgres15: "15.14.1.107-indata574-1"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1


### PR DESCRIPTION
## Overview
  This pull request introduces a standardized `tmux` configuration and automated session management for the Supabase infrastructure. It aims to improve operator productivity through a persistent, feature-rich terminal environment while enhancing security via automated shell timeouts.

## Technical Changes
   - New Task: `tasks/setup-tmux.yml`
       - Installs the `tmux` package via `apt`.
       - Session Hardening: Implements a 10-minute idle timeout for all shells by creating `/etc/profile.d/11-shell_timeout.sh` (`TMOUT=600`).
       - Global Configuration: Deploys a customized `/etc/tmux.conf` to ensure a consistent environment for all users.
       - Auto-Invocation: Configures interactive shells to automatically launch `tmux` via `/etc/profile.d/12-tmux.sh`, ensuring persistence across accidental disconnections.

   - New Template: `files/tmux.conf.j2`
       - Dual Prefixes: Enables both `Ctrl-b` (default) and `Ctrl-a` (common preference) for command invocation.
       - Intuitive Navigation: Adds `|` and `-` for vertical and horizontal splits, and `Alt+Arrow` keys for seamless pane switching.
       - Modern UX: Enables mouse support for pane resizing and selection.
       - Aesthetics: Customizes the status bar, pane borders, and clock mode for high visibility.

   - Playbook Integration
       - Registered the new Install tmux task in `playbook.yml`, positioned after system tuning and before database setup.