### PR TITLE
chore: suppress codeql paramiko host key alert in test infra

### DIFF
--- a/testinfra/test_ami_nix.py
+++ b/testinfra/test_ami_nix.py
@@ -207,7 +207,7 @@ def get_ssh_connection(instance_ip, ssh_identity_file, max_retries=10):
         try:
             # Create SSH client
             ssh = paramiko.SSHClient()
-            ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+            ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())  # codeql[py/paramiko-missing-host-key-validation] - intentional: ephemeral EC2 instances always have unknown host keys in test infra
 
             # Connect with our working parameters
             ssh.connect(


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore — suppresses a CodeQL false positive in test infrastructure.

## What is the current behavior?

CodeQL (enabled May 2026) flags `AutoAddPolicy` in `testinfra/test_ami_nix.py` as a missing server host-key validation vulnerability. The code connects to freshly-provisioned ephemeral EC2 instances whose host keys are always unknown by design.

## What is the new behavior?

Adds a `codeql[py/paramiko-missing-host-key-validation]` inline suppression annotation with a short justification comment, silencing the alert permanently regardless of line-number drift.
