### PR TITLE
chore: bump to pg_net 0.20.3

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.079-orioledb"
-  postgres17: "17.6.1.122"
-  postgres15: "15.14.1.122"
+  postgresorioledb-17: "17.6.0.080-orioledb"
+  postgres17: "17.6.1.123"
+  postgres15: "15.14.1.123"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1

--- a/nix/ext/versions.json
+++ b/nix/ext/versions.json
@@ -326,6 +326,13 @@
         "17"
       ],
       "hash": "sha256-xMYS6VOWxUVErx6bXTvad6Gj7WTudxmiI9k9HzSvMDQ="
+    },
+    "0.20.3": {
+      "postgresql": [
+        "15",
+        "17"
+      ],
+      "hash": "sha256-uOy/ESRKXngAyDTLHEQ81ZxZCfdtqoP9OxsqzyQJdEY="
     }
   },
   "pgaudit": {


### PR DESCRIPTION
Picks up pg_net 0.20.3, which contains two fixes:

- [supabase/pg_net#254](https://github.com/supabase/pg_net/pull/254) — `fix: flush pgstat counters from worker so autovacuum sees its writes`. Without the flush, per-write counters (`n_tup_ins`, `n_tup_del`, `n_mod_since_analyze`) for the worker's writes never reach shared stats, autovacuum is never scheduled, and `net._http_response` silently bloats. 
- [supabase/pg_net#255](https://github.com/supabase/pg_net/pull/255) — `fix: report worker activity to pg_stat_activity`. Populates the worker's `state` column in `pg_stat_activity` (idle / active) so operators can see whether the worker is doing work.

Refs PSQL-1216, PSQL-1221.

Release: https://github.com/supabase/pg_net/releases/tag/v0.20.3

## Changes

- `nix/ext/versions.json`: add `0.20.3` entry. Hash computed via `nix-prefetch-url --unpack` against the v0.20.3 tag.
- `ansible/vars.yml`: bump `postgres17` / `postgres15` / `postgresorioledb-17` patch numbers.