### PR TITLE
ansible: move somaxconn to tuned profile

### DIFF
--- a/ansible/tasks/setup-system.yml
+++ b/ansible/tasks/setup-system.yml
@@ -165,8 +165,3 @@
     group: 'root'
   when:
     - (debpkg_mode or stage2_nix)
-
-- name: configure system
-  ansible.posix.sysctl:
-    name: 'net.core.somaxconn'
-    value: 16834

--- a/ansible/tasks/setup-tuned.yml
+++ b/ansible/tasks/setup-tuned.yml
@@ -176,6 +176,19 @@
       when:
         - (debpkg_mode or nixpkg_mode)
 
+    - name: tuned - Set net.core.somaxconn
+      become: true
+      community.general.ini_file:
+        create: true
+        group: 'root'
+        mode: '0644'
+        no_extra_spaces: true
+        option: 'net.core.somaxconn'
+        path: '/etc/tuned/profiles/postgresql/tuned.conf'
+        section: 'sysctl'
+        state: 'present'
+        value: 16834
+
     - name: tuned - Enable zswap if swap is present
       when:
         - ansible_facts['swaptotal_mb'] > 0


### PR DESCRIPTION
Relocates net.core.somaxconn from setup-system.yml to the postgresql tuned profile in setup-tuned.yml.