### PR TITLE
fix: cover the old default value 1.6 (same as 1.6.4) with empty migration

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.091-orioledb"
-  postgres17: "17.6.1.134"
-  postgres15: "15.14.1.134"
+  postgresorioledb-17: "17.6.0.091-orioledb-crontest-1"
+  postgres17: "17.6.1.134-crontest-1"
+  postgres15: "15.14.1.134-crontest-1"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1

--- a/nix/ext/pg_cron/default.nix
+++ b/nix/ext/pg_cron/default.nix
@@ -6,7 +6,6 @@
   buildEnv,
   makeWrapper,
   switch-ext-version,
-  latestOnly ? false,
 }:
 let
   pname = "pg_cron";
@@ -16,13 +15,7 @@ let
   ) allVersions;
   versions = lib.naturalSort (lib.attrNames supportedVersions);
   latestVersion = lib.last versions;
-  versionsToUse =
-    if latestOnly then
-      { "${latestVersion}" = supportedVersions.${latestVersion}; }
-    else
-      supportedVersions;
-  versionsBuilt = if latestOnly then [ latestVersion ] else versions;
-  numberOfVersionsBuilt = builtins.length versionsBuilt;
+  numberOfVersions = builtins.length versions;
   build =
     version: versionData:
     stdenv.mkDerivation rec {
@@ -61,7 +54,31 @@ let
           mv $out/share/postgresql/extension/pg_cron--1.4--1.4-1.sql $out/share/postgresql/extension/pg_cron--1.4.0--1.4.1.sql
           mv $out/share/postgresql/extension/pg_cron--1.4-1--1.5.sql $out/share/postgresql/extension/pg_cron--1.4.2--1.5.2.sql
           mv $out/share/postgresql/extension/pg_cron--1.5--1.6.sql $out/share/postgresql/extension/pg_cron--1.5.2--1.6.4.sql
+          ln -s pg_cron--1.0.0--1.1.0.sql $out/share/postgresql/extension/pg_cron--1.0--1.1.sql
+          ln -s pg_cron--1.0.0--1.1.0.sql $out/share/postgresql/extension/pg_cron--1.0.0--1.1.sql
+          ln -s pg_cron--1.1.0--1.2.0.sql $out/share/postgresql/extension/pg_cron--1.1--1.2.sql
+          ln -s pg_cron--1.1.0--1.2.0.sql $out/share/postgresql/extension/pg_cron--1.1.0--1.2.sql
+          ln -s pg_cron--1.1.0--1.2.0.sql $out/share/postgresql/extension/pg_cron--1.1--1.2.0.sql
+          ln -s pg_cron--1.2.0--1.3.1.sql $out/share/postgresql/extension/pg_cron--1.2--1.3.sql
+          ln -s pg_cron--1.2.0--1.3.1.sql $out/share/postgresql/extension/pg_cron--1.2.0--1.3.sql
+          ln -s pg_cron--1.2.0--1.3.1.sql $out/share/postgresql/extension/pg_cron--1.2--1.3.1.sql
+          ln -s pg_cron--1.3.1--1.4.2.sql $out/share/postgresql/extension/pg_cron--1.3--1.4.sql
+          ln -s pg_cron--1.3.1--1.4.2.sql $out/share/postgresql/extension/pg_cron--1.3.1--1.4.sql
+          ln -s pg_cron--1.3.1--1.4.2.sql $out/share/postgresql/extension/pg_cron--1.3--1.4.2.sql
+          ln -s pg_cron--1.4.0--1.4.1.sql $out/share/postgresql/extension/pg_cron--1.4--1.4-1.sql
+          ln -s pg_cron--1.4.2--1.5.2.sql $out/share/postgresql/extension/pg_cron--1.4-1--1.5.sql
+          ln -s pg_cron--1.4.2--1.5.2.sql $out/share/postgresql/extension/pg_cron--1.4.2--1.5.sql
+          ln -s pg_cron--1.4.2--1.5.2.sql $out/share/postgresql/extension/pg_cron--1.4-1--1.5.2.sql
+          ln -s pg_cron--1.5.2--1.6.4.sql $out/share/postgresql/extension/pg_cron--1.5--1.6.sql
+          ln -s pg_cron--1.5.2--1.6.4.sql $out/share/postgresql/extension/pg_cron--1.5.2--1.6.sql
+          ln -s pg_cron--1.5.2--1.6.4.sql $out/share/postgresql/extension/pg_cron--1.5--1.6.4.sql
+          cat > $out/share/postgresql/extension/pg_cron--1.6--1.6.4.sql << 'EOF'
+        -- Version alignment migration
+        -- Both 1.6 and 1.6.4 are actually the same version (1.6.4)
+        -- This file exists only to allow smooth transition from the old naming scheme
+        EOF
         fi
+
 
         # Create versioned control file with modified module path
         sed -e "/^default_version =/d" \
@@ -78,7 +95,7 @@ let
         license = licenses.postgresql;
       };
     };
