### PR TITLE
feat: e2e pg_upgrade support for suspend and wake enabled projects

### DIFF
--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/common.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/common.sh
@@ -559,3 +559,29 @@ drop role supabase_tmp;
 commit;
 EOSQL
 }
+
+function guard_for_state() {
+  local service_name="$1"
+  if [ -d /opt/supabase-state ]; then
+    echo "$service_name" >> /opt/supabase-state/guard
+  fi
+}
+
+function unguard_for_state() {
+  if [ -f /opt/supabase-state/guard ]; then
+    rm -f /opt/supabase-state/guard
+  fi
+}
+
+function stop_service_if_exists() {
+  local service_name="$1"
+  if systemctl cat "$service_name" >/dev/null 2>&1; then
+    systemctl stop "$service_name"
+  fi
+}
+
+function setup_state() {
+  if [ -f /opt/supabase-state/supabase-state ]; then
+    /opt/supabase-state/supabase-state setup --fix-perms --start-services
+  fi
+}

--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/complete.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/complete.sh
@@ -242,6 +242,8 @@ function complete_pg_upgrade {
 
     echo "running" > /tmp/pg-upgrade-status
 
+    guard_for_state "postgresql"
+
     echo "1. Mounting data disk"
     if [ -z "$IS_CI" ]; then
         # Let udev finish detecting the vollume before mounting
@@ -260,6 +262,7 @@ function complete_pg_upgrade {
         echo "Skipping mount -a -v"
     fi
 
+    setup_state
     # copying custom configurations
     echo "2. Copying custom configurations"
     retry 3 copy_configs
@@ -308,6 +311,8 @@ function complete_pg_upgrade {
 
     echo "6. Starting vacuum analyze"
     retry 3 start_vacuum_analyze
+
+    unguard_for_state
 }
 
 function copy_configs {

--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/prepare.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/prepare.sh
@@ -9,7 +9,16 @@
 
 set -euo pipefail
 
+SCRIPT_DIR=$(dirname -- "$0";)
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/common.sh"
+
 systemctl stop postgresql
 
 cp /etc/postgresql-custom/pgsodium_root.key /data/pgsodium_root.key
+
+guard_for_state "adminapi"
+guard_for_state "envoy"
+stop_service_if_exists supabase-state.service
+
 umount /data


### PR DESCRIPTION
Contributes to INFRA-2255

* prepare.sh sources common.sh, writes a guard file listing services (adminapi, envoy) that supabase-state should leave alone, and stops supabase-state.service before unmounting /data
* complete.sh guards postgresql before mount, runs setup_state (supabase-state setup --fix-perms --start-services) when the binary exists, and removes the guard at the end of a successful upgrade
* common.sh adds guard_for_state, unguard_for_state, stop_service_if_exists (systemctl cat-based to avoid SIGPIPE under pipefail), and setup_state helpers
