### PR TITLE
fix(pg_upgrade): use systemctl to start data.mount

### DIFF
--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/complete.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/complete.sh
@@ -248,12 +248,10 @@ function complete_pg_upgrade {
         udevadm settle --timeout=60 || true
         wait_for_data_device
 
-        retry 8 mount -a -v
-
-        # `nofail` in /etc/fstab makes `mount -a` exit with a code of 0 even when the volume is absent
-        # In the offchance of the volume not being mounted or detected, explicitly fail here
-        if ! mountpoint -q /data; then
-            echo "FATAL: /data is not a mountpoint"
+        # `mount -a` skips systemd-managed mounts (x-systemd.device-timeout in fstab)
+        systemctl start data.mount
+        if ! retry 8 mountpoint -q /data; then
+            echo "FATAL: /data is not a mountpoint after systemctl start data.mount"
             exit 1
         fi
     else


### PR DESCRIPTION
`complete.sh` used `mount -a` to mount `/data` after the upgraded volume was re-attached. Because the fstab entry for `/data` includes `x-systemd.device-timeout`, systemd takes ownership of the `data.mount` unit — and `mount -a` from util-linux silently skips systemd-managed mounts, exiting 0 without mounting anything.

This caused `copy_configs` to run against an unmounted `/data`, exhausting its 3 retries in ~6s and marking the upgrade as failed.

Ref: INC-495

Replace `retry 8 mount -a -v` with `systemctl start data.mount`, which explicitly activates the systemd unit. Follow it with `retry 8 mountpoint  -q /data` as a safety net with an explicit failure message.

PR #2133 (Paul Cioanca) addressed the secondary race — EBS API reporting `in-use` before the NVMe device is visible to the OS — by adding `udevadm settle` and `wait_for_data_device`. This PR addresses the root cause that remained after that fix.

Please go the `Preview` tab and select the appropriate sub-template:

* [Default](?expand=1&template=default.md)
* [Extension Upgrade](?expand=1&template=extension_upgrade.md)