### PR TITLE
chore(admin-mgr): bump version of admin-mgr to release 0.38.1 for restore lifecycle improvements

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.092-orioledb"
-  postgres17: "17.6.1.135"
-  postgres15: "15.14.1.135"
+  postgresorioledb-17: "17.6.0.093-orioledb"
+  postgres17: "17.6.1.136"
+  postgres15: "15.14.1.136"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1
@@ -61,7 +61,7 @@ postgres_exporter_release_checksum:
   amd64: sha256:cb89fc5bf4485fb554e0d640d9684fae143a4b2d5fa443009bd29c59f9129e84
 
 adminapi_release: "0.107.0"
-adminmgr_release: "0.38.0"
+adminmgr_release: "0.38.1"
 supabase_admin_agent_release: 1.11.2
 supabase_admin_agent_splay: 30s
 


### PR DESCRIPTION
Bumping the `admin-mgr` binary to release restore lifecycle improvements.