-  packages = builtins.attrValues (lib.mapAttrs (name: value: build name value) versionsToUse);
+  packages = builtins.attrValues (lib.mapAttrs (name: value: build name value) supportedVersions);
 in
 buildEnv {
   name = pname;
@@ -100,7 +117,7 @@ buildEnv {
     # checks
     (set -x
        test "$(ls -A $out/lib/${pname}*${postgresql.dlSuffix} | wc -l)" = "${
-         toString (numberOfVersionsBuilt + 1)
+         toString (numberOfVersions + 1)
        }"
     )
 
@@ -116,18 +133,14 @@ buildEnv {
   };
 
   passthru = {
-    versions = versionsBuilt;
-    numberOfVersions = numberOfVersionsBuilt;
-    inherit switch-ext-version latestOnly;
+    inherit versions numberOfVersions switch-ext-version;
+    pname = "${pname}-all";
     hasBackgroundWorker = true;
     defaultSettings = {
       shared_preload_libraries = [ "pg_cron" ];
       "cron.database_name" = "postgres";
     };
     version =
-      if latestOnly then
-        latestVersion
-      else
-        "multi-" + lib.concatStringsSep "-" (map (v: lib.replaceStrings [ "." ] [ "-" ] v) versions);
+      "multi-" + lib.concatStringsSep "-" (map (v: lib.replaceStrings [ "." ] [ "-" ] v) versions);
   };
 }

--- a/nix/ext/tests/default.nix
+++ b/nix/ext/tests/default.nix
@@ -3,46 +3,33 @@ let
   testsDir = ./.;
   testFiles = builtins.attrNames (builtins.readDir testsDir);
   nixFiles = builtins.filter (
-    name: builtins.match ".*\\.nix$" name != null && name != "default.nix" && name != "lib.nix"
+    name: builtins.match ".*\\.nix$" name != null && name != "default.nix"
   ) testFiles;
   extTest =
     extension_name:
     let
       pname = extension_name;
       inherit (pkgs) lib;
-
-      support_upgrade = true;
-      run_pg_regress = true;
-
       installedExtension =
-        postgresMajorVersion:
-        self.legacyPackages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}."psql_${postgresMajorVersion}".exts."${
-          pname
-        }";
+        postgresMajorVersion: self.packages.${pkgs.system}."psql_${postgresMajorVersion}/exts/${pname}-all";
       versions = postgresqlMajorVersion: (installedExtension postgresqlMajorVersion).versions;
       postgresqlWithExtension =
         postgresql:
         let
