### PR TITLE
ci: add OCI smoke gate workflow

### DIFF
--- a/.github/workflows/oci-smoke-gate.yml
+++ b/.github/workflows/oci-smoke-gate.yml
@@ -1,0 +1,130 @@
+name: OCI smoke gate
+
+# Builds the AMI as an OCI image via supabox's support/ami/Dockerfile,
+# brings up the supabox platform stack, and runs supadev-smoke as a
+# fast pre-flight check before the more expensive testinfra/EC2 path.
+#
+# Intent: catch service-level, migration, and contract regressions in
+# ~5-10 min on a GH runner, so that PRs touching ansible/nix/migrations
+# fail fast and never burn EC2 minutes on broken builds.
+#
+# pause-restore.yaml coverage will be added in a follow-up once the
+# upstream test/pause-restore.yaml YAML parse fix lands.
+#
+# Tracked under RELENG-31.
+
+on:
+  pull_request:
+    paths:
+      - 'ansible/**'
+      - 'nix/**'
+      - 'migrations/**'
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'Dockerfile-15'
+      - 'Dockerfile-17'
+      - 'Dockerfile-orioledb-17'
+      - 'Dockerfile-multigres'
+      - 'Dockerfile-kubernetes'
+      - '.github/workflows/oci-smoke-gate.yml'
+  workflow_dispatch:
+  merge_group:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: oci-smoke-gate-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 60
+
+    env:
+      # Pinned supabox commit. Bump deliberately; tracks supabox `main`.
+      # Verified locally against this ref on 2026-05-15.
+      SUPABOX_REF: a0fe25c
+
+    steps:
+      - name: Checkout postgres at PR commit
+        uses: supabase/postgres/.github/actions/shared-checkout@HEAD
+        with:
+          path: postgres
+
+      - name: Checkout supabox at pinned ref
+        uses: actions/checkout@v4
+        with:
+          repository: supabase/supabox
+          ref: ${{ env.SUPABOX_REF }}
+          path: supabox
+
+      - name: Use this postgres commit from this PR in supabox/repos/postgres
+        run: |
+          set -euo pipefail
+          rm -rf supabox/repos/postgres
+          cp -a postgres supabox/repos/postgres
+          echo "PR postgres SHA inside supabox is: $(git -C supabox/repos/postgres rev-parse HEAD)"
+
+      - name: Install Nix
+        uses: ./postgres/.github/actions/nix-install-ephemeral
+
+      - name: Configure Nix substituter for postgres binary cache
+        run: |
+          sudo tee -a /etc/nix/nix.conf > /dev/null <<'EOF'
+          extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
+          extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=
+          EOF
+          sudo systemctl restart nix-daemon || true
+
+      - name: Initialize supabox in systemd mode
+        working-directory: supabox
+        run: |
+          ./supabox clean  # unnecessary here being a fresh runner, but useful if copied/pasted to a running env
+          ./supabox init systemd,pg17
+
+      - name: Build AMI-as-OCI image
+        working-directory: supabox
+        run: |
+          docker compose build supabase-postgres-17
+
+      - name: Bring platform stack up
+        working-directory: supabox
+        run: |
+          docker compose up -d --wait --wait-timeout 300
+
+      - name: Run supadev-smoke
+        working-directory: supabox
+        run: |
+          mkdir -p diagnostics
+          ./dctest test/supadev-smoke.yaml \
+            --results-file diagnostics/dctest-smoke-results.json \
+            --results-verbose
+
+      - name: Capture supabox state (always)
+        if: always()
+        working-directory: supabox
+        run: |
+          mkdir -p diagnostics/state
+          docker compose ps --all > diagnostics/state/compose-ps.txt 2>&1 || true
+          docker ps -a --format 'table {{.Names}}\t{{.Status}}\t{{.Image}}' \
+            > diagnostics/state/docker-ps.txt 2>&1 || true
+
+      - name: Dump container logs on failure
+        if: failure()
+        working-directory: supabox
+        run: |
+          mkdir -p diagnostics/logs
+          for c in $(docker ps -a --format '{{.Names}}'); do
+            docker logs --tail 500 "$c" > "diagnostics/logs/${c}.log" 2>&1 || true
+          done
+
+      - name: Upload diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: oci-smoke-diagnostics-${{ github.run_id }}
+          path: supabox/diagnostics/
+          retention-days: 14
+          if-no-files-found: warn


### PR DESCRIPTION
## What kind of change does this PR introduce?

CI — adds a new GH Actions workflow. Not wired as a required check; just runs and reports.

## What is the current behavior?

There's no fast pre-EC2 validation for PRs touching the AMI build. `testinfra-ami-build.yml` is the only path, and it does the full Packer + EC2 round-trip (~20-40 min) before any service-level behavior is exercised.

## What is the new behavior?

A new workflow `.github/workflows/oci-smoke-gate.yml` that runs on PRs touching `ansible/`, `nix/`, `migrations/`, `flake.{nix,lock}`, `Dockerfile-*`, or itself (plus `workflow_dispatch` and `merge_group`).

It builds the AMI as an OCI image via `supabase/supabox`'s `support/ami/Dockerfile`, brings the supabox platform stack up, and runs `dctest test/supadev-smoke.yaml`. Diagnostics + container logs (on failure) are uploaded as a 14-day artifact.

This PR **does not** make any other workflow depend on it. It runs alongside `testinfra-ami-build.yml` and reports its own status. Promoting it to a required check is a follow-up once we see how reliable it is across real PRs.

## Additional context

- Local trial: validated on macOS Docker against supabox `a0fe25c` on 2026-05-15 — 59/59 supadev-smoke tests pass, ~5.5 min of dctest after init. CI wall-clock expected ~15-25 min cold cache.
- `SUPABOX_REF` is SHA-pinned, not tracking `main`, so sibling-team changes can't silently break this workflow. Bump deliberately.
- `pause-restore.yaml` coverage is intentionally deferred — upstream supabox needs a YAML parse fix first, and the spec is slower.
- No PG-version matrix yet (pg17 only). Add later.

Relates [RELENG-31](https://linear.app/supabase/issue/RELENG-31/wire-oci-smoke-gate-into-supabasepostgres-ci-before-test-ami-nixpy).
