### PR TITLE
fix(pg_upgrade): retry nix-store -r to avoid hangs on stalled S3 fetches

### DIFF
--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
@@ -358,12 +358,12 @@ EXTRA_NIX_CONF
 		# and record "failed" instead of hanging.
 		nix_store_ok="false"
 		for attempt in 1 2 3; do
-			if timeout -k 10 120 nix-store -r "$STORE_PATH"; then
+			if timeout -k 10s 120s nix-store -r "$STORE_PATH"; then
 				nix_store_ok="true"
 				break
 			fi
 			if [ "$attempt" -lt 3 ]; then
-				echo "WARNING: nix-store -r attempt ${attempt}/3 for $STORE_PATH failed or stalled (>120s); retrying"
+				echo "WARNING: nix-store -r attempt ${attempt}/3 for $STORE_PATH failed or stalled (>=120s + up to 10s kill grace); retrying"
 			else
 				echo "ERROR: nix-store -r failed after 3 attempts for $STORE_PATH"
 			fi

--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
@@ -348,8 +348,22 @@ EXTRA_NIX_CONF
 
 		echo "Store path: $STORE_PATH"
 
-		# Realize from binary cache (no nix evaluation needed!)
-		nix-store -r "$STORE_PATH"
+		# Realize the closure from the binary cache.
+		#
+		# nix-store -r can stall indefinitely on a dropped S3 connection without
+		# erroring out (its own download timeout doesn't reliably fire), so guard each
+		# attempt with a timeout and retry. nix-store is resumable, so a retry only
+		# re-fetches the unfinished paths. Failing as a normal command (not exit 1)
+		# lets the ERR trap run cleanup and record "failed" instead of hanging.
+		nix_store_ok="false"
+		for attempt in 1 2 3; do
+			if timeout -k 10 120 nix-store -r "$STORE_PATH"; then
+				nix_store_ok="true"
+				break
+			fi
+			echo "WARNING: nix-store -r attempt ${attempt}/3 for $STORE_PATH failed or stalled (>120s); retrying"
+		done
+		[ "$nix_store_ok" = "true" ]
 
 		PG_UPGRADE_BIN_DIR="$STORE_PATH"
 		PGSHARENEW="$PG_UPGRADE_BIN_DIR/share/postgresql"

--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
@@ -352,16 +352,21 @@ EXTRA_NIX_CONF
 		#
 		# nix-store -r can stall indefinitely on a dropped S3 connection without
 		# erroring out (its own download timeout doesn't reliably fire), so guard each
-		# attempt with a timeout and retry. nix-store is resumable, so a retry only
-		# re-fetches the unfinished paths. Failing as a normal command (not exit 1)
-		# lets the ERR trap run cleanup and record "failed" instead of hanging.
+		# attempt with a timeout and retry. Each path downloads atomically: already-
+		# registered paths are skipped on retry but an in-flight NAR restarts from
+		# 0%. Failing as a normal command (not exit 1) lets the ERR trap run cleanup
+		# and record "failed" instead of hanging.
 		nix_store_ok="false"
 		for attempt in 1 2 3; do
 			if timeout -k 10 120 nix-store -r "$STORE_PATH"; then
 				nix_store_ok="true"
 				break
 			fi
-			echo "WARNING: nix-store -r attempt ${attempt}/3 for $STORE_PATH failed or stalled (>120s); retrying"
+			if [ "$attempt" -lt 3 ]; then
+				echo "WARNING: nix-store -r attempt ${attempt}/3 for $STORE_PATH failed or stalled (>120s); retrying"
+			else
+				echo "ERROR: nix-store -r failed after 3 attempts for $STORE_PATH"
+			fi
 		done
 		[ "$nix_store_ok" = "true" ]
 


### PR DESCRIPTION
## What

Wrap the binary-cache `nix-store -r` step in the pg_upgrade initiate script with a per-attempt timeout and a small retry loop.

## Why

`nix-store -r` can stall indefinitely on a dropped S3 connection without erroring out, its own download timeout doesn't reliably fire. When that happens the upgrade hangs forever reporting `running`, eventually exhausting the caller's poll budget with no useful error.

## How

- Each attempt runs under `timeout` (3 × 120s); `nix-store` is resumable, so a retry only re-fetches the paths that didn't finish.
- On exhaustion it fails as a normal command (not `exit 1`) so the existing `ERR` trap runs cleanup and records `failed`, turning an indefinite hang into a fast, reported failure.
- Worst case (360s) stays within the nix-fetch window the upgrade poller already allows, so no caller-side timeout changes are needed.