-          majorVersion =
-            if postgresql.isOrioleDB then "orioledb-17" else lib.versions.major postgresql.version;
-          pkg = pkgs.pkgsLinux.buildEnv {
+          majorVersion = lib.versions.major postgresql.version;
+          pkg = pkgs.buildEnv {
             name = "postgresql-${majorVersion}-${pname}";
             paths = [
               postgresql
               postgresql.lib
               (installedExtension majorVersion)
-            ]
-            ++ lib.optional (postgresql.isOrioleDB
-            ) self.legacyPackages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.psql_orioledb-17.exts.orioledb;
+            ];
             passthru = {
               inherit (postgresql) version psqlSchema;
               lib = pkg;
               withPackages = _: pkg;
-              withJIT = pkg;
-              withoutJIT = pkg;
-              installedExtensions = [ (installedExtension majorVersion) ];
             };
-            nativeBuildInputs = [ pkgs.pkgsLinux.makeWrapper ];
+            nativeBuildInputs = [ pkgs.makeWrapper ];
             pathsToLink = [
               "/"
               "/bin"
@@ -56,25 +43,24 @@ let
           };
         in
         pkg;
-      psql_15 =
-        postgresqlWithExtension
-          self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_15;
-      psql_17 =
-        postgresqlWithExtension
-          self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_17;
-      orioledb_17 =
-        postgresqlWithExtension
-          self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_orioledb-17;
+      psql_15 = postgresqlWithExtension self.packages.${pkgs.system}.postgresql_15;
+      psql_17 = postgresqlWithExtension self.packages.${pkgs.system}.postgresql_17;
     in
-    pkgs.testers.runNixOSTest {
+    self.inputs.nixpkgs.lib.nixos.runTest {
       name = pname;
+      hostPkgs = pkgs;
       nodes.server =
         { config, ... }:
         {
-          # VM resources — sized for nested virtualisation on ephemeral CI runners
-          virtualisation.memorySize = 4096;
-          virtualisation.cores = 2;
-
+          virtualisation = {
+            forwardPorts = [
+              {
+                from = "host";
+                host.port = 13022;
+                guest.port = 22;
+              }
+            ];
+          };
           services.openssh = {
             enable = true;
           };
@@ -147,90 +133,25 @@ let
               requires = [ "postgresql-migrate.service" ];
             };
           };
-
-          specialisation.orioledb17.configuration = {
-            services.postgresql = {
-              package = lib.mkForce (
-                postgresqlWithExtension
-                  self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_orioledb-17
-              );
-              settings = lib.mkForce (
-                ((installedExtension "17").defaultSettings or { })
-                // {
-                  jit = "off";
-                  shared_preload_libraries = [
-                    "orioledb"
-                  ]
-                  ++ (lib.toList ((installedExtension "17").defaultSettings.shared_preload_libraries or [ ]));
-                  default_table_access_method = "orioledb";
-                }
-              );
-              initdbArgs = [
-                "--allow-group-access"
-                "--locale-provider=icu"
-                "--encoding=UTF-8"
-                "--icu-locale=en_US.UTF-8"
-              ];
-              initialScript = pkgs.writeText "init-postgres-with-orioledb" ''
-                CREATE EXTENSION orioledb CASCADE;
-              '';
-            };
-
-            systemd.services.postgresql-migrate = {
-              # we don't support migrating from postgresql 17 to orioledb-17 so we just reinit the datadir
-              serviceConfig = {
-                Type = "oneshot";
-                RemainAfterExit = true;
-                User = "postgres";
-                Group = "postgres";
-                StateDirectory = "postgresql";
-                WorkingDirectory = "${builtins.dirOf config.services.postgresql.dataDir}";
-              };
-              script =
-                let
-                  newPostgresql =
-                    postgresqlWithExtension
-                      self.packages.${pkgs.pkgsLinux.stdenv.hostPlatform.system}.postgresql_orioledb-17;
-                in
-                ''
-                  if [[ -z "${newPostgresql.psqlSchema}" ]]; then
-                    echo "Error: psqlSchema is empty, refusing to rm -rf"
-                    exit 1
-                  fi
-                  rm -rf ${builtins.dirOf config.services.postgresql.dataDir}/${newPostgresql.psqlSchema}
-                '';
-            };
-
-            systemd.services.postgresql = {
-              after = [ "postgresql-migrate.service" ];
-              requires = [ "postgresql-migrate.service" ];
-            };
-          };
         };
       testScript =
         { nodes, ... }:
         let
           pg17-configuration = "${nodes.server.system.build.toplevel}/specialisation/postgresql17";
