### PR TITLE
fix: wrap in retry on outer call

### DIFF
--- a/.github/actions/nix-build-retry/action.yml
+++ b/.github/actions/nix-build-retry/action.yml
@@ -1,0 +1,74 @@
+name: 'Nix build with retry'
+description: |
+  Runs `nix build --accept-flake-config -L` and retries on transient network
+  errors (codeload.github.com 5xx, DNS, TLS, connection resets). Genuine build
+  failures exit immediately without retrying.
+inputs:
+  attr:
+    description: 'The flake attribute to build, including the leading `.#`, e.g. `.#psql_17_cli_portable`'
+    required: true
+  extra-args:
+    description: 'Additional arguments inserted between `-L` and the attribute, e.g. `--system aarch64-linux`'
+    required: false
+    default: ''
+  attempts:
+    description: 'Maximum number of attempts'
+    required: false
+    default: '3'
+  initial-delay-seconds:
+    description: 'Backoff before the second attempt; doubled before each subsequent attempt'
+    required: false
+    default: '30'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: nix build (with retry)
+      shell: bash
+      env:
+        ATTR: ${{ inputs.attr }}
+        EXTRA_ARGS: ${{ inputs.extra-args }}
+        ATTEMPTS: ${{ inputs.attempts }}
+        INITIAL_DELAY: ${{ inputs.initial-delay-seconds }}
+      run: |
+        set -uo pipefail
+
+        log_file=$(mktemp)
+        trap 'rm -f "$log_file"' EXIT
+
+        # Patterns that indicate a transient network/upstream failure rather
+        # than a real build error. Keep conservative — false positives waste
+        # CI minutes by re-running deterministic build failures.
+        transient_re='HTTP error 5[0-9][0-9]|error: unable to download|Failed to open archive|Connection (reset|refused|timed out)|Couldn'\''t resolve host|Could not resolve host|unexpected end[- ]of[- ]file|SSL connection|TLS connection|Resource temporarily unavailable|Temporary failure in name resolution'
+
+        delay="$INITIAL_DELAY"
+        rc=0
+        for attempt in $(seq 1 "$ATTEMPTS"); do
+          echo "::group::nix build attempt ${attempt}/${ATTEMPTS}: ${ATTR} ${EXTRA_ARGS}"
+          # Stream to console AND capture for post-hoc pattern matching.
+          # PIPESTATUS preserves nix's exit code through the tee.
+          nix build --accept-flake-config -L ${EXTRA_ARGS} "${ATTR}" 2>&1 | tee "$log_file"
+          rc=${PIPESTATUS[0]}
+          echo "::endgroup::"
+
+          if [ "$rc" -eq 0 ]; then
+            exit 0
+          fi
+
+          if [ "$attempt" -ge "$ATTEMPTS" ]; then
+            echo "::error::nix build failed after ${attempt} attempt(s) (exit ${rc})"
+            exit "$rc"
+          fi
+
+          if grep -qE "$transient_re" "$log_file"; then
+            echo "::warning::Transient error on attempt ${attempt}; sleeping ${delay}s then retrying"
+            sleep "$delay"
+            delay=$((delay * 2))
+          else
+            echo "::error::nix build failed with non-transient error on attempt ${attempt} (exit ${rc}); not retrying"
+            exit "$rc"
+          fi
+        done
+
+        # Defensive — loop should always exit via one of the branches above.
+        exit "$rc"

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -37,12 +37,16 @@ jobs:
         uses: ./.github/actions/nix-install-ephemeral
 
       - name: Run portability check
-        run: |
-          nix build .#checks.${{ matrix.system }}.psql_17_cli_portable --system ${{ matrix.system }} -L --accept-flake-config
+        uses: ./.github/actions/nix-build-retry
+        with:
+          attr: .#checks.${{ matrix.system }}.psql_17_cli_portable
+          extra-args: --system ${{ matrix.system }}
 
       - name: Build portable CLI bundle
-        run: |
-          nix build .#psql_17_cli_portable --system ${{ matrix.system }} -L --accept-flake-config
+        uses: ./.github/actions/nix-build-retry
+        with:
+          attr: .#psql_17_cli_portable
+          extra-args: --system ${{ matrix.system }}
 
       - name: Determine version
         id: version

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -53,8 +53,9 @@ jobs:
         uses: ./.github/actions/nix-install-self-hosted
       - name: nix build
         if: ${{ matrix.attr != '' }}
-        shell: bash
-        run: nix build --accept-flake-config -L .#${{ matrix.attr }}
+        uses: ./.github/actions/nix-build-retry
+        with:
+          attr: .#${{ matrix.attr }}
 
   nix-build-checks-aarch64-linux:
     name: >-
@@ -84,8 +85,9 @@ jobs:
         uses: ./.github/actions/nix-install-self-hosted
       - name: nix build
         if: ${{ matrix.attr != '' }}
-        shell: bash
-        run: nix build --accept-flake-config -L .#${{ matrix.attr }}
+        uses: ./.github/actions/nix-build-retry
+        with:
+          attr: .#${{ matrix.attr }}
 
   nix-build-packages-aarch64-darwin:
     name: >-
@@ -107,8 +109,9 @@ jobs:
         uses: ./.github/actions/nix-install-self-hosted
       - name: nix build
         if: ${{ matrix.attr != '' }}
