### PR TITLE
ansible: pin salt to installed version

### DIFF
--- a/ansible/tasks/internal/install-salt.yml
+++ b/ansible/tasks/internal/install-salt.yml
@@ -55,3 +55,15 @@
       - salt-minion={{ salt_version }}
     state: present
     update_cache: yes
+
+- name: Pin salt packages at major version
+  tags: mmlb
+  ansible.builtin.copy:
+    content: |
+      Package: salt-common salt-minion
+      Pin: version {{ salt_version.split('.')[0] }}.*
+      Pin-Priority: 1001
+    dest: /etc/apt/preferences.d/saltstack-pin
+    owner: root
+    group: root
+    mode: "0644"

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -21,7 +21,7 @@ pgbouncer_release_checksum: sha256:6e566ae92fe3ef7f6a1b9e26d6049f7d7ca39c40e29e7
 # The checksum can be found under "Assets", in the GitHub release page for each version.
 # The binaries used are: ubuntu-aarch64 and linux-static.
 # https://github.com/PostgREST/postgrest/releases
-postgrest_release: 14.5
+postgrest_release: "14.5" # keep this as a string, otherwise gets treated as yaml float which will likely only lead to tears
 postgrest_arm_release_checksum: sha256:70c07ff875710538903c9b6b6de00e126250e335da25b0ff7d1b13bb4c94bf41
 postgrest_x86_release_checksum: sha256:ab5cc7e974d4940447991804588cfb8b3f7b2c57b691f0905df04d51ede69470
 
@@ -32,7 +32,7 @@ gotrue_x86_release_checksum: sha1:3d9c625505b504b9cddc2bec429a37000846f84d
 
 aws_cli_release: 2.23.11
 
-salt_version: 3007.14
+salt_version: "3007.14" # keep this as a string, otherwise gets treated as yaml float which will likely only lead to tears
 
 golang_version: 1.22.11
 golang_version_checksum:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Build correctness fix, maybe bug fix too.

## What is the current behavior?

We install a specific version of salt (https://github.com/supabase/postgres/blob/develop/ansible/vars.yml#L35) but the blanket apt-get update/upgrade in https://github.com/supabase/postgres/blob/develop/scripts/90-cleanup.sh#L43-L44 is currently upgrading salt to recently released 3008.

## What is the new behavior?

With package marked held it does not upgrade unexpectedly

## Additional context

This may or may not be the cause of recent AMI amd64 build failures. Either way this is good to have because we would want to be in charge of upgrades.