### PR TITLE
ci: build-ami: Use arch in EXECUTION_ID

### DIFF
--- a/.github/actions/build-ami/action.yml
+++ b/.github/actions/build-ami/action.yml
@@ -49,7 +49,7 @@ runs:
       id: set-execution-id
       shell: bash
       run: |
-        EXECUTION_ID="${{ github.run_id }}-${{ inputs.postgres_version }}"
+        EXECUTION_ID="${{ github.run_id }}-${{ inputs.postgres_version }}-${{ inputs.arch }}"
         echo "EXECUTION_ID=$EXECUTION_ID" >> $GITHUB_ENV
         echo "execution_id=$EXECUTION_ID" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, maybe

## What is the current behavior?

Seeing some testinfra errors in CI that are just plain weird. Didn't have amd64 flavored builds before so maybe related.

## What is the new behavior?

Release AMI Nix already had the arch in the EXECUTION_ID, so lets mimic that, can't hurt right?

## Additional context

Looking to rework a bunch of this stuff as soon as I get a chance but keep getting hit with random issues while trying to make things incrementally better :(