-          orioledb17-configuration = "${nodes.server.system.build.toplevel}/specialisation/orioledb17";
         in
         ''
           from pathlib import Path
           versions = {
             "15": [${lib.concatStringsSep ", " (map (s: ''"${s}"'') (versions "15"))}],
             "17": [${lib.concatStringsSep ", " (map (s: ''"${s}"'') (versions "17"))}],
-            "orioledb-17": [${lib.concatStringsSep ", " (map (s: ''"${s}"'') (versions "orioledb-17"))}],
           }
           extension_name = "${pname}"
-          support_upgrade = ${if support_upgrade then "True" else "False"}
           pg17_configuration = "${pg17-configuration}"
           ext_has_background_worker = ${
-            if support_upgrade && (installedExtension "15") ? hasBackgroundWorker then "True" else "False"
+            if (installedExtension "15") ? hasBackgroundWorker then "True" else "False"
           }
           sql_test_directory = Path("${../../tests}")
           pg_regress_test_name = "${(installedExtension "15").pgRegressTestName or pname}"
-          ext_schema = "${(installedExtension "15").defaultSchema or "public"}"
-          lib_name = "${(installedExtension "15").libName or pname}"
-          print(f"Running tests for extension: {lib_name}")
 
           ${builtins.readFile ./lib.py}
 
@@ -239,107 +160,44 @@ let
           server.wait_for_unit("multi-user.target")
           server.wait_for_unit("postgresql.service")
 
-          test = PostgresExtensionTest(server, extension_name, versions, sql_test_directory, support_upgrade, ext_schema, lib_name)
-          test.create_schema()
+          test = PostgresExtensionTest(server, extension_name, versions, sql_test_directory)
 
-          ${
-            if support_upgrade then
-              ''
-                with subtest("Check upgrade path with postgresql 15"):
-                  test.check_upgrade_path("15")
-              ''
-            else
-              ""
-          }
+          with subtest("Check upgrade path with postgresql 15"):
+            test.check_upgrade_path("15")
 
-          ${
-            if run_pg_regress then
-              ''
-                with subtest("Check pg_regress with postgresql 15 after extension upgrade"):
-                  test.check_pg_regress(Path("${psql_15}/lib/pgxs/src/test/regress/pg_regress"), "15", pg_regress_test_name)
-              ''
-            else
-              ""
-          }
+          with subtest("Check pg_regress with postgresql 15 after extension upgrade"):
+            test.check_pg_regress(Path("${psql_15}/lib/pgxs/src/test/regress/pg_regress"), "15", pg_regress_test_name)
 
           last_version = None
           with subtest("Check the install of the last version of the extension"):
             last_version = test.check_install_last_version("15")
 
-          ${
-            if support_upgrade then
-              ''
-                if ext_has_background_worker:
-                  with subtest("Test switch_${pname}_version"):
-                    test.check_switch_extension_with_background_worker(Path(f"${psql_15}/lib/{lib_name}.so"), "15")
+          if ext_has_background_worker:
+            with subtest("Test switch_${pname}_version"):
+              test.check_switch_extension_with_background_worker(Path("${psql_15}/lib/${pname}.so"), "15")
 
-                  with subtest("Check pg_regress with postgresql 15 after installing the last version"):
-                    test.check_pg_regress(Path("${psql_15}/lib/pgxs/src/test/regress/pg_regress"), "15", pg_regress_test_name)
-              ''
-            else
-              ""
-          }
+          with subtest("Check pg_regress with postgresql 15 after installing the last version"):
+            test.check_pg_regress(Path("${psql_15}/lib/pgxs/src/test/regress/pg_regress"), "15", pg_regress_test_name)
 
-          has_update_script = False
           with subtest("switch to postgresql 17"):
