### PR TITLE
testinfra: Fix InstanceType and startup error handling

### DIFF
--- a/testinfra/test_ami_nix.py
+++ b/testinfra/test_ami_nix.py
@@ -291,7 +291,7 @@ def host():
                 "HttpEndpoint": "enabled",
             },
             IamInstanceProfile={"Name": "pg-ap-southeast-1"},
-            InstanceType="t4g.micro" if image.architecture == "arm64" else "t3.micro",
+            InstanceType="t4g.micro" if image.architecture == "arm64" else "t3.small",
             MinCount=1,
             MaxCount=1,
             ImageId=image.id,

--- a/testinfra/test_ami_nix.py
+++ b/testinfra/test_ami_nix.py
@@ -411,7 +411,7 @@ users:
 
     def is_healthy(ssh) -> bool:
         health_checks = [
-            ("postgres", "sudo -u postgres /usr/bin/pg_isready -U postgres"),
+            ("postgresql", "sudo -u postgres /usr/bin/pg_isready -U postgres"),
             (
                 "adminapi",
                 f"curl -sf -k --connect-timeout 30 --max-time 60 https://localhost:8085/health -H 'apikey: {supabase_admin_key}'",


### PR DESCRIPTION
This is used to get logs from journalctl but when the service name is wrong there's nothing to report and thus is very unhelpful.

## What kind of change does this PR introduce?

Buf fix 

## What is the current behavior?

If testinfra times out waiting on a healthy postgres service it will use journalctl to show last few lines of log, but the service name is wrong therefore the logs are empty. For example see https://github.com/supabase/postgres/actions/runs/27230790541/job/80420986600#step:12:161

## What is the new behavior?

Correct systemd service name should give us logs next time we hit this.