### PR TITLE
refactor(nix/cargo-pgrx): build cargo-pgrx by overriding upstream pkg

### DIFF
--- a/nix/cargo-pgrx/default.nix
+++ b/nix/cargo-pgrx/default.nix
@@ -1,10 +1,8 @@
 {
   lib,
+  cargo-pgrx,
   fetchCrate,
-  openssl,
-  pkg-config,
   makeRustPlatform,
-  stdenv,
   rust-bin,
   rustVersion ? "1.85.1",
 }:
@@ -14,73 +12,56 @@ let
     rustc = rust-bin.stable.${rustVersion}.default;
   };
   mkCargoPgrx =
-    {
-      version,
-      hash,
-      cargoHash,
-    }:
-    let
-      pname = if builtins.compareVersions "0.7.4" version >= 0 then "cargo-pgx" else "cargo-pgrx";
-    in
-    rustPlatform.buildRustPackage rec {
-      # rust-overlay uses 'cargo-auditable' wrapper for 'cargo' command, but it
-      # is using older version 0.18.1 of 'cargo_metadata' which doesn't support
-      # rust edition 2024, so we disable the 'cargo-auditable' just for now.
-      # ref: https://github.com/oxalica/rust-overlay/issues/153
-      auditable = false;
-      inherit pname;
-      inherit version;
-      src = fetchCrate { inherit version pname hash; };
-      inherit cargoHash;
-      nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ pkg-config ];
-      buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ openssl ];
+    args:
+    (cargo-pgrx.override { inherit rustPlatform; }).overrideAttrs rec {
+      pname = if lib.versionOlder version "0.7.4" then "cargo-pgx" else "cargo-pgrx";
+      inherit (args) version;
 
-      OPENSSL_DIR = "${openssl.dev}";
-      OPENSSL_INCLUDE_DIR = "${openssl.dev}/include";
-      OPENSSL_LIB_DIR = "${openssl.out}/lib";
-      PKG_CONFIG_PATH = "${openssl.dev}/lib/pkgconfig";
-      preCheck = ''
-        export PGRX_HOME=$(mktemp -d)
-      '';
-      checkFlags = [
-        # requires pgrx to be properly initialized with cargo pgrx init
-        "--skip=command::schema::tests::test_parse_managed_postmasters"
-      ];
-      meta = with lib; {
-        description = "Build Postgres Extensions with Rust";
-        homepage = "https://github.com/pgcentralfoundation/pgrx";
-        changelog = "https://github.com/pgcentralfoundation/pgrx/releases/tag/v${version}";
-        license = licenses.mit;
-        maintainers = with maintainers; [ happysalada ];
-        mainProgram = "cargo-pgrx";
+      src = fetchCrate {
+        inherit pname;
+        inherit (args)
+          version
+          hash
+          ;
+      };
+
+      cargoDeps = rustPlatform.fetchCargoVendor {
+        inherit
+          pname
+          src
+          ;
+        inherit (args) version;
+        hash = args.cargoHash;
       };
     };
 in
-{
-  cargo-pgrx_0_10_2 = mkCargoPgrx {
+lib.mapAttrs (_: mkCargoPgrx) {
+  cargo-pgrx_0_10_2 = {
     version = "0.10.2";
     hash = "sha256-FqjfbJmSy5UCpPPPk4bkEyvQCnaH9zYtkI7txgIn+ls=";
     cargoHash = "sha256-syZ3cQq8qDHBLvqmNDGoxeK6zXHJ47Jwkw3uhaXNCzI=";
   };
-  cargo-pgrx_0_11_3 = mkCargoPgrx {
+  cargo-pgrx_0_11_3 = {
     version = "0.11.3";
     hash = "sha256-UHIfwOdXoJvR4Svha6ud0FxahP1wPwUtviUwUnTmLXU=";
     cargoHash = "sha256-j4HnD8Zt9uhlV5N7ldIy9564o9qFEqs5KfXHmnQ1WEw=";
   };
-  cargo-pgrx_0_12_6 = mkCargoPgrx {
+  cargo-pgrx_0_12_6 = {
     version = "0.12.6";
     hash = "sha256-7aQkrApALZe6EoQGVShGBj0UIATnfOy2DytFj9IWdEA=";
     cargoHash = "sha256-pnMxWWfvr1/AEp8DvG4awig8zjdHizJHoZ5RJA8CL08=";
   };
-  cargo-pgrx_0_12_9 = mkCargoPgrx {
+  cargo-pgrx_0_12_9 = {
     version = "0.12.9";
     hash = "sha256-aR3DZAjeEEAjLQfZ0ZxkjLqTVMIEbU0UiZ62T4BkQq8=";
     cargoHash = "sha256-yZpD3FriL9UbzRtdFkfIfFfYIrRPYxr/lZ5rb0YBTPc=";
   };
-  cargo-pgrx_0_14_3 = mkCargoPgrx {
+  cargo-pgrx_0_14_3 = {
     version = "0.14.3";
     hash = "sha256-3TsNpEqNm3Uol5XPW1i0XEbP2fF2+RKB2d7lO6BDnvQ=";
     cargoHash = "sha256-LZUXhjMxkBs3O5feH4X5NQC7Qk4Ja6M5+sAYaSCikrY=";
   };
+}
+// {
   inherit mkCargoPgrx;
 }

--- a/nix/docs/flake-parts-architecture.md
+++ b/nix/docs/flake-parts-architecture.md
@@ -325,11 +325,6 @@ Overlays are flake-level (not per-system):
       postgresql_17
       supabase-groonga;
 
-    # Define new packages in terms of final/prev
-    cargo-pgrx = final.callPackage ../cargo-pgrx/default.nix {
-      inherit (final) lib darwin fetchCrate openssl;
-    };
-
     # Override existing packages
     buildPgrxExtension = final.callPackage ../cargo-pgrx/buildPgrxExtension.nix {
       inherit (final) cargo-pgrx lib;

--- a/nix/docs/updating-pgrx-extensions.md
+++ b/nix/docs/updating-pgrx-extensions.md
@@ -148,7 +148,7 @@ Use this when the extension requires a newer pgrx version.
 3. **Add cargo-pgrx entry** in `nix/cargo-pgrx/default.nix`:
 
    ```nix
-   cargo-pgrx_0_16_1 = mkCargoPgrx {
+   cargo-pgrx_0_16_1 = {
      version = "0.16.1";
      hash = "";
      cargoHash = "";

--- a/nix/overlays/default.nix
+++ b/nix/overlays/default.nix
@@ -16,15 +16,5 @@
       ;
 
     xmrig = throw "The xmrig package has been explicitly disabled in this flake.";
-
-    cargo-pgrx = final.callPackage ../cargo-pgrx/default.nix {
-      inherit (final) lib;
-      inherit (final) fetchCrate;
-      inherit (final) openssl;
-      inherit (final) pkg-config;
-      inherit (final) makeRustPlatform;
-      inherit (final) stdenv;
-      inherit (final) rust-bin;
-    };
   };
 }

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -108,7 +108,7 @@
           inherit (pkgs.callPackage ./wal-g.nix { }) wal-g-2;
           inherit (supascan-pkgs) goss supascan supascan-specs;
           inherit (pg-startup-profiler-pkgs) pg-startup-profiler;
-          inherit (pkgs.cargo-pgrx)
+          inherit (pkgs.callPackages ../cargo-pgrx { })
             cargo-pgrx_0_11_3
             cargo-pgrx_0_12_6
             cargo-pgrx_0_12_9


### PR DESCRIPTION
Replace the vendored and outdated cargo-pgrx expression with an override of the upstream nixpkgs package, dropping the manual dependency wiring, custom check flags, and meta block.

Remove the cargo-pgrx overlay and call the package set directly via `callPackages` in the package list. Using the overlay shadows the upstream package, and in addition just adds another layer of unneeded indirection.