### PR TITLE
feat: turn pg_graphql off by default for new projects

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -330,7 +330,7 @@ jobs:
           ./bin/psql -p 54322 -h 127.0.0.1 -U supabase_admin -d postgres -v ON_ERROR_STOP=1 -c "\dx" | tee extensions.log
 
           # Check for required extensions
-          for ext in pg_graphql pgcrypto uuid-ossp supabase_vault; do
+          for ext in pgcrypto uuid-ossp supabase_vault; do
             if ! grep -q "$ext" extensions.log; then
               echo "Required extension $ext not found"
               exit 1

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.067-orioledb"
-  postgres17: "17.6.1.110"
-  postgres15: "15.14.1.110"
+  postgresorioledb-17: "17.6.0.065-orioledb-gql-off"
+  postgres17: "17.6.1.108-gql-off"
+  postgres15: "15.14.1.108-gql-off"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.065-orioledb-gql-off"
-  postgres17: "17.6.1.108-gql-off"
-  postgres15: "15.14.1.108-gql-off"
+  postgresorioledb-17: "17.6.0.068-orioledb"
+  postgres17: "17.6.1.111"
+  postgres15: "15.14.1.111"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1

--- a/migrations/db/migrations/20260421000000_pg_graphql-off-by-default.sql
+++ b/migrations/db/migrations/20260421000000_pg_graphql-off-by-default.sql
@@ -1,0 +1,10 @@
+-- migrate:up
+drop extension if exists pg_graphql;
+
+-- migrate:down
+do $$
+begin
+  if exists (select 1 from pg_available_extensions where name = 'pg_graphql') then
+    create extension if not exists pg_graphql;
+  end if;
+end $$;

--- a/migrations/db/migrations/20260421000000_pg_graphql-off-by-default.sql
+++ b/migrations/db/migrations/20260421000000_pg_graphql-off-by-default.sql
@@ -2,9 +2,3 @@
 drop extension if exists pg_graphql;
 
 -- migrate:down
-do $$
-begin
-  if exists (select 1 from pg_available_extensions where name = 'pg_graphql') then
-    create extension if not exists pg_graphql;
-  end if;
-end $$;

--- a/migrations/db/migrations/20260421000001_rescope_pg_graphql_access_trigger.sql
+++ b/migrations/db/migrations/20260421000001_rescope_pg_graphql_access_trigger.sql
@@ -1,0 +1,52 @@
+-- migrate:up
+
+create or replace function extensions.grant_pg_graphql_access()
+    returns event_trigger
+    language plpgsql
+as $func$
+begin
+    if not exists (
+        select 1
+        from pg_event_trigger_ddl_commands() ev
+        join pg_catalog.pg_extension e on ev.objid = e.oid
+        where e.extname = 'pg_graphql'
+    ) then
+        return;
+    end if;
+
+    drop function if exists graphql_public.graphql;
+    create or replace function graphql_public.graphql(
+        "operationName" text default null,
+        query text default null,
+        variables jsonb default null,
+        extensions jsonb default null
+    )
+        returns jsonb
+        language sql
+    as $$
+        select graphql.resolve(
+            query := query,
+            variables := coalesce(variables, '{}'),
+            "operationName" := "operationName",
+            extensions := extensions
+        );
+    $$;
+
+    -- Attach the wrapper to the extension so DROP EXTENSION cascades to it,
+    -- which in turn triggers set_graphql_placeholder to reinstall the "not enabled" stub.
+    alter extension pg_graphql add function graphql_public.graphql(text, text, jsonb, jsonb);
+
+    grant usage on schema graphql to postgres, anon, authenticated, service_role;
+    grant execute on function graphql.resolve to postgres, anon, authenticated, service_role;
+    grant usage on schema graphql to postgres with grant option;
+    grant usage on schema graphql_public to postgres with grant option;
+end;
+$func$;
+
+drop event trigger if exists issue_pg_graphql_access;
+create event trigger issue_pg_graphql_access
+    on ddl_command_end
+    when tag in ('CREATE EXTENSION')
+    execute procedure extensions.grant_pg_graphql_access();
+
+-- migrate:down

--- a/migrations/schema-15.sql
+++ b/migrations/schema-15.sql
@@ -75,20 +75,6 @@ CREATE SCHEMA vault;
 
 
 --
--- Name: pg_graphql; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS pg_graphql WITH SCHEMA graphql;
-
-
---
--- Name: EXTENSION pg_graphql; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION pg_graphql IS 'pg_graphql: GraphQL support';
-
-
---
 -- Name: pg_stat_statements; Type: EXTENSION; Schema: -; Owner: -
 --
 
