### PR TITLE
ci: nix-build: Drop dependencies on nix-build-checks-*

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -61,7 +61,9 @@ jobs:
     name: >-
       ${{ matrix.name }}${{ matrix.postgresql_version && format(' - Postgres {0}', matrix.postgresql_version) || '' }}
       (aarch64-linux)
-    needs: [nix-eval, nix-build-packages-aarch64-linux]
+    needs:
+      - nix-eval
+      - nix-build-packages-aarch64-linux
     runs-on: ${{ matrix.runs_on.group && matrix.runs_on || matrix.runs_on.labels }}
     if: ${{ fromJSON(needs.nix-eval.outputs.checks_matrix).aarch64_linux != null }}
     strategy:
@@ -117,7 +119,9 @@ jobs:
     name: >-
       ${{ matrix.name }}${{ matrix.postgresql_version && format(' - Postgres {0}', matrix.postgresql_version) || '' }}
       (aarch64-darwin)
-    needs: [nix-eval, nix-build-packages-aarch64-darwin]
+    needs:
+      - nix-eval
+      - nix-build-packages-aarch64-darwin
     runs-on: ${{ matrix.attr != '' && matrix.runs_on.group && matrix.runs_on || matrix.runs_on.labels }}
     if: ${{ fromJSON(needs.nix-eval.outputs.checks_matrix).aarch64_darwin != null }}
     strategy:
@@ -170,7 +174,9 @@ jobs:
     name: >-
       ${{ matrix.name }}${{ matrix.postgresql_version && format(' - Postgres {0}', matrix.postgresql_version) || '' }}
       (x86_64-linux)
-    needs: [nix-eval, nix-build-packages-x86_64-linux]
+    needs:
+      - nix-eval
+      - nix-build-packages-x86_64-linux
     runs-on: ${{ matrix.attr != '' && matrix.runs_on.group && matrix.runs_on || matrix.runs_on.labels }}
     if: ${{ fromJSON(needs.nix-eval.outputs.checks_matrix).x86_64_linux != null }}
     strategy:
@@ -196,41 +202,26 @@ jobs:
           attr: .#${{ matrix.attr }}
 
   run-testinfra:
-    needs: [nix-eval, nix-build-packages-aarch64-linux, nix-build-checks-aarch64-linux, nix-build-packages-aarch64-darwin, nix-build-checks-aarch64-darwin, nix-build-packages-x86_64-linux, nix-build-checks-x86_64-linux]
-    if: |
-      !cancelled() &&
-      needs.nix-eval.result == 'success' &&
-      (needs.nix-build-packages-aarch64-linux.result == 'skipped' || needs.nix-build-packages-aarch64-linux.result == 'success') &&
-      (needs.nix-build-checks-aarch64-linux.result == 'skipped' || needs.nix-build-checks-aarch64-linux.result == 'success') &&
-      (needs.nix-build-packages-aarch64-darwin.result == 'skipped' || needs.nix-build-packages-aarch64-darwin.result == 'success') &&
-      (needs.nix-build-checks-aarch64-darwin.result == 'skipped' || needs.nix-build-checks-aarch64-darwin.result == 'success') &&
-      (needs.nix-build-packages-x86_64-linux.result == 'skipped' || needs.nix-build-packages-x86_64-linux.result == 'success') &&
-      (needs.nix-build-checks-x86_64-linux.result == 'skipped' || needs.nix-build-checks-x86_64-linux.result == 'success')
+    needs:
+      - nix-eval
+      - nix-build-packages-aarch64-linux
+      - nix-build-packages-aarch64-darwin
+      - nix-build-packages-x86_64-linux
     uses: ./.github/workflows/testinfra-ami-build.yml
     secrets:
       DEV_AWS_ROLE: ${{ secrets.DEV_AWS_ROLE }}
       NIX_SIGN_SECRET_KEY: ${{ secrets.NIX_SIGN_SECRET_KEY }}
 
   run-tests:
-    needs: [nix-eval, nix-build-packages-aarch64-linux, nix-build-checks-aarch64-linux, nix-build-packages-aarch64-darwin, nix-build-checks-aarch64-darwin, nix-build-packages-x86_64-linux, nix-build-checks-x86_64-linux]
-    if: |
-      !cancelled() &&
-      needs.nix-eval.result == 'success' &&
-      (needs.nix-build-packages-aarch64-linux.result == 'skipped' || needs.nix-build-packages-aarch64-linux.result == 'success') &&
-      (needs.nix-build-checks-aarch64-linux.result == 'skipped' || needs.nix-build-checks-aarch64-linux.result == 'success') &&
-      (needs.nix-build-packages-aarch64-darwin.result == 'skipped' || needs.nix-build-packages-aarch64-darwin.result == 'success') &&
-      (needs.nix-build-checks-aarch64-darwin.result == 'skipped' || needs.nix-build-checks-aarch64-darwin.result == 'success') &&
-      (needs.nix-build-packages-x86_64-linux.result == 'skipped' || needs.nix-build-packages-x86_64-linux.result == 'success') &&
-      (needs.nix-build-checks-x86_64-linux.result == 'skipped' || needs.nix-build-checks-x86_64-linux.result == 'success')
+    needs:
+      - nix-eval
+      - nix-build-packages-aarch64-linux
+      - nix-build-packages-aarch64-darwin
+      - nix-build-packages-x86_64-linux
     uses: ./.github/workflows/test.yml
 
   docker-image-test:
-    needs: [nix-eval, nix-build-packages-aarch64-linux, nix-build-checks-aarch64-linux]
-    if: |
-      !cancelled() &&
-      needs.nix-eval.result == 'success' &&
-      (needs.nix-build-packages-aarch64-linux.result == 'skipped' || needs.nix-build-packages-aarch64-linux.result == 'success') &&
-      (needs.nix-build-checks-aarch64-linux.result == 'skipped' || needs.nix-build-checks-aarch64-linux.result == 'success')
+    needs: nix-build-packages-aarch64-linux
     uses: ./.github/workflows/docker-image-test.yml
     secrets:
       DEV_AWS_ROLE: ${{ secrets.DEV_AWS_ROLE }}


### PR DESCRIPTION
## What kind of change does this PR introduce?

DevEx improvement by increasing PR performance

## What is the current behavior?

The `run-testinfra` and `run-tests` jobs are depending on the `nix-build-checks-*` jobs. They each take somewhere between 2-6mins.

## What is the new behavior?

 These `run-test*` jobs don't actually depend on anything from those `check` jobs (which are mostly formatter/linter checks anyway) so no need to wait ~6m to get real checks to run.

## Additional Context

I also cleaned up the `if:`s since they were written as if the dependents were showing up skipped which is not currently the case:

```
gh run view 27444894989 --json jobs --jq '.jobs[] | select(.name == "no packages to build (aarch64-darwin)") | .status, .conclusion'
completed
success
```

So this is a `kaizen` clean up that makes for a more readable file.