### PR TITLE
fix: update CLI options for SAA in systemd unit

### DIFF
--- a/ansible/files/supabase_admin_agent_config/supabase-admin-agent_salt.service.j2
+++ b/ansible/files/supabase_admin_agent_config/supabase-admin-agent_salt.service.j2
@@ -7,7 +7,7 @@ Requires=local-fs.target
 [Service]
 Type=oneshot
 {% if qemu_mode is defined and qemu_mode %}
-ExecStart=/opt/supabase-admin-agent/supabase-admin-agent --config /opt/supabase-admin-agent/config.yaml salt --apply --store-result --salt-archive configmanv3-main.tar.gz
+ExecStart=/opt/supabase-admin-agent/supabase-admin-agent --config /opt/supabase-admin-agent/config.yaml salt --apply --store-result --targets-key  targetsv3-main.yaml
 User=root
 Group=root
 {% else %}

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.086-orioledb"
-  postgres17: "17.6.1.129"
-  postgres15: "15.14.1.129"
+  postgresorioledb-17: "17.6.0.087-orioledb"
+  postgres17: "17.6.1.130"
+  postgres15: "15.14.1.130"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1


### PR DESCRIPTION
Since SAA 1.10.2, cli opts have changed for targeting, pulling yaml before tgz
