### PR TITLE
ansible: move panic_on_oom to tuned profile

### DIFF
--- a/ansible/tasks/setup-system.yml
+++ b/ansible/tasks/setup-system.yml
@@ -158,14 +158,6 @@
   when:
     - (debpkg_mode or nixpkg_mode)
   block:
-    # Set Sysctl params for restarting the OS on OOM after 10
-    - name: Set vm.panic_on_oom=1
-      ansible.builtin.sysctl:
-        name: 'vm.panic_on_oom'
-        reload: true
-        state: 'present'
-        value: '1'
-
     - name: Set kernel.panic=10
       ansible.builtin.sysctl:
         name: 'kernel.panic'

--- a/ansible/tasks/setup-tuned.yml
+++ b/ansible/tasks/setup-tuned.yml
@@ -1,6 +1,6 @@
-- name: Install and configure tuned when stage2_nix
+- name: Install and configure tuned
   when:
-    - (stage2_nix or nixpkg_mode)
+    - (stage2_nix or nixpkg_mode or debpkg_mode)
   block:
     - name: Install tuned
       ansible.builtin.apt:
@@ -134,6 +134,19 @@
         section: 'sysctl'
         state: 'present'
         value: '3000,3001,8085,9122,9187,9999'
+
+    - name: tuned - Set vm.panic_on_oom
+      become: true
+      community.general.ini_file:
+        create: true
+        group: 'root'
+        mode: '0644'
+        no_extra_spaces: true
+        option: 'vm.panic_on_oom'
+        path: '/etc/tuned/profiles/postgresql/tuned.conf'
+        section: 'sysctl'
+        state: 'present'
+        value: 1
 
     - name: tuned - Enable zswap if swap is present
       when:


### PR DESCRIPTION
Relocates vm.panic_on_oom from setup-system.yml to the postgresql tuned profile in setup-tuned.yml, preserving the platform-specific 'when' condition.