### PR TITLE
fix: upload upgrade scripts for x86 instances

### DIFF
--- a/.github/workflows/publish-nix-pgupgrade-bin-flake-version.yml
+++ b/.github/workflows/publish-nix-pgupgrade-bin-flake-version.yml
@@ -62,9 +62,11 @@ jobs:
 
       - name: Upload pg_upgrade scripts to s3 staging
         run: |
-          aws s3 cp /tmp/pg_upgrade_bin.tar.gz s3://${{ secrets.ARTIFACTS_BUCKET }}/upgrades/postgres/supabase-postgres-${{ steps.process_release_version.outputs.version }}/20.04.tar.gz
-          aws s3 cp /tmp/pg_upgrade_bin.tar.gz s3://${{ secrets.ARTIFACTS_BUCKET }}/upgrades/postgres/supabase-postgres-${{ steps.process_release_version.outputs.version }}/24.04.tar.gz
-          aws s3 cp /tmp/pg_upgrade_bin.tar.gz s3://${{ secrets.ARTIFACTS_BUCKET }}/upgrades/postgres/supabase-postgres-${{ steps.process_release_version.outputs.version }}/upgrade_bundle.tar.gz
+          for prefix in upgrades upgrades-x86 ; do
+              aws s3 cp /tmp/pg_upgrade_bin.tar.gz s3://${{ secrets.ARTIFACTS_BUCKET }}/${prefix}/postgres/supabase-postgres-${{ steps.process_release_version.outputs.version }}/20.04.tar.gz
+              aws s3 cp /tmp/pg_upgrade_bin.tar.gz s3://${{ secrets.ARTIFACTS_BUCKET }}/${prefix}/postgres/supabase-postgres-${{ steps.process_release_version.outputs.version }}/24.04.tar.gz
+              aws s3 cp /tmp/pg_upgrade_bin.tar.gz s3://${{ secrets.ARTIFACTS_BUCKET }}/${prefix}/postgres/supabase-postgres-${{ steps.process_release_version.outputs.version }}/upgrade_bundle.tar.gz
+          done
 
       - name: Slack Notification on Failure
         if: ${{ failure() }}
@@ -110,9 +112,11 @@ jobs:
 
       - name: Upload pg_upgrade scripts to s3 prod
         run: |
-          aws s3 cp /tmp/pg_upgrade_bin.tar.gz s3://${{ secrets.PROD_ARTIFACTS_BUCKET }}/upgrades/postgres/supabase-postgres-${{ steps.process_release_version.outputs.version }}/20.04.tar.gz
-          aws s3 cp /tmp/pg_upgrade_bin.tar.gz s3://${{ secrets.PROD_ARTIFACTS_BUCKET }}/upgrades/postgres/supabase-postgres-${{ steps.process_release_version.outputs.version }}/24.04.tar.gz
-          aws s3 cp /tmp/pg_upgrade_bin.tar.gz s3://${{ secrets.PROD_ARTIFACTS_BUCKET }}/upgrades/postgres/supabase-postgres-${{ steps.process_release_version.outputs.version }}/upgrade_bundle.tar.gz
+          for prefix in upgrades upgrades-x86 ; do
+              aws s3 cp /tmp/pg_upgrade_bin.tar.gz s3://${{ secrets.PROD_ARTIFACTS_BUCKET }}/${prefix}/postgres/supabase-postgres-${{ steps.process_release_version.outputs.version }}/20.04.tar.gz
+              aws s3 cp /tmp/pg_upgrade_bin.tar.gz s3://${{ secrets.PROD_ARTIFACTS_BUCKET }}/${prefix}/postgres/supabase-postgres-${{ steps.process_release_version.outputs.version }}/24.04.tar.gz
+              aws s3 cp /tmp/pg_upgrade_bin.tar.gz s3://${{ secrets.PROD_ARTIFACTS_BUCKET }}/${prefix}/postgres/supabase-postgres-${{ steps.process_release_version.outputs.version }}/upgrade_bundle.tar.gz
+          done
 
       - name: Slack Notification on Failure
         if: ${{ failure() }}

--- a/.github/workflows/publish-nix-pgupgrade-bin-flake-version.yml
+++ b/.github/workflows/publish-nix-pgupgrade-bin-flake-version.yml
@@ -51,8 +51,6 @@ jobs:
         working-directory: /tmp/
         run: |
           mkdir -p "${{ steps.process_release_version.outputs.major_version }}"
