### PR TITLE
feat(multigres): use jsonlog and symlink to fd/1 

### DIFF
--- a/Dockerfile-multigres
+++ b/Dockerfile-multigres
@@ -115,6 +115,7 @@ RUN mkdir -p \
     /usr/lib/postgresql/share/postgresql \
     /usr/share/postgresql \
     /var/lib/postgresql/data \
+    /var/log/postgresql \
     /var/run/postgresql \
     /etc/postgresql \
     /etc/postgresql-custom \
@@ -122,6 +123,7 @@ RUN mkdir -p \
         /usr/lib/postgresql \
         /var/lib/postgresql \
         /usr/share/postgresql \
+        /var/log/postgresql \
         /var/run/postgresql \
         /etc/postgresql \
         /etc/postgresql-custom
@@ -130,7 +132,7 @@ COPY --chown=postgres:postgres ansible/files/postgresql_config/postgresql.conf.j
 COPY --chown=postgres:postgres ansible/files/postgresql_config/pg_hba.conf.j2 /etc/postgresql/pg_hba.conf
 COPY --chown=postgres:postgres ansible/files/postgresql_config/pg_ident.conf.j2 /etc/postgresql/pg_ident.conf
 COPY --chown=postgres:postgres ansible/files/postgresql_config/conf.d /etc/postgresql-custom/conf.d
-COPY --chown=postgres:postgres ansible/files/postgresql_config/postgresql-stdout-log.conf /etc/postgresql/logging.conf
+COPY --chown=postgres:postgres ansible/files/postgresql_config/postgresql-jsonlog.conf /etc/postgresql/logging.conf
 COPY --chown=postgres:postgres ansible/files/postgresql_config/supautils.conf.j2 /etc/postgresql-custom/supautils.conf
 COPY --chown=postgres:postgres ansible/files/postgresql_extension_custom_scripts /etc/postgresql-custom/extension-custom-scripts
 COPY --chown=postgres:postgres ansible/files/postgresql_config/custom_walg.conf /etc/postgresql-custom/wal-g.conf
@@ -197,11 +199,11 @@ RUN chown -R postgres:postgres /usr/lib/postgresql && \
 # Can't use /etc/pgctld because it's a mount point
 COPY docker/pgctld/postgresql.conf.tmpl /etc/pgctld-custom/postgresql.conf.tmpl
 
-# Wrapper: injects --postgres-config-template on every pgctld call so the team's
-# unmodified k8s manifests and local provisioner commands work without extra flags.
-RUN printf '#!/bin/sh\nexec /nix/var/nix/profiles/default/bin/pgctld --postgres-config-template /etc/pgctld-custom/postgresql.conf.tmpl "$@"\n' \
-    > /usr/local/bin/pgctld && \
-    chmod +x /usr/local/bin/pgctld
+# Wrapper: injects --postgres-config-template on every pgctld call AND bridges
+# postgres's JSON log file to container stdout via a /proc/1/fd/1 symlink so
+# kubelet + Vector can ship it without a sidecar. See docker/pgctld/pgctld-wrapper.
+COPY --chmod=755 docker/pgctld/pgctld-wrapper /usr/local/bin/pgctld
+ENV POSTGRES_CONFIG_TEMPLATE_PATH=/etc/pgctld-custom/postgresql.conf.tmpl
 
 # Strip extensions absent from pg17 vanilla build
 RUN sed -i 's/ timescaledb,//g; s/ plv8,//g' /etc/postgresql-custom/supautils.conf
@@ -283,11 +285,11 @@ ENV LANGUAGE=C
 # Can't use /etc/pgctld because it's a mount point
 COPY docker/pgctld/orioledb-postgresql.conf.tmpl /etc/pgctld-custom/orioledb-postgresql.conf.tmpl
 
-# Wrapper: injects --postgres-config-template on every pgctld call so the team's
-# unmodified k8s manifests and local provisioner commands work without extra flags.
-RUN printf '#!/bin/sh\nexec /nix/var/nix/profiles/default/bin/pgctld --postgres-config-template /etc/pgctld-custom/orioledb-postgresql.conf.tmpl "$@"\n' \
-    > /usr/local/bin/pgctld && \
-    chmod +x /usr/local/bin/pgctld
+# Wrapper: injects --postgres-config-template on every pgctld call AND bridges
+# postgres's JSON log file to container stdout via a /proc/1/fd/1 symlink so
+# kubelet + Vector can ship it without a sidecar. See docker/pgctld/pgctld-wrapper.
+COPY --chmod=755 docker/pgctld/pgctld-wrapper /usr/local/bin/pgctld
+ENV POSTGRES_CONFIG_TEMPLATE_PATH=/etc/pgctld-custom/orioledb-postgresql.conf.tmpl
 
 # Regenerate manifest after orioledb added 00-pre-init.sql to init-scripts/
 RUN set -e && \