-        shell: bash
-        run: nix build --accept-flake-config -L .#${{ matrix.attr }}
+        uses: ./.github/actions/nix-build-retry
+        with:
+          attr: .#${{ matrix.attr }}
 
   nix-build-checks-aarch64-darwin:
     name: >-
@@ -130,8 +133,9 @@ jobs:
         uses: ./.github/actions/nix-install-self-hosted
       - name: nix build
         if: ${{ matrix.attr != '' }}
-        shell: bash
-        run: nix build --accept-flake-config -L .#${{ matrix.attr }}
+        uses: ./.github/actions/nix-build-retry
+        with:
+          attr: .#${{ matrix.attr }}
 
   nix-build-packages-x86_64-linux:
     name: >-
@@ -158,8 +162,9 @@ jobs:
           NIX_SIGN_SECRET_KEY: ${{ secrets.NIX_SIGN_SECRET_KEY }}
       - name: nix build
         if: ${{ matrix.attr != '' }}
-        shell: bash
-        run: nix build --accept-flake-config -L .#${{ matrix.attr }}
+        uses: ./.github/actions/nix-build-retry
+        with:
+          attr: .#${{ matrix.attr }}
 
   nix-build-checks-x86_64-linux:
     name: >-
@@ -186,8 +191,9 @@ jobs:
           NIX_SIGN_SECRET_KEY: ${{ secrets.NIX_SIGN_SECRET_KEY }}
       - name: nix build
         if: ${{ matrix.attr != '' }}
-        shell: bash
-        run: nix build --accept-flake-config -L .#${{ matrix.attr }}
+        uses: ./.github/actions/nix-build-retry
+        with:
+          attr: .#${{ matrix.attr }}
 
   run-testinfra:
     needs: [nix-eval, nix-build-packages-aarch64-linux, nix-build-checks-aarch64-linux, nix-build-packages-aarch64-darwin, nix-build-checks-aarch64-darwin, nix-build-packages-x86_64-linux, nix-build-checks-x86_64-linux]


### PR DESCRIPTION
## Summary

Wrap nix build in a retry composite action to ride out transient codeload.github.com 502s during flake-input fetch. Nix's built-in retry (5 attempts, ~5s total) is too short to survive typical GitHub blips and there's no outer retry today, so a single 502 fails the entire job.

example error causing the problem https://github.com/supabase/postgres/pull/2105

### Changes

New .github/actions/nix-build-retry runs nix build, streams logs, and retries up to 3 times (30s, 60s, 120s backoff) only on transient signatures (HTTP 5xx, unable to download, Failed to open archive, connection/DNS/TLS errors). Real build failures exit immediately. Wired into 8 callsites: 6 in nix-build.yml, 2 in cli-release.yml.

### Test plan

Nix CI passes on this PR (proves the wrapper doesn't break the happy path). Spot-check one job's log to confirm the retry group renders correctly. The retry path itself can only be validated against a real transient failure  bash logic is bash -n + YAML-validated locally.

### Context

#### The endpoint Nix is hitting

When a flake input is `github:owner/repo`, Nix resolves it to one of two URLs:

- With `access-tokens = github.com=...` configured: `https://api.github.com/repos/owner/repo/tarball/<sha>`
- Without auth (or when auth isn't being honored): `https://github.com/owner/repo/archive/<sha>.tar.gz`

Our error log shows the second form, so auth is likely not being applied at evaluation time.

Either URL ends up at the same place. `api.github.com/.../tarball/<sha>` returns a 302 redirect to a short-lived signed URL on `codeload.github.com`. `github.com/.../archive/<sha>.tar.gz` redirects to the same codeload endpoint. The `Authorization` header is dropped on the redirect (codeload rejects authenticated requests), so the actual byte transfer is anonymous in both cases. Auth only protects the metadata step from rate limits, not the download itself.

`codeload.github.com` is the on-demand tarball generator. It does not store archives; it generates them by walking git on each request. Popular SHAs (HEAD of well-known repos) get cached at the CDN edge. Less-popular SHAs — our 5-month-old `flake-parts` pin, for example — miss the cache, trigger backend regeneration, and that's where the 502s come from when the generator is busy or unhealthy.

#### GitHub SLA on this endpoint

GitHub's stability and SLA guarantees only cover **release assets** (the `releases/download/<tag>/<file>` URLs you upload to manually). They explicitly do not cover auto-generated source archives. Community-discussion threads that document codeload returning 502/403 under load — e.g. `github/community` discussions [#8149](https://github.com/orgs/community/discussions/8149) and [#45830](https://github.com/orgs/community/discussions/45830), plus repeated incidents tracked by Composer, Wikimedia, and Sublime Package Control — all get the same answer from GitHub: archive endpoints are best-effort.

#### Why this matters for our CI

Every fresh ephemeral runner re-fetches every github-typed flake input from codeload. With 17 such inputs in our `flake.lock` and a matrix that fans out to ~30 concurrent jobs across PRs, a single codeload backend hiccup lands on multiple jobs at once. Nix's internal retry caps at 5 attempts within ~5 seconds, which is well below the typical duration of a codeload incident, so we fail the whole build over what is functionally a load-balancer hiccup on an endpoint GitHub doesn't even promise to keep up.

The retry wrapper buys ~3.5 minutes of total back-off (30s + 60s + 120s) which is enough to ride out almost every codeload incident in practice. The deeper fix is to stop hitting codeload at all by populating flake inputs into our existing S3 substituter, but that's a separate change.
