### PR TITLE
chore: bump jit gatekeeper version

### DIFF
--- a/nix/packages/gatekeeper.nix
+++ b/nix/packages/gatekeeper.nix
@@ -6,12 +6,12 @@ let
 
   upstream-gatekeeper = buildGoModule124 {
     pname = "jit-db-gatekeeper";
-    version = "1.0.2";
+    version = "1.0.5";
     src = pkgs.fetchFromGitHub {
       owner = "supabase";
       repo = "jit-db-gatekeeper";
-      rev = "v1.0.2";
-      sha256 = "sha256-YMbWvE2GrtVB3N7aw+HGb4sO+oGiU0PML9qC42uO51Y=";
+      rev = "v1.0.5";
+      sha256 = "sha256-z+TE9Cc+NL6nvCIkAKFdSgm4V/1K45tRRnfQdauDjes=";
     };
     vendorHash = null;
 
@@ -34,7 +34,7 @@ in
 
 pkgs.stdenv.mkDerivation {
   pname = "gatekeeper";
-  version = "1.0.2";
+  version = "1.0.5";
 
   buildInputs = [ upstream-gatekeeper ];
 


### PR DESCRIPTION
Bumps to latest version.

* adds support for scoped PATs