### PR TITLE
Install ncdu along htop on every system

### DIFF
--- a/ansible/tasks/setup-system.yml
+++ b/ansible/tasks/setup-system.yml
@@ -17,6 +17,7 @@
           - fail2ban
           - htop
           - linux-libc-dev
+          - ncdu
           - net-tools
           - nftables
           - ngrep


### PR DESCRIPTION
## What kind of change does this PR introduce?

ncdu is one of these small very useful tools, like htop. It’s a curses UI to recursively dig through the system and figure out where the disc space is being wasted.