@@ -228,54 +214,43 @@ COMMENT ON FUNCTION extensions.grant_pg_cron_access() IS 'Grants access to pg_cr
 CREATE FUNCTION extensions.grant_pg_graphql_access() RETURNS event_trigger
     LANGUAGE plpgsql
     AS $_$
-DECLARE
-    func_is_graphql_resolve bool;
-BEGIN
-    func_is_graphql_resolve = (
-        SELECT n.proname = 'resolve'
-        FROM pg_event_trigger_ddl_commands() AS ev
-        LEFT JOIN pg_catalog.pg_proc AS n
-        ON ev.objid = n.oid
-    );
+begin
+    if not exists (
+        select 1
+        from pg_event_trigger_ddl_commands() ev
+        join pg_catalog.pg_extension e on ev.objid = e.oid
+        where e.extname = 'pg_graphql'
+    ) then
+        return;
+    end if;
 
-    IF func_is_graphql_resolve
-    THEN
-        -- Update public wrapper to pass all arguments through to the pg_graphql resolve func
-        DROP FUNCTION IF EXISTS graphql_public.graphql;
-        create or replace function graphql_public.graphql(
-            "operationName" text default null,
-            query text default null,
-            variables jsonb default null,
-            extensions jsonb default null
-        )
-            returns jsonb
-            language sql
-        as $$
-            select graphql.resolve(
-                query := query,
-                variables := coalesce(variables, '{}'),
-                "operationName" := "operationName",
-                extensions := extensions
-            );
-        $$;
+    drop function if exists graphql_public.graphql;
+    create or replace function graphql_public.graphql(
+        "operationName" text default null,
+        query text default null,
+        variables jsonb default null,
+        extensions jsonb default null
+    )
+        returns jsonb
+        language sql
+    as $$
+        select graphql.resolve(
+            query := query,
+            variables := coalesce(variables, '{}'),
+            "operationName" := "operationName",
+            extensions := extensions
+        );
+    $$;
 
-        -- This hook executes when `graphql.resolve` is created. That is not necessarily the last
-        -- function in the extension so we need to grant permissions on existing entities AND
-        -- update default permissions to any others that are created after `graphql.resolve`
-        grant usage on schema graphql to postgres, anon, authenticated, service_role;
-        grant select on all tables in schema graphql to postgres, anon, authenticated, service_role;
-        grant execute on all functions in schema graphql to postgres, anon, authenticated, service_role;
-        grant all on all sequences in schema graphql to postgres, anon, authenticated, service_role;
-        alter default privileges in schema graphql grant all on tables to postgres, anon, authenticated, service_role;
-        alter default privileges in schema graphql grant all on functions to postgres, anon, authenticated, service_role;
-        alter default privileges in schema graphql grant all on sequences to postgres, anon, authenticated, service_role;
+    -- Attach the wrapper to the extension so DROP EXTENSION cascades to it,
+    -- which in turn triggers set_graphql_placeholder to reinstall the "not enabled" stub.
+    alter extension pg_graphql add function graphql_public.graphql(text, text, jsonb, jsonb);
 
-        -- Allow postgres role to allow granting usage on graphql and graphql_public schemas to custom roles
-        grant usage on schema graphql_public to postgres with grant option;
-        grant usage on schema graphql to postgres with grant option;
-    END IF;
-
-END;
+    grant usage on schema graphql to postgres, anon, authenticated, service_role;
+    grant execute on function graphql.resolve to postgres, anon, authenticated, service_role;
+    grant usage on schema graphql to postgres with grant option;
+    grant usage on schema graphql_public to postgres with grant option;
+end;
 $_$;
 
 
@@ -470,6 +445,39 @@ $_$;
 --
 
 COMMENT ON FUNCTION extensions.set_graphql_placeholder() IS 'Reintroduces placeholder function for graphql_public.graphql';
+
+
+--
+-- Name: graphql(text, text, jsonb, jsonb); Type: FUNCTION; Schema: graphql_public; Owner: -
+--
+
+CREATE FUNCTION graphql_public.graphql("operationName" text DEFAULT NULL::text, query text DEFAULT NULL::text, variables jsonb DEFAULT NULL::jsonb, extensions jsonb DEFAULT NULL::jsonb) RETURNS jsonb
+    LANGUAGE plpgsql
+    AS $$
+            DECLARE
+                server_version float;
+            BEGIN
+                server_version = (SELECT (SPLIT_PART((select version()), ' ', 2))::float);
+
+                IF server_version >= 14 THEN
+                    RETURN jsonb_build_object(
+                        'errors', jsonb_build_array(
+                            jsonb_build_object(
+                                'message', 'pg_graphql extension is not enabled.'
+                            )
+                        )
+                    );
+                ELSE
+                    RETURN jsonb_build_object(
+                        'errors', jsonb_build_array(
+                            jsonb_build_object(
+                                'message', 'pg_graphql is only available on projects running Postgres 14 onwards.'
+                            )
+                        )
+                    );
+                END IF;
+            END;
+        $$;
 
 
 --
