### PR TITLE
docs: remove empty path settings from nix.conf snippets

### DIFF
--- a/nix/docs/start-here.md
+++ b/nix/docs/start-here.md
@@ -25,14 +25,10 @@ builders-use-substitutes = true
 cores = 0
 experimental-features = nix-command flakes
 max-jobs = auto
-netrc-file =
 require-sigs = true
 substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com https://postgrest.cachix.org https://cache.nixos.org/
 trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI= postgrest.cachix.org-1:icgW4R15fz1+LqvhPjt4EnX/r19AaqxiVV+1olwlZtI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-trusted-substituters =
 trusted-users = YOUR_USERNAME root
-extra-sandbox-paths =
-extra-substituters =
 ```
 
 **Important**: Replace `YOUR_USERNAME` with your actual username in the `trusted-users` line.
@@ -71,14 +67,10 @@ builders-use-substitutes = true
 cores = 0
 experimental-features = nix-command flakes
 max-jobs = auto
-netrc-file =
 require-sigs = true
 substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com https://postgrest.cachix.org https://cache.nixos.org/
 trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI= postgrest.cachix.org-1:icgW4R15fz1+LqvhPjt4EnX/r19AaqxiVV+1olwlZtI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-trusted-substituters =
 trusted-users = YOUR_USERNAME root
-extra-sandbox-paths =
-extra-substituters =
 ```
 
 **Important**: Replace `YOUR_USERNAME` with your actual username in the `trusted-users` line.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update / bug fix

## What is the current behavior?

The `nix.conf` snippets in `nix/docs/start-here.md` (both the "Update Existing Installation" and "Fresh Installation" sections) include several settings with empty values:

```
netrc-file =
trusted-substituters =
extra-sandbox-paths =
extra-substituters =
```

On Nix < 2.34.0 these were silently ignored. Starting with Nix 2.34.0 (released 2026-02-27), `netrc-file` was migrated from the global `Settings` class (where it was a plain string) into a new `FileTransferSettings` class as a `std::filesystem::path`-typed field ([commit `04d13a96e`](https://github.com/NixOS/nix/commit/04d13a96e33f18bc2d1c5606dbdda1d3331ec944)). A separate change in the same release added strict validation that rejects empty values for all path-typed settings ([commit `93c51acfb5cd`](https://github.com/NixOS/nix/commit/93c51acfb5cdc28c4a44cc2ad86359b2b14528f0)). Together these mean any `netrc-file =` line with an empty value now produces:

```
error: setting 'netrc-file' is a path and paths cannot be empty
```

This is acknowledged in the [Nix 2.34.1 release notes](https://nix.dev/manual/nix/2.34/release-notes/rl-2.34) and the regression was tracked in [NixOS/nix#15408](https://github.com/NixOS/nix/pull/15408). Since the docs already prescribe installing Nix 2.34.6, every new follower of these instructions hits this error.

## What is the new behavior?

The four empty-value lines (`netrc-file =`, `trusted-substituters =`, `extra-sandbox-paths =`, `extra-substituters =`) are removed from both `nix.conf` snippets. Omitting these lines is equivalent to keeping them set to their defaults, so there is no behavioural change — only the compatibility error is eliminated.

## Additional context

Workaround (for anyone already affected): manually remove the empty-value lines from `/etc/nix/nix.conf` and restart `nix-daemon`.
