### PR TITLE
ci: Configure nix to always allow substitutes

### DIFF
--- a/.github/actions/nix-install-ephemeral/action.yml
+++ b/.github/actions/nix-install-ephemeral/action.yml
@@ -45,11 +45,12 @@ runs:
       shell: bash
       run: |
         sudo tee /tmp/nix-extra.conf > /dev/null <<'NIXCONF'
+        always-allow-substitutes = true
         extra-experimental-features = nix-command flakes
+        extra-system-features = kvm
+        max-jobs = 4
         substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com
         trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-        max-jobs = 4
-        extra-system-features = kvm
         NIXCONF
 
         if [ "${{ inputs.push-to-cache }}" = "true" ]; then
@@ -57,6 +58,8 @@ runs:
         fi
 
         curl -L https://releases.nixos.org/nix/nix-2.34.6/install | sh -s -- --daemon --yes --nix-extra-conf-file /tmp/nix-extra.conf
+
+        cat /etc/nix/nix.conf
 
         # Add nix to PATH for subsequent steps
         echo "/nix/var/nix/profiles/default/bin" >> "$GITHUB_PATH"


### PR DESCRIPTION
## What kind of change does this PR introduce?

DevEx improvements

## What is the current behavior?

We use `buildEnv` and `runCommand` *a lot*, these both set `preferLocalBuild = true` which according to the nixpkgs docs:

> This is intended for very cheap commands (<1s execution time)

which is definitely not the case if we have to fire up a VM, install nix, configure it, fetch our code, fetch all the inputs and add to the store ... As a matter of fact I've run the numbers!

Before these changes:
[time start](https://github.com/supabase/postgres/actions/runs/27440583587/job/81114145389?pr=2215#step:2:5): 1781295677
[time end](https://github.com/supabase/postgres/actions/runs/27440583587/job/81117523178?pr=2215#step:2:5): 1781296916
duration: 1781296916 - 1781295677 = 1239s = 20m 39s

After these changes:
[time start](https://github.com/supabase/postgres/actions/runs/27442122967/job/81118949070?pr=2215#step:2:5): 1781297443
[time end](https://github.com/supabase/postgres/actions/runs/27442122967/job/81119013000?pr=2215#step:2:5): 1781297467
duration: 1781297467 - 1781297443 = 24s = 24s (:smile:)

Which leads to (`/me checks notes`) 51x improvement (take with some :salt:, the rest of CI is still going to take long time).

Obviously this is the best case scenario (and actually a little pessimistic since the some of the nix-build-checks are also cached and I forgot to count those) but there are plenty of PRs just bumping non-nix version numbers and ci files that will benefit from this. The nix builds should benefit too since real builds won't be waiting on concurrency limits for stuff thats actually available in binary cache.

## What is the new behavior?

nix will *always* allow substituters which nix-eval-jobs picks up on so won't emit jobs for trivial builds. Saving time, runners and $!