@@ -776,7 +784,7 @@ CREATE EVENT TRIGGER issue_pg_cron_access ON ddl_command_end
 --
 
 CREATE EVENT TRIGGER issue_pg_graphql_access ON ddl_command_end
-         WHEN TAG IN ('CREATE FUNCTION')
+         WHEN TAG IN ('CREATE EXTENSION')
    EXECUTE FUNCTION extensions.grant_pg_graphql_access();
 
 

--- a/migrations/schema-17.sql
+++ b/migrations/schema-17.sql
@@ -76,20 +76,6 @@ CREATE SCHEMA vault;
 
 
 --
--- Name: pg_graphql; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS pg_graphql WITH SCHEMA graphql;
-
-
---
--- Name: EXTENSION pg_graphql; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION pg_graphql IS 'pg_graphql: GraphQL support';
-
-
---
 -- Name: pg_stat_statements; Type: EXTENSION; Schema: -; Owner: -
 --
 
@@ -229,54 +215,43 @@ COMMENT ON FUNCTION extensions.grant_pg_cron_access() IS 'Grants access to pg_cr
 CREATE FUNCTION extensions.grant_pg_graphql_access() RETURNS event_trigger
     LANGUAGE plpgsql
     AS $_$
-DECLARE
-    func_is_graphql_resolve bool;
-BEGIN
-    func_is_graphql_resolve = (
-        SELECT n.proname = 'resolve'
-        FROM pg_event_trigger_ddl_commands() AS ev
-        LEFT JOIN pg_catalog.pg_proc AS n
-        ON ev.objid = n.oid
-    );
+begin
+    if not exists (
+        select 1
+        from pg_event_trigger_ddl_commands() ev
+        join pg_catalog.pg_extension e on ev.objid = e.oid
+        where e.extname = 'pg_graphql'
+    ) then
+        return;
+    end if;
 
-    IF func_is_graphql_resolve
-    THEN
-        -- Update public wrapper to pass all arguments through to the pg_graphql resolve func
-        DROP FUNCTION IF EXISTS graphql_public.graphql;
-        create or replace function graphql_public.graphql(
-            "operationName" text default null,
-            query text default null,
-            variables jsonb default null,
-            extensions jsonb default null
-        )
-            returns jsonb
-            language sql
-        as $$
-            select graphql.resolve(
-                query := query,
-                variables := coalesce(variables, '{}'),
-                "operationName" := "operationName",
-                extensions := extensions
-            );
-        $$;
+    drop function if exists graphql_public.graphql;
+    create or replace function graphql_public.graphql(
+        "operationName" text default null,
+        query text default null,
+        variables jsonb default null,
+        extensions jsonb default null
+    )
+        returns jsonb
+        language sql
+    as $$
+        select graphql.resolve(
+            query := query,
+            variables := coalesce(variables, '{}'),
+            "operationName" := "operationName",
+            extensions := extensions
+        );
+    $$;
 
-        -- This hook executes when `graphql.resolve` is created. That is not necessarily the last
-        -- function in the extension so we need to grant permissions on existing entities AND
-        -- update default permissions to any others that are created after `graphql.resolve`
-        grant usage on schema graphql to postgres, anon, authenticated, service_role;
-        grant select on all tables in schema graphql to postgres, anon, authenticated, service_role;
-        grant execute on all functions in schema graphql to postgres, anon, authenticated, service_role;
-        grant all on all sequences in schema graphql to postgres, anon, authenticated, service_role;
-        alter default privileges in schema graphql grant all on tables to postgres, anon, authenticated, service_role;
-        alter default privileges in schema graphql grant all on functions to postgres, anon, authenticated, service_role;
-        alter default privileges in schema graphql grant all on sequences to postgres, anon, authenticated, service_role;
+    -- Attach the wrapper to the extension so DROP EXTENSION cascades to it,
+    -- which in turn triggers set_graphql_placeholder to reinstall the "not enabled" stub.
+    alter extension pg_graphql add function graphql_public.graphql(text, text, jsonb, jsonb);
 
-        -- Allow postgres role to allow granting usage on graphql and graphql_public schemas to custom roles
-        grant usage on schema graphql_public to postgres with grant option;
-        grant usage on schema graphql to postgres with grant option;
-    END IF;
-
-END;
+    grant usage on schema graphql to postgres, anon, authenticated, service_role;
+    grant execute on function graphql.resolve to postgres, anon, authenticated, service_role;
+    grant usage on schema graphql to postgres with grant option;
+    grant usage on schema graphql_public to postgres with grant option;
+end;
 $_$;
 
 
