### PR TITLE
security: disable password auth for root and ubuntu

### DIFF
--- a/ebssurrogate/scripts/qemu-bootstrap-nix.sh
+++ b/ebssurrogate/scripts/qemu-bootstrap-nix.sh
@@ -160,6 +160,15 @@ function clean_system {
 	# remove passwords in user-data-cloudimg.img (required for Packer login)
 	usermod -p '*' ubuntu
 	usermod -p '*' root
+
+  # Ensure that PasswordAuthentication is off
+  # From chroot-boostrap-nix.sh
+  sed -i -E \
+    -e 's/^#?\s*PasswordAuthentication\s+(yes|no)\s*$/PasswordAuthentication no/g' \
+    -e 's/^#?\s*ChallengeResponseAuthentication\s+(yes|no)\s*$/ChallengeResponseAuthentication no/g' \
+    /etc/ssh/sshd_config
+  grep -qE "^PasswordAuthentication\s+no" /etc/ssh/sshd_config \
+    || { echo "ERROR: PasswordAuthentication is not disabled in sshd_config"; exit 1; }
 }
 
 install_nix

--- a/ebssurrogate/scripts/qemu-bootstrap-nix.sh
+++ b/ebssurrogate/scripts/qemu-bootstrap-nix.sh
@@ -156,6 +156,10 @@ function clean_system {
 	rm -rf /root/.vpython*
 	rm -rf /root/go
 	rm -rf /mnt/usr/share/doc
+
+	# remove passwords in user-data-cloudimg.img (required for Packer login)
+	usermod -p '*' ubuntu
+	usermod -p '*' root
 }
 
 install_nix


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes KUBEINT-203.

This prevents the users from being logged into except by SSH public key
authentication.

It also explicitly disables password/challenge response auth for SSH.

## What is the current behavior?

The passwords used in `user-data-cloudimg` are persisted in every qemu image.

SSHd configuration has the default (i.e. challenge response and password auth disabled)

## What is the new behavior?

The passwords are now set to '*'. We also uncomment/explicitly disable challenge response and SSH password auth.

```bash
$ cat /etc/shadow
root:*:20594:0:99999:7:::
daemon:*:20558:0:99999:7:::
bin:*:20558:0:99999:7:::
sys:*:20558:0:99999:7:::
sync:*:20558:0:99999:7:::
games:*:20558:0:99999:7:::
man:*:20558:0:99999:7:::
lp:*:20558:0:99999:7:::
mail:*:20558:0:99999:7:::
news:*:20558:0:99999:7:::
uucp:*:20558:0:99999:7:::
proxy:*:20558:0:99999:7:::
www-data:*:20558:0:99999:7:::
backup:*:20558:0:99999:7:::
list:*:20558:0:99999:7:::
irc:*:20558:0:99999:7:::
_apt:*:20558:0:99999:7:::
nobody:*:20558:0:99999:7:::
systemd-network:!*:20558::::::
systemd-timesync:!*:20558::::::
dhcpcd:!:20558::::::
messagebus:!:20558::::::
systemd-resolve:!*:20558::::::
sshd:!:20558::::::
pollinate:!:20558::::::
ubuntu:!*:20594:0:99999:7:::
_rpc:!:20594::::::
$ grep -i password /etc/ssh/sshd_config
#PermitRootLogin prohibit-password
# To disable tunneled clear text passwords, change to no here!
PasswordAuthentication no
#PermitEmptyPasswords no
# Change to yes to enable challenge-response passwords (beware issues with
# PasswordAuthentication.  Depending on your PAM configuration,
# the setting of "PermitRootLogin prohibit-password".
# PAM authentication, then enable this but set PasswordAuthentication
```

## Additional context