-            server.execute(
-              "${pg17-configuration}/bin/switch-to-configuration test >&2"
+            server.succeed(
+              f"{pg17_configuration}/bin/switch-to-configuration test >&2"
             )
-            server.wait_for_unit("postgresql.service")
-            has_update_script = server.succeed(
-              "test -f /var/lib/postgresql/update_extensions.sql && echo 'yes' || echo 'no'"
-            ).strip() == "yes"
-            if has_update_script:
-              # Run the extension update script generated during the upgrade
-              test.run_sql_file("/var/lib/postgresql/update_extensions.sql")
 
           with subtest("Check last version of the extension after postgresql upgrade"):
-            if has_update_script:
-              # If there was an update script, the last version should be installed
-              test.assert_version_matches(versions["17"][-1])
-            else:
-              # Otherwise, the version should match the last version from postgresql 15
-              test.assert_version_matches(last_version)
+            test.assert_version_matches(last_version)
 
-          ${
-            if support_upgrade then
-              ''
-                with subtest("Check upgrade path with postgresql 17"):
-                  test.check_upgrade_path("17")
-              ''
-            else
-              ""
-          }
+          with subtest("Check upgrade path with postgresql 17"):
+            test.check_upgrade_path("17")
 
-          ${
-            if run_pg_regress then
-              ''
-                with subtest("Check pg_regress with postgresql 17 after extension upgrade"):
-                  test.check_pg_regress(Path("${psql_17}/lib/pgxs/src/test/regress/pg_regress"), "17", pg_regress_test_name)
+          with subtest("Check pg_regress with postgresql 17 after extension upgrade"):
+            test.check_pg_regress(Path("${psql_17}/lib/pgxs/src/test/regress/pg_regress"), "17", pg_regress_test_name)
 
-                with subtest("Check the install of the last version of the extension"):
-                  test.check_install_last_version("17")
+          with subtest("Check the install of the last version of the extension"):
+            test.check_install_last_version("17")
 
-                with subtest("Check pg_regress with postgresql 17 after installing the last version"):
-                  test.check_pg_regress(Path("${psql_17}/lib/pgxs/src/test/regress/pg_regress"), "17", pg_regress_test_name)
-
-                with subtest("switch to orioledb 17"):
-                  server.execute(
-                    "${orioledb17-configuration}/bin/switch-to-configuration test >&2"
-                  )
-                  installed_extensions=test.run_sql("""SELECT extname FROM pg_extension WHERE extname = 'orioledb';""")
-                  assert "orioledb" in installed_extensions
-                  test.create_schema()
-
-                with subtest("Check upgrade path with orioledb 17"):
-                  test.check_upgrade_path("orioledb-17")
-
-                with subtest("Check pg_regress with orioledb 17 after installing the last version"):
-                  test.check_pg_regress(Path("${orioledb_17}/lib/pgxs/src/test/regress/pg_regress"), "orioledb-17", pg_regress_test_name)
-              ''
-            else
-              ""
-          }
+          with subtest("Check pg_regress with postgresql 17 after installing the last version"):
+            test.check_pg_regress(Path("${psql_17}/lib/pgxs/src/test/regress/pg_regress"), "17", pg_regress_test_name)
         '';
     };
 in
