### PR TITLE
chore(deps): bump admin-mgr 0.38.0, admin-api 0.107.0, pg patch versions

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.091-orioledb"
-  postgres17: "17.6.1.134"
-  postgres15: "15.14.1.134"
+  postgresorioledb-17: "17.6.0.092-orioledb"
+  postgres17: "17.6.1.135"
+  postgres15: "15.14.1.135"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1
@@ -60,8 +60,8 @@ postgres_exporter_release_checksum:
   arm64: sha256:29ba62d538b92d39952afe12ee2e1f4401250d678ff4b354ff2752f4321c87a0
   amd64: sha256:cb89fc5bf4485fb554e0d640d9684fae143a4b2d5fa443009bd29c59f9129e84
 
-adminapi_release: "0.105.2"
-adminmgr_release: "0.36.1"
+adminapi_release: "0.107.0"
+adminmgr_release: "0.38.0"
 supabase_admin_agent_release: 1.11.2
 supabase_admin_agent_splay: 30s
 


### PR DESCRIPTION
## Summary

Bumps `ansible/vars.yml` so new AMIs built from this branch ship the host-lock work merged across admin-mgr, supabase-admin-api, and salt:

- `adminmgr_release`: `0.36.1` → `0.38.0`
- `adminapi_release`: `0.105.2` → `0.107.0`

Plus the three Postgres patch version bumps to match the latest released tags:

- `postgresorioledb-17`: `17.6.0.091-orioledb` → `17.6.0.092-orioledb`
- `postgres17`: `17.6.1.134` → `17.6.1.135`
- `postgres15`: `15.14.1.134` → `15.14.1.135`

## Context

[INDATA-722](https://linear.app/supabase/issue/INDATA-722) introduced a host-level coordination lock at `/var/run/admin-mgr/lock.json` that admin-mgr writes for the duration of every long-running operation (restore, replica setup, walg toggle). admin-api and salt both consult the lock before any postgres lifecycle action so external restarts and reloads cannot interrupt a WAL-G restore mid-recovery.

For full design / contract see:
- supabase/admin-mgr README — `The host lock model` section
- supabase/supabase-admin-api README — `Coordinating with admin-mgr (host lock)` section
- supabase/admin-mgr#101, supabase/supabase-admin-api#332, supabase/salt#577

## Rollout

- This PR: new AMIs picking up the lock-aware binaries directly.
- Existing instances: covered by the salt pillar bump in supabase/salt#577 (admin-mgr and admin-api versions pinned to match).

## Test plan

- [x] admin-mgr 0.38.0 manually validated end-to-end on a staging instance (11 lock-behaviour tests + a real restore cycle).
- [x] supabase-admin-api 0.107.0 manually validated end-to-end via the test-admin-api script against a staging box (L1 dedup, L2 chokepoint, sync acquire, exit-75 mapping).
- [ ] Build the AMIs and smoke-test on a fresh staging project.
- [ ] Confirm the three pg patch bumps land cleanly through the existing CI matrix.
