### PR TITLE
chore(ansible/vars): bump ansible vars for admin-api

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.091-orioledb"
-  postgres17: "17.6.1.134"
-  postgres15: "15.14.1.134"
+  postgresorioledb-17: "17.6.0.092-orioledb"
+  postgres17: "17.6.1.135"
+  postgres15: "15.14.1.135"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1
@@ -60,7 +60,7 @@ postgres_exporter_release_checksum:
   arm64: sha256:29ba62d538b92d39952afe12ee2e1f4401250d678ff4b354ff2752f4321c87a0
   amd64: sha256:cb89fc5bf4485fb554e0d640d9684fae143a4b2d5fa443009bd29c59f9129e84
 
-adminapi_release: "0.105.2"
+adminapi_release: "0.106.0"
 adminmgr_release: "0.36.1"
 supabase_admin_agent_release: 1.11.2
 supabase_admin_agent_splay: 30s


### PR DESCRIPTION
## What kind of change does this PR introduce?

This bumps the admin-api release used by default in new postgres deployments.  The latest admin-api release changes how firewall rules are managed on supabase projects.


- `ansible/vars.yml`: `adminapi_release` `0.105.2` → `0.106.0`
- `postgres15`: `15.14.1.134` → `15.14.1.135`
- `postgres17`: `17.6.1.134` → `17.6.1.135`
- `postgresorioledb-17`: `17.6.0.091-orioledb` → `17.6.0.092-orioledb`
