### PR TITLE
ansible: move kernel.panic to tuned profile

### DIFF
--- a/ansible/tasks/setup-system.yml
+++ b/ansible/tasks/setup-system.yml
@@ -154,17 +154,6 @@
         owner: 'root'
         group: 'root'
 
-- name: Execute tasks when (debpkg_mode or nixpkg_mode)
-  when:
-    - (debpkg_mode or nixpkg_mode)
-  block:
-    - name: Set kernel.panic=10
-      ansible.builtin.sysctl:
-        name: 'kernel.panic'
-        reload: true
-        state: 'present'
-        value: '10'
-
 - name: set hosts file
   ansible.builtin.copy:
     content: |

--- a/ansible/tasks/setup-tuned.yml
+++ b/ansible/tasks/setup-tuned.yml
@@ -148,6 +148,21 @@
         state: 'present'
         value: 1
 
+    - name: tuned - Set kernel.panic=10
+      become: true
+      community.general.ini_file:
+        create: true
+        group: 'root'
+        mode: '0644'
+        no_extra_spaces: true
+        option: 'kernel.panic'
+        path: '/etc/tuned/profiles/postgresql/tuned.conf'
+        section: 'sysctl'
+        state: 'present'
+        value: 10
+      when:
+        - (debpkg_mode or nixpkg_mode)
+
     - name: tuned - Enable zswap if swap is present
       when:
         - ansible_facts['swaptotal_mb'] > 0


### PR DESCRIPTION
Relocates kernel.panic=10 from setup-system.yml to the postgresql tuned profile in setup-tuned.yml, preserving the 'when' condition. This PR also removes the now-empty task block from setup-system.yml. **Note: This PR depends on the prior PR (INDATA-378-05) and should be merged after it.**