@@ -471,6 +446,39 @@ $_$;
 --
 
 COMMENT ON FUNCTION extensions.set_graphql_placeholder() IS 'Reintroduces placeholder function for graphql_public.graphql';
+
+
+--
+-- Name: graphql(text, text, jsonb, jsonb); Type: FUNCTION; Schema: graphql_public; Owner: -
+--
+
+CREATE FUNCTION graphql_public.graphql("operationName" text DEFAULT NULL::text, query text DEFAULT NULL::text, variables jsonb DEFAULT NULL::jsonb, extensions jsonb DEFAULT NULL::jsonb) RETURNS jsonb
+    LANGUAGE plpgsql
+    AS $$
+            DECLARE
+                server_version float;
+            BEGIN
+                server_version = (SELECT (SPLIT_PART((select version()), ' ', 2))::float);
+
+                IF server_version >= 14 THEN
+                    RETURN jsonb_build_object(
+                        'errors', jsonb_build_array(
+                            jsonb_build_object(
+                                'message', 'pg_graphql extension is not enabled.'
+                            )
+                        )
+                    );
+                ELSE
+                    RETURN jsonb_build_object(
+                        'errors', jsonb_build_array(
+                            jsonb_build_object(
+                                'message', 'pg_graphql is only available on projects running Postgres 14 onwards.'
+                            )
+                        )
+                    );
+                END IF;
+            END;
+        $$;
 
 
 --
@@ -777,7 +785,7 @@ CREATE EVENT TRIGGER issue_pg_cron_access ON ddl_command_end
 --
 
 CREATE EVENT TRIGGER issue_pg_graphql_access ON ddl_command_end
-         WHEN TAG IN ('CREATE FUNCTION')
+         WHEN TAG IN ('CREATE EXTENSION')
    EXECUTE FUNCTION extensions.grant_pg_graphql_access();
 
 

--- a/migrations/schema-orioledb-17.sql
+++ b/migrations/schema-orioledb-17.sql
@@ -90,20 +90,6 @@ COMMENT ON EXTENSION orioledb IS 'OrioleDB -- the next generation transactional 
 
 
 --
--- Name: pg_graphql; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS pg_graphql WITH SCHEMA graphql;
-
-
---
--- Name: EXTENSION pg_graphql; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION pg_graphql IS 'pg_graphql: GraphQL support';
-
-
---
 -- Name: pg_stat_statements; Type: EXTENSION; Schema: -; Owner: -
 --
 
@@ -243,54 +229,43 @@ COMMENT ON FUNCTION extensions.grant_pg_cron_access() IS 'Grants access to pg_cr
 CREATE FUNCTION extensions.grant_pg_graphql_access() RETURNS event_trigger
     LANGUAGE plpgsql
     AS $_$
-DECLARE
-    func_is_graphql_resolve bool;
-BEGIN
-    func_is_graphql_resolve = (
-        SELECT n.proname = 'resolve'
-        FROM pg_event_trigger_ddl_commands() AS ev
-        LEFT JOIN pg_catalog.pg_proc AS n
-        ON ev.objid = n.oid
-    );
+begin
+    if not exists (
+        select 1
+        from pg_event_trigger_ddl_commands() ev
+        join pg_catalog.pg_extension e on ev.objid = e.oid
+        where e.extname = 'pg_graphql'
+    ) then
+        return;
+    end if;
 
-    IF func_is_graphql_resolve
-    THEN
-        -- Update public wrapper to pass all arguments through to the pg_graphql resolve func
-        DROP FUNCTION IF EXISTS graphql_public.graphql;
-        create or replace function graphql_public.graphql(
-            "operationName" text default null,
-            query text default null,
-            variables jsonb default null,
-            extensions jsonb default null
-        )
-            returns jsonb
-            language sql
-        as $$
-            select graphql.resolve(
-                query := query,
-                variables := coalesce(variables, '{}'),
-                "operationName" := "operationName",
-                extensions := extensions
-            );
-        $$;
+    drop function if exists graphql_public.graphql;
+    create or replace function graphql_public.graphql(
+        "operationName" text default null,
+        query text default null,
+        variables jsonb default null,
+        extensions jsonb default null
+    )
+        returns jsonb
+        language sql
+    as $$
+        select graphql.resolve(
+            query := query,
+            variables := coalesce(variables, '{}'),
+            "operationName" := "operationName",
+            extensions := extensions
+        );
+    $$;
 
