### PR TITLE
feat: update pgvector to 0.8.2

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.084-orioledb"
-  postgres17: "17.6.1.127"
-  postgres15: "15.14.1.127"
+  postgresorioledb-17: "17.6.0.085-orioledb"
+  postgres17: "17.6.1.128"
+  postgres15: "15.14.1.128"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1

--- a/nix/ext/versions.json
+++ b/nix/ext/versions.json
@@ -601,6 +601,13 @@
         "17"
       ],
       "hash": "sha256-JsZV+I4eRMypXTjGmjCtMBXDVpqTIPHQa28ogXncE/Q="
+    },    
+    "0.8.2": {
+      "postgresql": [
+        "15",
+        "17"
+      ],
+      "hash": "sha256-TLPlH+amFdeI2pEsUZuvoQ1JA0sCMiIAWdkgqGBo4mI="
     }
   },
   "wrappers": {


### PR DESCRIPTION
## What kind of change does this PR introduce?

- upgrade pgvector from 0.8.0 to 0.8.2

This release fixes a buffer overflow with parallel HNSW index builds (CVE-2026-3172), which can leak sensitive data from other relations or crash the database server. Users are encouraged to upgrade when possible.

## Additional context

Add any other context or screenshots.

## Action Items

- [x] **New extension releases** were Checked for any breaking changes

- [x] internal e2e testing
