### PR TITLE
fix(nix): fetch pg_plan_filter from correct GitHub repo

### DIFF
--- a/nix/ext/pg_plan_filter.nix
+++ b/nix/ext/pg_plan_filter.nix
@@ -20,7 +20,7 @@ let
 
       src = fetchFromGitHub {
         owner = "pgexperts";
-        repo = pname;
+        repo = "pg_plan_filter";
         inherit rev hash;
       };
 
@@ -41,7 +41,7 @@ let
 
       meta = with lib; {
         description = "Filter PostgreSQL statements by execution plans";
-        homepage = "https://github.com/pgexperts/${pname}";
+        homepage = "https://github.com/pgexperts/pg_plan_filter";
         platforms = postgresql.meta.platforms;
         license = licenses.postgresql;
       };


### PR DESCRIPTION
## Problem

`nix/ext/pg_plan_filter.nix` uses `repo = pname` (`plan_filter`), which fetches from `pgexperts/plan_filter` — a repo that does not exist (404).

The actual source is [`pgexperts/pg_plan_filter`](https://github.com/pgexperts/pg_plan_filter).

This breaks `postgresql-and-plugins-17.6` builds when the `plan_filter` extension must be built from source (no binary cache hit).

## Fix

- Set `repo = "pg_plan_filter"` in `fetchFromGitHub` (keep `pname = "plan_filter"` — that's the installed extension name)
- Fix `meta.homepage` to match

No `versions.json` hash change needed; same commit rev, correct tarball.