### PR TITLE
fix(ci): set github token in nix-install-ephemeral

### DIFF
--- a/.github/actions/nix-install-ephemeral/action.yml
+++ b/.github/actions/nix-install-ephemeral/action.yml
@@ -62,6 +62,13 @@ runs:
         echo "/nix/var/nix/profiles/default/bin" >> "$GITHUB_PATH"
         # Source the daemon profile so nix works in this step too
         . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+    - name: Configure Nix with GitHub token
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        echo "access-tokens = github.com=$GH_TOKEN" | sudo tee -a /etc/nix/nix.conf > /dev/null
+        sudo systemctl restart nix-daemon || true
     - name: Print Nix version
       shell: bash
       run: nix --version


### PR DESCRIPTION
dockerhub-release-matrix.yml kept failing because of GitHub API rate limits on the "Get image tag" step - set GITHUB_TOKEN so we don't get rate limited

https://github.com/supabase/postgres/actions/runs/24725291192/job/72326312637
