### PR TITLE
fix: lower default max_slot_wal_keep_size from 4096MB to 512MB

### DIFF
--- a/ansible/files/postgresql_config/postgresql.conf.j2
+++ b/ansible/files/postgresql_config/postgresql.conf.j2
@@ -299,7 +299,7 @@ max_wal_senders = 10		# max number of walsender processes
 max_replication_slots = 5	# max number of replication slots
 				# (change requires restart)
 #wal_keep_size = 0		# in megabytes; 0 disables
-max_slot_wal_keep_size = 4096   # in megabytes; -1 disables
+max_slot_wal_keep_size = 512    # in megabytes; -1 disables
 #wal_sender_timeout = 60s	# in milliseconds; 0 disables
 #track_commit_timestamp = off	# collect timestamp of transaction commit
 				# (change requires restart)

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.072-orioledb"
-  postgres17: "17.6.1.115"
-  postgres15: "15.14.1.115"
+  postgresorioledb-17: "17.6.0.073-orioledb"
+  postgres17: "17.6.1.116"
+  postgres15: "15.14.1.116"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -60,7 +60,7 @@ postgres_exporter_release_checksum:
   arm64: sha256:29ba62d538b92d39952afe12ee2e1f4401250d678ff4b354ff2752f4321c87a0
   amd64: sha256:cb89fc5bf4485fb554e0d640d9684fae143a4b2d5fa443009bd29c59f9129e84
 
-adminapi_release: "0.100.2"
+adminapi_release: "0.101.0"
 adminmgr_release: "0.32.3"
 supabase_admin_agent_release: 1.8.0
 supabase_admin_agent_splay: 30s


### PR DESCRIPTION
## Summary

- `max_slot_wal_keep_size` was set to `4096MB`, exceeding the total disk size of free tier projects (2GB) — a lagging or disconnected replication slot could fill the disk entirely before Postgres invalidates it
- Lowered to `512MB`, which fits safely within free tier disk overhead
- Free tier projects cannot attach physical replicas, but logical replication slots are still possible (e.g. Supabase Realtime, logical replication, CDC tools) and this setting applies to all slot types
- WAL archiving to S3 via `archive_command` means local WAL retention is not required for recovery, so a lower cap has no impact on PITR

## Test plan

- [x] Verify Postgres starts correctly with the new default on an AMI build
- [x] Confirm Supabase Realtime slot is not affected under normal operation
- [x] Confirm a lagging slot is invalidated at ~512MB rather than ~4GB
- [x] Consider whether this should be tier-specific in a follow-up