-        -- This hook executes when `graphql.resolve` is created. That is not necessarily the last
-        -- function in the extension so we need to grant permissions on existing entities AND
-        -- update default permissions to any others that are created after `graphql.resolve`
-        grant usage on schema graphql to postgres, anon, authenticated, service_role;
-        grant select on all tables in schema graphql to postgres, anon, authenticated, service_role;
-        grant execute on all functions in schema graphql to postgres, anon, authenticated, service_role;
-        grant all on all sequences in schema graphql to postgres, anon, authenticated, service_role;
-        alter default privileges in schema graphql grant all on tables to postgres, anon, authenticated, service_role;
-        alter default privileges in schema graphql grant all on functions to postgres, anon, authenticated, service_role;
-        alter default privileges in schema graphql grant all on sequences to postgres, anon, authenticated, service_role;
+    -- Attach the wrapper to the extension so DROP EXTENSION cascades to it,
+    -- which in turn triggers set_graphql_placeholder to reinstall the "not enabled" stub.
+    alter extension pg_graphql add function graphql_public.graphql(text, text, jsonb, jsonb);
 
-        -- Allow postgres role to allow granting usage on graphql and graphql_public schemas to custom roles
-        grant usage on schema graphql_public to postgres with grant option;
-        grant usage on schema graphql to postgres with grant option;
-    END IF;
-
-END;
+    grant usage on schema graphql to postgres, anon, authenticated, service_role;
+    grant execute on function graphql.resolve to postgres, anon, authenticated, service_role;
+    grant usage on schema graphql to postgres with grant option;
+    grant usage on schema graphql_public to postgres with grant option;
+end;
 $_$;
 
 
@@ -485,6 +460,39 @@ $_$;
 --
 
 COMMENT ON FUNCTION extensions.set_graphql_placeholder() IS 'Reintroduces placeholder function for graphql_public.graphql';
+
+
+--
+-- Name: graphql(text, text, jsonb, jsonb); Type: FUNCTION; Schema: graphql_public; Owner: -
+--
+
+CREATE FUNCTION graphql_public.graphql("operationName" text DEFAULT NULL::text, query text DEFAULT NULL::text, variables jsonb DEFAULT NULL::jsonb, extensions jsonb DEFAULT NULL::jsonb) RETURNS jsonb
+    LANGUAGE plpgsql
+    AS $$
+            DECLARE
+                server_version float;
+            BEGIN
+                server_version = (SELECT (SPLIT_PART((select version()), ' ', 2))::float);
+
+                IF server_version >= 14 THEN
+                    RETURN jsonb_build_object(
+                        'errors', jsonb_build_array(
+                            jsonb_build_object(
+                                'message', 'pg_graphql extension is not enabled.'
+                            )
+                        )
+                    );
+                ELSE
+                    RETURN jsonb_build_object(
+                        'errors', jsonb_build_array(
+                            jsonb_build_object(
+                                'message', 'pg_graphql is only available on projects running Postgres 14 onwards.'
+                            )
+                        )
+                    );
+                END IF;
+            END;
+        $$;
 
 
 --
@@ -791,7 +799,7 @@ CREATE EVENT TRIGGER issue_pg_cron_access ON ddl_command_end
 --
 
 CREATE EVENT TRIGGER issue_pg_graphql_access ON ddl_command_end
-         WHEN TAG IN ('CREATE FUNCTION')
+         WHEN TAG IN ('CREATE EXTENSION')
    EXECUTE FUNCTION extensions.grant_pg_graphql_access();
 
 

--- a/nix/tests/expected/evtrigs.out
+++ b/nix/tests/expected/evtrigs.out
@@ -9,20 +9,21 @@ join pg_proc p
   on e.evtfoid = p.oid
 join pg_namespace n_func
   on p.pronamespace = n_func.oid
-where p.prorettype = 'event_trigger'::regtype;
+where p.prorettype = 'event_trigger'::regtype
+order by e.evtname;
                 evtname                 |    evtowner    | evtfunction_schema |            evtfunction             | function_owner 
 ----------------------------------------+----------------+--------------------+------------------------------------+----------------
- issue_graphql_placeholder              | supabase_admin | extensions         | set_graphql_placeholder            | supabase_admin
- pgrst_ddl_watch                        | supabase_admin | extensions         | pgrst_ddl_watch                    | supabase_admin
- pgrst_drop_watch                       | supabase_admin | extensions         | pgrst_drop_watch                   | supabase_admin
- issue_pg_cron_access                   | supabase_admin | extensions         | grant_pg_cron_access               | supabase_admin
- issue_pg_net_access                    | supabase_admin | extensions         | grant_pg_net_access                | supabase_admin
  graphql_watch_ddl                      | supabase_admin | graphql            | graphql.increment_schema_version   | supabase_admin
  graphql_watch_drop                     | supabase_admin | graphql            | graphql.increment_schema_version   | supabase_admin