-          # TODO (darora): temporary to test .121
-          GITHUB_SHA=ed0c0e626a75b4f0a1d9678e8cf4040a6ca7f716
           echo "$GITHUB_SHA" > "${{ steps.process_release_version.outputs.major_version }}/nix_flake_version"
           tar -czvf pg_upgrade_bin.tar.gz "${{ steps.process_release_version.outputs.major_version }}"
 
@@ -103,8 +101,6 @@ jobs:
         working-directory: /tmp/
         run: |
           mkdir -p "${{ steps.process_release_version.outputs.major_version }}"
-          # TODO (darora): temporary to test .121
-          GITHUB_SHA=ed0c0e626a75b4f0a1d9678e8cf4040a6ca7f716
           echo "$GITHUB_SHA" > "${{ steps.process_release_version.outputs.major_version }}/nix_flake_version"
           tar -czvf pg_upgrade_bin.tar.gz "${{ steps.process_release_version.outputs.major_version }}"
 

--- a/.github/workflows/publish-nix-pgupgrade-bin-flake-version.yml
+++ b/.github/workflows/publish-nix-pgupgrade-bin-flake-version.yml
@@ -51,6 +51,8 @@ jobs:
         working-directory: /tmp/
         run: |
           mkdir -p "${{ steps.process_release_version.outputs.major_version }}"
+          # TODO (darora): temporary to test .121
+          GITHUB_SHA=ed0c0e626a75b4f0a1d9678e8cf4040a6ca7f716
           echo "$GITHUB_SHA" > "${{ steps.process_release_version.outputs.major_version }}/nix_flake_version"
           tar -czvf pg_upgrade_bin.tar.gz "${{ steps.process_release_version.outputs.major_version }}"
 
@@ -101,6 +103,8 @@ jobs:
         working-directory: /tmp/
         run: |
           mkdir -p "${{ steps.process_release_version.outputs.major_version }}"
+          # TODO (darora): temporary to test .121
+          GITHUB_SHA=ed0c0e626a75b4f0a1d9678e8cf4040a6ca7f716
           echo "$GITHUB_SHA" > "${{ steps.process_release_version.outputs.major_version }}/nix_flake_version"
           tar -czvf pg_upgrade_bin.tar.gz "${{ steps.process_release_version.outputs.major_version }}"
 

--- a/.github/workflows/publish-nix-pgupgrade-scripts.yml
+++ b/.github/workflows/publish-nix-pgupgrade-scripts.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Upload pg_upgrade scripts to s3 staging
         run: |
           aws s3 cp /tmp/pg_upgrade_scripts.tar.gz "s3://${{ secrets.ARTIFACTS_BUCKET }}/upgrades/postgres/supabase-postgres-${{ steps.process_release_version.outputs.version }}/pg_upgrade_scripts.tar.gz"
+          aws s3 cp /tmp/pg_upgrade_scripts.tar.gz "s3://${{ secrets.ARTIFACTS_BUCKET }}/upgrades-x86/postgres/supabase-postgres-${{ steps.process_release_version.outputs.version }}/pg_upgrade_scripts.tar.gz"
 
       - name: Slack Notification on Failure
         if: ${{ failure() }}
@@ -113,6 +114,7 @@ jobs:
       - name: Upload pg_upgrade scripts to s3 prod
         run: |
           aws s3 cp /tmp/pg_upgrade_scripts.tar.gz "s3://${{ secrets.PROD_ARTIFACTS_BUCKET }}/upgrades/postgres/supabase-postgres-${{ steps.process_release_version.outputs.version }}/pg_upgrade_scripts.tar.gz"
+          aws s3 cp /tmp/pg_upgrade_scripts.tar.gz "s3://${{ secrets.PROD_ARTIFACTS_BUCKET }}/upgrades-x86/postgres/supabase-postgres-${{ steps.process_release_version.outputs.version }}/pg_upgrade_scripts.tar.gz"
 
       - name: Slack Notification on Failure
         if: ${{ failure() }}


### PR DESCRIPTION
x86 instances expect their artifacts to be at a slightly different
location. While most of their are already uploaded, the upgrade
scripts are currently not.

Towards GENCOMP-69