--- a/ansible/files/postgresql_config/postgresql-jsonlog.conf
+++ b/ansible/files/postgresql_config/postgresql-jsonlog.conf
@@ -1,0 +1,35 @@
+# - Where to Log -
+
+log_destination = 'jsonlog'		# Valid values are combinations of
+					# stderr, csvlog, jsonlog, syslog, and
+					# eventlog, depending on platform.
+					# jsonlog requires logging_collector to be on.
+
+# This is used when logging to stderr:
+logging_collector = on		# Enable capturing of stderr, csvlog, and jsonlog
+					# into log files. Required to be on for
+					# jsonlogs.
+					# (change requires restart)
+
+# These are only used if logging_collector is on:
+log_directory = '/var/log/postgresql'			# directory where log files are written,
+					# can be absolute or relative to PGDATA
+log_filename = 'postgresql.log'	# log file name pattern,
+					# can include strftime() escapes
+					# (jsonlog writes to the same name with .json suffix,
+					# so this becomes postgresql.json on disk)
+log_file_mode = 0640			# creation mode for log files,
+					# begin with 0 to use octal notation
+log_rotation_age = 0			# Automatic rotation of logfiles will
+					# happen after that time.  0 disables.
+log_rotation_size = 0		# Automatic rotation of logfiles will
+					# happen after that much log output.
+					# 0 disables.
+#log_truncate_on_rotation = off		# If on, an existing log file with the
+					# same name as the new log file will be
+					# truncated rather than appended to.
+					# But such truncation only occurs on
+					# time-driven rotation, not on restarts
+					# or size-driven rotation.  Default is
+					# off, meaning append to existing files
+					# in all cases.

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.082-orioledb"
-  postgres17: "17.6.1.125"
-  postgres15: "15.14.1.125"
+  postgresorioledb-17: "17.6.0.083-orioledb"
+  postgres17: "17.6.1.126"
+  postgres15: "15.14.1.126"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1

--- a/docker/pgctld/pgctld-wrapper
+++ b/docker/pgctld/pgctld-wrapper
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Wrapper invoked as /usr/local/bin/pgctld by the multigres-operator's pod
+# spec (Command: ["/usr/local/bin/pgctld"]). Two responsibilities:
+#
+# 1. Inject --postgres-config-template so unmodified k8s manifests and local
+#    provisioner commands work without extra flags. Variant-specific template
+#    path is supplied via POSTGRES_CONFIG_TEMPLATE_PATH; vanilla pg17 default
+#    if unset.
+#
+# 2. Bridge postgres's JSON log file to the container's stdout so kubelet +
+#    Vector can ship it without a sidecar or a tail-F daemon:
+#
+#      log_destination = 'jsonlog'       (postgresql-jsonlog.conf)
+#      log_directory   = /var/log/postgresql
+#      log_filename    = postgresql.log  -> postgres writes postgresql.json
+#
+#    Symlink that .json path at /proc/1/fd/1. The kernel resolves the symlink
+#    when postgres opens the file for append — at that point this script has
+#    exec'd pgctld, so pgctld is PID 1 and its fd 1 is the container's
+#    stdout stream (inherited from the container runtime). Postgres's writes
+#    land on stdout, kubelet captures, Vector ships to Logflare.
+#
+#    Rotation is disabled in postgresql-jsonlog.conf (log_rotation_age=0,
+#    log_rotation_size=0), so postgres never tries to rename the symlink.
+set -e
+
+mkdir -p /var/log/postgresql 2>/dev/null || true
+ln -sf /proc/1/fd/1 /var/log/postgresql/postgresql.json
+
+exec /nix/var/nix/profiles/default/bin/pgctld \
+  --postgres-config-template "${POSTGRES_CONFIG_TEMPLATE_PATH:-/etc/pgctld-custom/postgresql.conf.tmpl}" \
+  "$@"

--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
     "multigres": {
       "flake": false,
       "locked": {
-        "lastModified": 1777958128,
-        "narHash": "sha256-bW7Giftisi2pObfCSKoxr+yi4pINjoXdfSk3fwN3er0=",
+        "lastModified": 1779407344,
+        "narHash": "sha256-UQE/2Ru4V1ip5WI+03NqaceTf2KqVV1xEzQWMtqDc6k=",
         "owner": "multigres",
         "repo": "multigres",
-        "rev": "7c14506b93d62b86e7ba922a90dcbf7b5574aa09",
+        "rev": "96303016e56f172d7bed2450f98cf7466f770b5f",
         "type": "github"
       },
       "original": {

--- a/nix/packages/docker-image-test.nix
+++ b/nix/packages/docker-image-test.nix
@@ -349,7 +349,7 @@ writeShellApplication {
 
             # 6. shared_preload_libraries must include orioledb — injected by wrapper, no flags needed
             local spl
-            spl=$(docker exec "$container" sh -c "
+            spl=$(docker exec -e PGPASSWORD="$POSTGRES_PASSWORD" "$container" sh -c "
                 psql -U $POSTGRES_USER -d postgres -h $pooler_dir/pg_sockets \
                     -tAc \"SHOW shared_preload_libraries;\" 2>&1") || true
             if ! echo "$spl" | grep -q "orioledb"; then
@@ -361,7 +361,7 @@ writeShellApplication {
 
             # 7. default_table_access_method must be orioledb
             local tam
-            tam=$(docker exec "$container" sh -c "
+            tam=$(docker exec -e PGPASSWORD="$POSTGRES_PASSWORD" "$container" sh -c "
                 psql -U $POSTGRES_USER -d postgres -h $pooler_dir/pg_sockets \
                     -tAc \"SHOW default_table_access_method;\" 2>&1") || true
             if ! echo "$tam" | grep -q "orioledb"; then

--- a/nix/packages/pgctld.nix
+++ b/nix/packages/pgctld.nix
@@ -17,7 +17,7 @@ buildGoModule {
   '';
   # Tests require a running PostgreSQL instance (integration tests); skip in sandbox.
   doCheck = false;
-  vendorHash = "sha256-P+B5fDlCdL0gxUa96BXz+1D0+6RSlul8eMv7iEI3Lpo=";
+  vendorHash = "sha256-lObK/Oukh1oEPQENlhny8eNxRhSlTKywO3GCGZ8u5Qw=";
 
   meta = {
     description = "PostgreSQL control daemon for Multigres cluster lifecycle management";


### PR DESCRIPTION
Use jsonlog to make parsing log lines to Logflare easier.

Also symlink the log destination to /proc/1/fd/1, so that Postgres logs
show up in container logs.