### PR TITLE
packer: Run scripts with stdout going to stderr

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.090-orioledb"
-  postgres17: "17.6.1.133"
-  postgres15: "15.14.1.133"
+  postgresorioledb-17: "17.6.0.090-orioledb-mmlb-err123-1"
+  postgres17: "17.6.1.133-mmlb-err123-1"
+  postgres15: "15.14.1.133-mmlb-err123-1"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1

--- a/ebssurrogate/scripts/surrogate-bootstrap-nix.sh
+++ b/ebssurrogate/scripts/surrogate-bootstrap-nix.sh
@@ -10,6 +10,8 @@ set -o errexit
 set -o pipefail
 set -o xtrace
 
+exec 1>&2
+
 if [ $(dpkg --print-architecture) = "amd64" ]; then
 	ARCH="amd64"
 else

--- a/ebssurrogate/scripts/surrogate-bootstrap-nix.sh
+++ b/ebssurrogate/scripts/surrogate-bootstrap-nix.sh
@@ -417,6 +417,10 @@ function upload_ccache {
 
 # Unmount bind mounts
 function umount_reset_mappings {
+	fuser -vm /mnt || true
+	lsof +f -- /mnt || true
+	ls -l /proc/*/root | grep /mnt || true
+
 	umount -l /mnt/dev
 	umount -l /mnt/proc
 	umount -l /mnt/sys

--- a/scripts/nix-provision.sh
+++ b/scripts/nix-provision.sh
@@ -5,6 +5,8 @@ set -o errexit
 set -o pipefail
 set -o xtrace
 
+exec 1>&2
+
 function install_packages {
 	# Setup Ansible on host VM
 	sudo apt-get update && sudo apt-get install -y software-properties-common


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix/debugging.

## What is the current behavior?

Still seeing `exited 123` errors even after my last PR went in (which is not surprising as I didn't actually change any logic). Not sure why my PR and AMI build didn't trip up the error but its definitely happening still https://github.com/supabase/postgres/actions/runs/27033322500/job/79809778592. Looking at the logs that we now have the last line printed is `umount /mnt` and claude-code guesses that it has to do with salt being updated at the end in `90-cleanup.sh` and running something from post-install hooks/scripts.

## What is the new behavior?

I've set it so stdout goes to stderr for the _main_ scripts run by packer so that we don't have unbuffered stderr showing up in the middle of buffered stdout in a point that appears way too early to make sense. Now they'll both go to stderr which is unbuffered by default and should be in sync (this way we also won't lose any logs to buffers in case of OOM or something else).

## Additional context

Holding of on marking salt packages as held to see if I can trigger this once.