+ issue_graphql_placeholder              | supabase_admin | extensions         | set_graphql_placeholder            | supabase_admin
+ issue_pg_cron_access                   | supabase_admin | extensions         | grant_pg_cron_access               | supabase_admin
  issue_pg_graphql_access                | supabase_admin | extensions         | grant_pg_graphql_access            | supabase_admin
+ issue_pg_net_access                    | supabase_admin | extensions         | grant_pg_net_access                | supabase_admin
  pg_tle_event_trigger_for_drop_function | supabase_admin | pgtle              | pgtle.pg_tle_feature_info_sql_drop | supabase_admin
  pgaudit_ddl_command_end                | supabase_admin | public             | pgaudit_ddl_command_end            | supabase_admin
  pgaudit_sql_drop                       | supabase_admin | public             | pgaudit_sql_drop                   | supabase_admin
+ pgrst_ddl_watch                        | supabase_admin | extensions         | pgrst_ddl_watch                    | supabase_admin
+ pgrst_drop_watch                       | supabase_admin | extensions         | pgrst_drop_watch                   | supabase_admin
  pgsodium_trg_mask_update               | supabase_admin | pgsodium           | pgsodium.trg_mask_update           | supabase_admin
 (12 rows)
 

--- a/nix/tests/expected/evtrigs.out
+++ b/nix/tests/expected/evtrigs.out
@@ -12,14 +12,14 @@ join pg_namespace n_func
 where p.prorettype = 'event_trigger'::regtype;
                 evtname                 |    evtowner    | evtfunction_schema |            evtfunction             | function_owner 
 ----------------------------------------+----------------+--------------------+------------------------------------+----------------
- issue_pg_graphql_access                | supabase_admin | extensions         | grant_pg_graphql_access            | supabase_admin
  issue_graphql_placeholder              | supabase_admin | extensions         | set_graphql_placeholder            | supabase_admin
  pgrst_ddl_watch                        | supabase_admin | extensions         | pgrst_ddl_watch                    | supabase_admin
  pgrst_drop_watch                       | supabase_admin | extensions         | pgrst_drop_watch                   | supabase_admin
- graphql_watch_ddl                      | supabase_admin | graphql            | graphql.increment_schema_version   | supabase_admin
- graphql_watch_drop                     | supabase_admin | graphql            | graphql.increment_schema_version   | supabase_admin
  issue_pg_cron_access                   | supabase_admin | extensions         | grant_pg_cron_access               | supabase_admin
  issue_pg_net_access                    | supabase_admin | extensions         | grant_pg_net_access                | supabase_admin
+ graphql_watch_ddl                      | supabase_admin | graphql            | graphql.increment_schema_version   | supabase_admin
+ graphql_watch_drop                     | supabase_admin | graphql            | graphql.increment_schema_version   | supabase_admin
+ issue_pg_graphql_access                | supabase_admin | extensions         | grant_pg_graphql_access            | supabase_admin
  pg_tle_event_trigger_for_drop_function | supabase_admin | pgtle              | pgtle.pg_tle_feature_info_sql_drop | supabase_admin
  pgaudit_ddl_command_end                | supabase_admin | public             | pgaudit_ddl_command_end            | supabase_admin
  pgaudit_sql_drop                       | supabase_admin | public             | pgaudit_sql_drop                   | supabase_admin

--- a/nix/tests/expected/z_multigres-17_evtrigs.out
+++ b/nix/tests/expected/z_multigres-17_evtrigs.out
@@ -17,9 +17,9 @@ where p.prorettype = 'event_trigger'::regtype;
  pgrst_drop_watch                       | supabase_admin | extensions         | pgrst_drop_watch                   | supabase_admin
  issue_pg_cron_access                   | supabase_admin | extensions         | grant_pg_cron_access               | supabase_admin
  issue_pg_net_access                    | supabase_admin | extensions         | grant_pg_net_access                | supabase_admin
+ issue_pg_graphql_access                | supabase_admin | extensions         | grant_pg_graphql_access            | supabase_admin
  graphql_watch_ddl                      | supabase_admin | graphql            | graphql.increment_schema_version   | supabase_admin
  graphql_watch_drop                     | supabase_admin | graphql            | graphql.increment_schema_version   | supabase_admin
- issue_pg_graphql_access                | supabase_admin | extensions         | grant_pg_graphql_access            | supabase_admin
  pgaudit_ddl_command_end                | supabase_admin | public             | pgaudit_ddl_command_end            | supabase_admin
  pgaudit_sql_drop                       | supabase_admin | public             | pgaudit_sql_drop                   | supabase_admin
  pg_tle_event_trigger_for_drop_function | supabase_admin | pgtle              | pgtle.pg_tle_feature_info_sql_drop | supabase_admin

