### PR TITLE
nix: Avoid unnecessary nixpkgs git checkout

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -265,18 +265,14 @@
     },
     "nixpkgs-oldstable": {
       "locked": {
-        "lastModified": 1712666087,
-        "narHash": "sha256-WwjUkWsjlU8iUImbivlYxNyMB1L5YVqE8QotQdL9jWc=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "a76c4553d7e741e17f289224eda135423de0491d",
-        "type": "github"
+        "lastModified": 1712670910,
+        "narHash": "sha256-GKfWxagYxrsVeVVpxsp+NvBCbMM13zJy4JKN+MxG1sM=",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.05pre609661.a76c4553d7e7/nixexprs.tar.xz"
       },
       "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "a76c4553d7e741e17f289224eda135423de0491d",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.05pre609661.a76c4553d7e7/nixexprs.tar.xz"
       }
     },
     "nixpkgs_2": {

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,7 @@
 
     nix-eval-jobs.url = "github:nix-community/nix-eval-jobs";
     nix-eval-jobs.inputs.flake-parts.follows = "flake-parts";
+    # nix-eval-jobs.inputs.nixpkgs.follows = "nixpkgs"; Uncomment when *our* nixpkgs is bumped again
     nix-eval-jobs.inputs.treefmt-nix.follows = "treefmt-nix";
 
     nix2container.url = "github:nlewo/nix2container";
@@ -38,6 +39,7 @@
     # for extensions that require older package versions
     nixpkgs-oldstable.url = "github:NixOS/nixpkgs/a76c4553d7e741e17f289224eda135423de0491d";
 
+    # Uncomment nix-eval-jobs...nixpkgs.follows when this gets bumped
     nixpkgs.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
 
     rust-overlay.url = "github:oxalica/rust-overlay";

--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,7 @@
 
     # Pin to a specific nixpkgs version that has compatible v8 and curl versions
     # for extensions that require older package versions
-    nixpkgs-oldstable.url = "github:NixOS/nixpkgs/a76c4553d7e741e17f289224eda135423de0491d";
+    nixpkgs-oldstable.url = "https://releases.nixos.org/nixpkgs/nixpkgs-24.05pre609661.a76c4553d7e7/nixexprs.tar.xz";
 
     # Uncomment nix-eval-jobs...nixpkgs.follows when this gets bumped
     nixpkgs.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";

--- a/flake.nix
+++ b/flake.nix
@@ -9,30 +9,42 @@
   inputs = {
     devshell.url = "github:numtide/devshell";
     devshell.inputs.nixpkgs.follows = "nixpkgs";
+
     flake-parts.url = "github:hercules-ci/flake-parts";
+
     flake-utils.url = "github:numtide/flake-utils";
-    git-hooks.inputs.nixpkgs.follows = "nixpkgs";
+
     git-hooks.url = "github:cachix/git-hooks.nix";
+    git-hooks.inputs.nixpkgs.follows = "nixpkgs";
+
     multigres.url = "github:multigres/multigres";
     multigres.flake = false;
-    nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
+
     nix-darwin.url = "github:nix-darwin/nix-darwin";
+    nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
+
+    nix-editor.url = "github:snowfallorg/nix-editor";
     nix-editor.inputs.nixpkgs.follows = "nixpkgs";
     nix-editor.inputs.utils.follows = "flake-utils";
-    nix-editor.url = "github:snowfallorg/nix-editor";
+
+    nix-eval-jobs.url = "github:nix-community/nix-eval-jobs";
     nix-eval-jobs.inputs.flake-parts.follows = "flake-parts";
     nix-eval-jobs.inputs.treefmt-nix.follows = "treefmt-nix";
-    nix-eval-jobs.url = "github:nix-community/nix-eval-jobs";
-    nix2container.inputs.nixpkgs.follows = "nixpkgs";
+
     nix2container.url = "github:nlewo/nix2container";
+    nix2container.inputs.nixpkgs.follows = "nixpkgs";
+
     # Pin to a specific nixpkgs version that has compatible v8 and curl versions
     # for extensions that require older package versions
     nixpkgs-oldstable.url = "github:NixOS/nixpkgs/a76c4553d7e741e17f289224eda135423de0491d";
+
     nixpkgs.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
-    rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+
     rust-overlay.url = "github:oxalica/rust-overlay";
-    treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
+    rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+
     treefmt-nix.url = "github:numtide/treefmt-nix";
+    treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs =


### PR DESCRIPTION
## What kind of change does this PR introduce?

DevEx (minor)

## What is the current behavior?

I noticed we had an extra nixpkgs in flake.lock, was easy to miss because its actually something that nix-eval-jobs should have done on its own (by propagating the nixpkgs input to its treefmt-nix). This does have a slight/tiny effect on build times since we waste time fetching a nixpkgs tree and copying into /nix/store only for it to never be used.

## What is the new behavior?

No time wasted fetching unnecessary nixpkgs tree, no time wasted copying into /nix/store.