### PR TITLE
INDATA-653 rm unwanted .list extensions

### DIFF
--- a/ansible/tasks/internal/install-salt.yml
+++ b/ansible/tasks/internal/install-salt.yml
@@ -19,7 +19,7 @@
     - name: salt apt repo
       ansible.builtin.apt_repository:
         repo: "deb [signed-by=/etc/apt/keyrings/salt-archive-keyring-2023.pgp arch=arm64] https://packages.broadcom.com/artifactory/saltproject-deb/ stable main"
-        filename: "salt.list"
+        filename: "salt"
         state: present
   when: platform == "arm64"
 
@@ -44,7 +44,7 @@
     - name: salt apt repo
       ansible.builtin.apt_repository:
         repo: "deb [signed-by=/etc/apt/keyrings/salt-archive-keyring-2023.pgp arch=amd64] https://packages.broadcom.com/artifactory/saltproject-deb/ stable main"
-        filename: "salt.list"
+        filename: "salt"
         state: present
   when: platform == "amd64"
 

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.081-orioledb"
-  postgres17: "17.6.1.124"
-  postgres15: "15.14.1.124"
+  postgresorioledb-17: "17.6.0.082-orioledb"
+  postgres17: "17.6.1.125"
+  postgres15: "15.14.1.125"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

In ansible/tasks/internal/install-salt.yml:22,47
salt.list -> salt.list.list

## What is the new behavior?

salt -> salt.list

Feel free to include screenshots if it includes visual changes.

## Additional context

the module automatically adds the .list extension