### PR TITLE
fix: bump admin mgr version for statement timeout fix on backup

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.076-orioledb"
-  postgres17: "17.6.1.119"
-  postgres15: "15.14.1.119"
+  postgresorioledb-17: "17.6.0.077-orioledb"
+  postgres17: "17.6.1.120"
+  postgres15: "15.14.1.120"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1
@@ -61,7 +61,7 @@ postgres_exporter_release_checksum:
   amd64: sha256:cb89fc5bf4485fb554e0d640d9684fae143a4b2d5fa443009bd29c59f9129e84
 
 adminapi_release: "0.101.0"
-adminmgr_release: "0.32.3"
+adminmgr_release: "0.35.3"
 supabase_admin_agent_release: 1.8.0
 supabase_admin_agent_splay: 30s
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bump the `admin-mgr` version to `0.35.3` to introduce a new `statement_timeout` during backup runs.

ref: https://github.com/supabase/admin-mgr/pull/92