--- a/nix/tests/expected/z_multigres-17_evtrigs.out
+++ b/nix/tests/expected/z_multigres-17_evtrigs.out
@@ -12,14 +12,14 @@ join pg_namespace n_func
 where p.prorettype = 'event_trigger'::regtype;
                 evtname                 |    evtowner    | evtfunction_schema |            evtfunction             | function_owner 
 ----------------------------------------+----------------+--------------------+------------------------------------+----------------
- issue_pg_graphql_access                | supabase_admin | extensions         | grant_pg_graphql_access            | supabase_admin
  issue_graphql_placeholder              | supabase_admin | extensions         | set_graphql_placeholder            | supabase_admin
  pgrst_ddl_watch                        | supabase_admin | extensions         | pgrst_ddl_watch                    | supabase_admin
  pgrst_drop_watch                       | supabase_admin | extensions         | pgrst_drop_watch                   | supabase_admin
- graphql_watch_ddl                      | supabase_admin | graphql            | graphql.increment_schema_version   | supabase_admin
- graphql_watch_drop                     | supabase_admin | graphql            | graphql.increment_schema_version   | supabase_admin
  issue_pg_cron_access                   | supabase_admin | extensions         | grant_pg_cron_access               | supabase_admin
  issue_pg_net_access                    | supabase_admin | extensions         | grant_pg_net_access                | supabase_admin
+ graphql_watch_ddl                      | supabase_admin | graphql            | graphql.increment_schema_version   | supabase_admin
+ graphql_watch_drop                     | supabase_admin | graphql            | graphql.increment_schema_version   | supabase_admin
+ issue_pg_graphql_access                | supabase_admin | extensions         | grant_pg_graphql_access            | supabase_admin
  pgaudit_ddl_command_end                | supabase_admin | public             | pgaudit_ddl_command_end            | supabase_admin
  pgaudit_sql_drop                       | supabase_admin | public             | pgaudit_sql_drop                   | supabase_admin
  pg_tle_event_trigger_for_drop_function | supabase_admin | pgtle              | pgtle.pg_tle_feature_info_sql_drop | supabase_admin

--- a/nix/tests/expected/z_multigres-orioledb-17_evtrigs.out
+++ b/nix/tests/expected/z_multigres-orioledb-17_evtrigs.out
@@ -17,9 +17,9 @@ where p.prorettype = 'event_trigger'::regtype;
  pgrst_drop_watch                       | supabase_admin | extensions         | pgrst_drop_watch                   | supabase_admin
  issue_pg_cron_access                   | supabase_admin | extensions         | grant_pg_cron_access               | supabase_admin
  issue_pg_net_access                    | supabase_admin | extensions         | grant_pg_net_access                | supabase_admin
+ issue_pg_graphql_access                | supabase_admin | extensions         | grant_pg_graphql_access            | supabase_admin
  graphql_watch_ddl                      | supabase_admin | graphql            | graphql.increment_schema_version   | supabase_admin
  graphql_watch_drop                     | supabase_admin | graphql            | graphql.increment_schema_version   | supabase_admin
- issue_pg_graphql_access                | supabase_admin | extensions         | grant_pg_graphql_access            | supabase_admin
  pgaudit_ddl_command_end                | supabase_admin | public             | pgaudit_ddl_command_end            | supabase_admin
  pgaudit_sql_drop                       | supabase_admin | public             | pgaudit_sql_drop                   | supabase_admin
  pg_tle_event_trigger_for_drop_function | supabase_admin | pgtle              | pgtle.pg_tle_feature_info_sql_drop | supabase_admin

--- a/nix/tests/expected/z_multigres-orioledb-17_evtrigs.out
+++ b/nix/tests/expected/z_multigres-orioledb-17_evtrigs.out
@@ -12,14 +12,14 @@ join pg_namespace n_func
 where p.prorettype = 'event_trigger'::regtype;
                 evtname                 |    evtowner    | evtfunction_schema |            evtfunction             | function_owner 
 ----------------------------------------+----------------+--------------------+------------------------------------+----------------
- issue_pg_graphql_access                | supabase_admin | extensions         | grant_pg_graphql_access            | supabase_admin
  issue_graphql_placeholder              | supabase_admin | extensions         | set_graphql_placeholder            | supabase_admin
  pgrst_ddl_watch                        | supabase_admin | extensions         | pgrst_ddl_watch                    | supabase_admin
  pgrst_drop_watch                       | supabase_admin | extensions         | pgrst_drop_watch                   | supabase_admin
- graphql_watch_ddl                      | supabase_admin | graphql            | graphql.increment_schema_version   | supabase_admin
- graphql_watch_drop                     | supabase_admin | graphql            | graphql.increment_schema_version   | supabase_admin
  issue_pg_cron_access                   | supabase_admin | extensions         | grant_pg_cron_access               | supabase_admin
  issue_pg_net_access                    | supabase_admin | extensions         | grant_pg_net_access                | supabase_admin
