### PR TITLE
fix: reset reserved blocks on the data disk after resize

### DIFF
--- a/ansible/files/admin_api_scripts/grow_fs.sh
+++ b/ansible/files/admin_api_scripts/grow_fs.sh
@@ -54,6 +54,12 @@ if [ -b "${XVDH_DEVICE}" ] ; then
     if [[ "${VOLUME_TYPE}" == "data" ]]; then
         resize2fs "${XVDH_DEVICE}"
 
+        # Explicitly reserving 100MiB worth of blocks for the data volume
+        #
+        # This is owned in $GIT_DIR/ebssurrogate/scripts/surrogate-bootstrap-nix.sh
+        RESERVED_DATA_VOLUME_BLOCK_COUNT=$((100 * 1024 * 1024 / 4096))
+        tune2fs -r $RESERVED_DATA_VOLUME_BLOCK_COUNT "${XVDH_DEVICE}"
+
     elif [[ "${VOLUME_TYPE}" == "root" ]] ; then
         PLACEHOLDER_FL=/home/ubuntu/50M_PLACEHOLDER
         rm -f "${PLACEHOLDER_FL}" || true

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.068-orioledb"
-  postgres17: "17.6.1.111"
-  postgres15: "15.14.1.111"
+  postgresorioledb-17: "17.6.0.069-orioledb"
+  postgres17: "17.6.1.112"
+  postgres15: "15.14.1.112"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1

--- a/ebssurrogate/scripts/surrogate-bootstrap-nix.sh
+++ b/ebssurrogate/scripts/surrogate-bootstrap-nix.sh
@@ -201,6 +201,8 @@ function format_and_mount_rootfs {
 	mkfs.ext4 /dev/xvdh
 
 	# Explicitly reserving 100MiB worth of blocks for the data volume
+	#
+	# Any changes here should be propagated to $GIT_DATA_DIR/ansible/files/admin_api_scripts/grow_fs.sh
 	RESERVED_DATA_VOLUME_BLOCK_COUNT=$((100 * 1024 * 1024 / 4096))
 	tune2fs -r $RESERVED_DATA_VOLUME_BLOCK_COUNT /dev/xvdh
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Part of [GENCOMP-36: Fix reserved block scaling issue in grow_fs.sh](https://linear.app/supabase/issue/GENCOMP-36/fix-reserved-block-scaling-issue-in-grow-fssh).

## What is the current behavior?

The reserved filesystem space is set to 150MB when creating the database. However, scaling the disk size up resets the reserved filesystem space back at 10%.

## What is the new behavior?

This modifies grow_fs.sh to reset the reserved filesystem space back to 150MB.

## Additional context

Old docs: https://www.notion.so/supabase/Investigate-increased-used_bytes-space-after-a-filesystem-resize-1025004b775f8050aa8acaf2a8fce448

Scaled empty database: 
<img width="2378" height="764" alt="image" src="https://github.com/user-attachments/assets/7042d146-8fa3-448e-adcd-64223c6cea9d" />
