### PR TITLE
test: no-op PR for 15.14 smoke baseline (do not merge)

### DIFF
--- a/nix/docs/README.md
+++ b/nix/docs/README.md
@@ -1,5 +1,7 @@
 # Documentation
 
+<!-- Cosmetic no-op marker (PSQL-1230): smoke-test baseline against develop. -->
+
 This directory contains most of the "runbooks" and documentation on how to use
 this repository.
 


### PR DESCRIPTION
## Purpose

Throwaway reference PR. **Do not merge.**

`supadev trigger-smoke-tests` resolves engine versions from the target PR's `ansible/vars.yml`. To run the smoke matrix against develop's **current production** versions (`15.14.1.132` / `17.6.1.132` / `17.6.0.089-orioledb`) instead of the `15.18.1.001_utk_test` build under test in #2155, we need a PR pointed at develop.

This PR exists only to provide that URL. The diff is a single cosmetic comment in `nix/docs/README.md`; nothing in `ansible/`, `migrations/`, or `nix/tests/` is touched.

## Why we're doing this

Investigating whether the **storage tenant-migration race** we've been seeing on `15.18.1.001_utk_test` smoke runs (`terminating connection due to administrator command` mid storage migration) also reproduces on current production 15.14 AMIs. If yes → race is environmental, not 15.18-specific. If no → something genuinely changed on the PG path.

Context: PSQL-1230 (PG 17.10 / 15.18 release).

## Cleanup

Will close this PR (without merging) once the smoke runs have produced enough data points (~2-3 runs of `upgrade`, `pitr`, `replication`, `disk-pressure` against this PR).