### PR TITLE
fix: ensure apparmor-utils is installed for aa-enforce

### DIFF
--- a/ansible/tasks/setup-postgres.yml
+++ b/ansible/tasks/setup-postgres.yml
@@ -294,6 +294,10 @@
     owner: 'root'
     src: 'files/postgresql_config/sbpostgres_apparmor'
 
+- name: ensure apparmor-utils are installed
+  ansible.builtin.apt:
+    name: apparmor-utils
+
 - name: parse apparmor sbpostgres profile
   ansible.builtin.command:
     cmd: '/usr/sbin/apparmor_parser -r /etc/apparmor.d/sbpostgres'


### PR DESCRIPTION
This unbreaks Qemu images used by v3 projects.

https://github.com/supabase/postgres/actions/runs/24743244028/job/72388189434 has a broken build because of #2087. Add `aa-enable` (via apparmor-utils) to unbreak.

Should be a no-op for regular AMIs.

Tested on an earlier commit: https://github.com/supabase/postgres/actions/runs/24755229641/job/72426938397?pr=2120