+ graphql_watch_ddl                      | supabase_admin | graphql            | graphql.increment_schema_version   | supabase_admin
+ graphql_watch_drop                     | supabase_admin | graphql            | graphql.increment_schema_version   | supabase_admin
+ issue_pg_graphql_access                | supabase_admin | extensions         | grant_pg_graphql_access            | supabase_admin
  pgaudit_ddl_command_end                | supabase_admin | public             | pgaudit_ddl_command_end            | supabase_admin
  pgaudit_sql_drop                       | supabase_admin | public             | pgaudit_sql_drop                   | supabase_admin
  pg_tle_event_trigger_for_drop_function | supabase_admin | pgtle              | pgtle.pg_tle_feature_info_sql_drop | supabase_admin

--- a/nix/tests/sql/evtrigs.sql
+++ b/nix/tests/sql/evtrigs.sql
@@ -9,4 +9,5 @@ join pg_proc p
   on e.evtfoid = p.oid
 join pg_namespace n_func
   on p.pronamespace = n_func.oid
-where p.prorettype = 'event_trigger'::regtype;
+where p.prorettype = 'event_trigger'::regtype
+order by e.evtname;


### PR DESCRIPTION
## Summary

Ships pg_graphql disabled by default on newly-provisioned Postgres instances. Existing projects are unaffected because the new migrations only run on first boot (sentinel-guarded).

## Changes

**New migrations**
- `20260421000000_pg_graphql-off-by-default.sql`: drops `pg_graphql` as the final migration step so new DBs start with the extension off. Down migration recreates it if available.
- `20260421000001_rescope_pg_graphql_access_trigger.sql`: fixes a pre-existing latent bug in the `grant_pg_graphql_access` event trigger. Previously it fired on `CREATE FUNCTION` and ran body logic for any function named `resolve`, causing failures like `ERROR: must be owner of function graphql_public.graphql` for unrelated user code. The trigger now fires on `CREATE EXTENSION` and early-exits unless the extension being created is `pg_graphql`.

**Wrapper attachment fix (inside the rescoped trigger)**
Because `ddl_command_end` fires after extension creation completes, the rebuilt `graphql_public.graphql(...)` wrapper is not in `creating_extension` context and is not an extension member. Without an explicit attach, `DROP EXTENSION` would not cascade to the wrapper and the `set_graphql_placeholder` trigger would not reinstall the "not enabled" stub. Added `ALTER EXTENSION pg_graphql ADD FUNCTION graphql_public.graphql(...)` inside the trigger body to make drop cascades work correctly.

**Schema dumps regenerated**
- `migrations/schema-{15,17,orioledb-17}.sql`: removed `CREATE EXTENSION pg_graphql`, added the standalone placeholder `graphql_public.graphql()`, updated `grant_pg_graphql_access` body, flipped event trigger WHEN TAG from `CREATE FUNCTION` to `CREATE EXTENSION`.

**Test expectations updated**
- `nix/tests/expected/*evtrigs.out`: row reordering only. The event trigger is recreated by the new migration, giving it a new OID and shifting row order in the output. No semantic changes.

**Version bumps**
- `ansible/vars.yml`: postgres releases tagged with `-gql-off` suffix.

## Behavioral verification

Tested locally via psql:
1. Fresh DB boot without pg_graphql, wrapper is the "not enabled" placeholder
2. `CREATE EXTENSION pg_graphql` installs the real wrapper (plpgsql, prolang 13)
3. `DROP EXTENSION pg_graphql` reinstates the placeholder (sql, prolang 14)
4. Re-enable path works
5. Landmine test: `CREATE FUNCTION myapp.resolve(...)` as non-superuser no longer triggers `grant_pg_graphql_access` and does not error

## Scope of impact

- New projects: pg_graphql is off by default; customers who want it run `CREATE EXTENSION pg_graphql`
- Existing projects: unaffected. The infrastructure `run_migrations()` call in `/infrastructure/init-scripts/project/00-init.sh` is sentinel-guarded, so these migrations run only at first boot

## Test plan

- [x] Docker image tests pass (`nix run .#docker-image-test`)
- [x] pg_regress suite passes for all three flavors (pg15, pg17, orioledb-17)
- [x] Smoke test a newly-provisioned project: verify `pg_graphql` is absent until explicitly enabled
- [x] Verify `CREATE EXTENSION pg_graphql` still installs cleanly on a fresh instance
- [x] Verify `DROP EXTENSION pg_graphql` reinstates the placeholder function
- [x] Verify creating a user function named `resolve` no longer triggers the graphql wrapper replacement path