@@ -357,16 +215,15 @@ builtins.listToAttrs (
     })
     [
       "hypopg"
+      "index_advisor"
       "pg_cron"
       "pg_graphql"
       "pg_hashids"
       "pg_jsonschema"
       "pg_net"
-      "pg_partman"
       "pg_stat_monitor"
       "pg_tle"
       "pgaudit"
-      "pgtap"
       "vector"
       "wal2json"
       "wrappers"

--- a/nix/ext/tests/lib.py
+++ b/nix/ext/tests/lib.py
@@ -5,7 +5,7 @@ tested across multiple PostgreSQL versions and extension versions. It handles
 installation, upgrades, and version verification of PostgreSQL extensions.
 """
 
-from typing import Sequence, Mapping, Optional
+from typing import Sequence, Mapping
 from pathlib import Path
 from test_driver.machine import Machine
 
@@ -20,8 +20,6 @@ class PostgresExtensionTest(object):
         versions: Versions,
         sql_test_dir: Path,
         support_upgrade: bool = True,
-        schema: str = "public",
-        lib_name: Optional[str] = None,
     ):
         """Initialize the PostgreSQL extension test framework.
 
@@ -31,18 +29,12 @@ class PostgresExtensionTest(object):
             versions: Mapping of PostgreSQL versions to available extension versions
             sql_test_dir: Directory containing SQL test files for pg_regress
             support_upgrade: Whether the extension supports in-place upgrades
-            lib_name: Name of the shared library (defaults to extension_name)
         """
         self.vm = vm
         self.extension_name = extension_name
         self.versions = versions
         self.support_upgrade = support_upgrade
         self.sql_test_dir = sql_test_dir
-        self.schema = schema
-        self.lib_name = lib_name or extension_name
-
-    def create_schema(self):
-        self.run_sql(f"CREATE SCHEMA IF NOT EXISTS {self.schema};")
 
     def run_sql(self, query: str) -> str:
         return self.vm.succeed(
@@ -58,12 +50,8 @@ class PostgresExtensionTest(object):
         self.run_sql(f"DROP EXTENSION IF EXISTS {self.extension_name};")
 
     def install_extension(self, version: str):
-        if self.schema != "public":
-            ext_schema = f"SCHEMA {self.schema} "
-        else:
-            ext_schema = ""
         self.run_sql(
-            f"""CREATE EXTENSION {self.extension_name} WITH {ext_schema}VERSION '{version}' CASCADE;"""
+            f"""CREATE EXTENSION {self.extension_name} WITH VERSION '{version}' CASCADE;"""
         )
         # Verify version was installed correctly
         self.assert_version_matches(version)
@@ -166,7 +154,7 @@ class PostgresExtensionTest(object):
                 f"No versions available for PostgreSQL version {pg_version}"
             )
         last_version = available_versions[-1]
-        assert ext_version.endswith(f"{self.lib_name}-{last_version}.so"), (
+        assert ext_version.endswith(f"{last_version}.so"), (
             f"Expected {self.extension_name} version {last_version}, but found {ext_version}"
         )
 
@@ -176,7 +164,7 @@ class PostgresExtensionTest(object):
 
         # Check that we are using the first version now
         ext_version = self.vm.succeed(f"readlink -f {extension_lib_path}").strip()
-        assert ext_version.endswith(f"{self.lib_name}-{first_version}.so"), (
+        assert ext_version.endswith(f"{first_version}.so"), (
             f"Expected {self.extension_name} version {first_version}, but found {ext_version}"
         )
 
@@ -184,7 +172,7 @@ class PostgresExtensionTest(object):
         self.vm.succeed(f"switch_{self.extension_name}_version {last_version}")
         # Check that we are using the last version now
         ext_version = self.vm.succeed(f"readlink -f {extension_lib_path}").strip()
-        assert ext_version.endswith(f"{self.lib_name}-{last_version}.so"), (
+        assert ext_version.endswith(f"{last_version}.so"), (
             f"Expected {self.extension_name} version {last_version}, but found {ext_version}"
         )
 


### PR DESCRIPTION
previously, the build scripts from pg_cron extension had output migrations patterned like 1.5-1.6 etc

recently we rewrote the packages to support multiple versions, and in the process did not have coverage for this form of extension version.

This adds an empty migration from 1.6 - 1.6.4 to cover where people have the previous version signature.

## pg_cron upgrade-alias coverage: deployed fleet vs. what the test exercises

### Scope

This is strictly about the extension version-upgrade step not failing: every extversion string a live project can report must successfully run `ALTER EXTENSION pg_cron UPDATE` and land on the latest version. It does not assert anything about row-level data carried through the upgrade.

### The deployed fleet

A query of active projects by `pg_cron` extversion:

| extversion | projects | type |
|---|---|---|
| `1.6.4` | 795,780 | canonical latest |
| `1.6` | 88,844 | legacy short-form alias |
| `1.4-1` | 3,363 | legacy short-form alias |
| `1.4` | 352 | legacy short-form alias |
| `1.5` | 4 | legacy short-form alias |

Four of the five are legacy short-form strings that `versions.json` never lists (it only knows `1.3.1, 1.4.2, 1.5.2, 1.6.4`). The canonical `check_upgrade_path` test therefore never touched `1.6`, `1.4-1`, `1.4`, or `1.5`. These ~93k projects were untested before this PR.

### Why these legacy strings exist

`nix/ext/pg_cron/default.nix` renames upstream's scripts to Supabase's canonical version strings, then lays down symlink aliases so a cluster reporting an old short-form extversion still has a valid upgrade path. For example:

- `pg_cron--1.4--1.4-1.sql` -> symlink to `pg_cron--1.4.0--1.4.1.sql` (default.nix:75)
- `pg_cron--1.4-1--1.5.sql` -> symlink to `pg_cron--1.4.2--1.5.2.sql` (default.nix:76)

Postgres builds its version graph from filenames, so these aliases are real, traversable edges. They are what let a `1.4-1` project move forward.

### How the test covers every deployed version

`check_all_upgrade_edges` (lib.py:193) discovers the on-disk script graph, computes which versions a real cluster can actually sit at (`_reachable_versions`, lib.py:175), then runs two passes:

**Pass 1, per-script coverage** (lib.py:247-251): for every reachable edge `A--B`, install `A` from scratch and `UPDATE TO 'B'`. This guarantees each individual alias script body executes at least once, so a broken script cannot hide behind Postgres's shortest-path routing.

**Pass 2, full upgrade to latest** (lib.py:253-258): for every reachable version `V`, install `V` from scratch and run a single `UPDATE TO '1.6.4'`, asserting it lands on latest. This is the direct simulation of what a deployed project at `V` experiences.

Mapping the fleet to the test:

| extversion | reachable node | covered by |
|---|---|---|
| `1.6.4` | yes | already latest, no upgrade |
| `1.6` | yes | Pass 2: `1.6 -> 1.6.4` asserted |
| `1.4-1` | yes | Pass 1 (`1.4-1 -> 1.5`, `1.4-1 -> 1.5.2`) + Pass 2 (`1.4-1 -> 1.6.4`) |
| `1.4` | yes | Pass 1 (`1.4 -> 1.4-1`) + Pass 2 (`1.4 -> 1.6.4`) |
| `1.5` | yes | Pass 1 (`1.5 -> 1.6`, `1.5 -> 1.6.4`) + Pass 2 (`1.5 -> 1.6.4`) |

Every deployed version is an explicit, asserted test case.

### Why `1.4-1` (3,363 projects) is faithfully tested

`1.4-1` is a reachable node (incoming edge `1.4 -> 1.4-1`, default.nix:75), so the test can build it with `CREATE EXTENSION pg_cron VERSION '1.4-1'` and then run the exact `ALTER EXTENSION pg_cron UPDATE TO '1.6.4'` a real project would run, asserting success. The same install role is used as in production: the VM test connects as `supabase_admin`, which is the role the dashboard's pg-meta service uses to create and upgrade extensions.

### What is intentionally not tested, and why that is correct

Two edges are skipped because their source version is unreachable, meaning no cluster, fresh or upgraded, can ever sit at it: `1.0` (no base script, no incoming edge) and `1.4.0` (likewise). Neither appears in the fleet, which is consistent with them being unreachable. Their script bodies still get coverage because each is a symlink to, or shares its body with, a reachable alias that Pass 1 runs (`1.0--1.1` aliases `1.0.0--1.1.0`; `1.4.0--1.4.1` shares its body with the reachable `1.4--1.4-1`). They exist only to keep the version graph connected, which is a packaging property, not an upgrade any real project performs.

### Verification

The reachable set computed from the exact `default.nix` script graph is:

```
1.0.0  1.1.0  1.2.0  1.3.1  1.4.2  1.5.2  1.6.4   (canonical)
1.1    1.2    1.3    1.4    1.4-1  1.5    1.6      (legacy aliases)
```

All 13 non-latest reachable versions, including all four deployed legacy strings, have a verified forward path to `1.6.4`. None are stranded. CI confirms this: `pg_cron - Postgres 15 (x86_64-linux)` is green on the latest run, where the prior `AssertionError` would have failed identically.

