### PR TITLE
ansible: move tcp_keepalive_time to tuned profile

### DIFF
--- a/ansible/tasks/setup-system.yml
+++ b/ansible/tasks/setup-system.yml
@@ -154,13 +154,6 @@
         owner: 'root'
         group: 'root'
 
-    # Set Sysctl params specific to keepalives
-    - name: Set net.ipv4.tcp_keepalive_time=1800
-      ansible.builtin.sysctl:
-        name: 'net.ipv4.tcp_keepalive_time'
-        value: 1800
-        state: 'present'
-
     - name: Set net.ipv4.tcp_keepalive_intvl=60
       ansible.builtin.sysctl:
         name: 'net.ipv4.tcp_keepalive_intvl'

--- a/ansible/tasks/setup-tuned.yml
+++ b/ansible/tasks/setup-tuned.yml
@@ -111,6 +111,19 @@
             state: 'present'
             value: 10
 
+
+        - name: tuned - Set tcp_keepalive_time
+          become: true
+          community.general.ini_file:
+            create: true
+            group: 'root'
+            mode: '0644'
+            no_extra_spaces: true
+            option: 'net.ipv4.tcp_keepalive_time'
+            path: '/etc/tuned/profiles/postgresql/tuned.conf'
+            section: 'sysctl'
+            state: 'present'
+            value: 1800
         - name: tuned - Load zstd compressor module
           become: true
           community.general.modprobe:


### PR DESCRIPTION
Relocates net.ipv4.tcp_keepalive_time from setup-system.yml to the postgresql tuned profile in setup-tuned.yml to ensure consistent system tuning management.