### PR TITLE
packer: set xtrace for clean up scripts

### DIFF
--- a/scripts/90-cleanup-qemu.sh
+++ b/scripts/90-cleanup-qemu.sh
@@ -4,7 +4,7 @@
 # © 2021 DigitalOcean LLC.
 # This code is licensed under Apache 2.0 license (see LICENSE.md for details)
 
-set -o errexit
+set -ex
 
 # Ensure /tmp exists and has the proper permissions before
 # checking for security updates

--- a/scripts/90-cleanup.sh
+++ b/scripts/90-cleanup.sh
@@ -4,7 +4,7 @@
 # © 2021 DigitalOcean LLC.
 # This code is licensed under Apache 2.0 license (see LICENSE.md for details)
 
-set -o errexit
+set -ex
 
 # Ensure /tmp exists and has the proper permissions before
 # checking for security updates


### PR DESCRIPTION
## What kind of change does this PR introduce?

Simple commit for better CI logs

## What is the current behavior?

This was all in service of fixing AMI build failures, for example: https://github.com/supabase/postgres/actions/runs/26757788681/job/78981563652#step:9:6046. Similar to #2177, but looks like its still biting.

## What is the new behavior?

I was trying to debug the issue and wanted to have `set -x` in the clean up scripts but when I tried building the AMI again it all worked. So I want to leave this in since its helpful if/when there's an error in the script again.