### PR TITLE
ansible: move ip_local_reserved_ports to tuned profile

### DIFF
--- a/ansible/tasks/setup-system.yml
+++ b/ansible/tasks/setup-system.yml
@@ -154,14 +154,6 @@
         owner: 'root'
         group: 'root'
 
-    # postgres_exporter runs on port 9187 and postgresT occasionlly chooses it as random srcport
-    # adminapi for 8085
-    - name: Set net.ipv4.ip_local_reserved_ports
-      ansible.builtin.sysctl:
-        name: 'net.ipv4.ip_local_reserved_ports'
-        value: '9187,8085'
-        state: 'present'
-
 - name: Execute tasks when (debpkg_mode or nixpkg_mode)
   when:
     - (debpkg_mode or nixpkg_mode)

--- a/ansible/tasks/setup-tuned.yml
+++ b/ansible/tasks/setup-tuned.yml
@@ -120,6 +120,21 @@
         state: 'present'
         value: 1800
 
+    # Reserve ports to prevent they are used as random srcports:
+    # 3000: postgrest, 3001: postgrest-admin, 8085: adminapi, 9122: pgbouncer_exporter, 9187: postgres_exporter, 9999: vector
+    - name: tuned - Set ip_local_reserved_ports
+      become: true
+      community.general.ini_file:
+        create: true
+        group: 'root'
+        mode: '0644'
+        no_extra_spaces: true
+        option: 'net.ipv4.ip_local_reserved_ports'
+        path: '/etc/tuned/profiles/postgresql/tuned.conf'
+        section: 'sysctl'
+        state: 'present'
+        value: '3000,3001,8085,9122,9187,9999'
+
     - name: tuned - Enable zswap if swap is present
       when:
         - ansible_facts['swaptotal_mb'] > 0


### PR DESCRIPTION
Relocates net.ipv4.ip_local_reserved_ports from setup-system.yml to the postgresql tuned profile in setup-tuned.yml.