### PR TITLE
fix: rewire postgresVersion input in pg_upgrade publish workflows

### DIFF
--- a/.github/workflows/publish-nix-pgupgrade-bin-flake-version.yml
+++ b/.github/workflows/publish-nix-pgupgrade-bin-flake-version.yml
@@ -23,8 +23,19 @@ jobs:
 
       - name: Set PostgreSQL versions
         id: set-versions
+        env:
+          POSTGRES_VERSION: ${{ inputs.postgresVersion }}
         run: |
-          VERSIONS=$(nix run nixpkgs#yq-go -- -o=json -I=0 '.postgres_major' ansible/vars.yml)
+          set -eo pipefail
+          if [[ -n "$POSTGRES_VERSION" ]]; then
+            git rev-parse --verify "$POSTGRES_VERSION" || {
+              echo "Error: git tag '$POSTGRES_VERSION' not found"
+              exit 1
+            }
+            VERSIONS=$(git show "$POSTGRES_VERSION:ansible/vars.yml" | nix run nixpkgs#yq-go -- -o=json -I=0 '.postgres_major')
+          else
+            VERSIONS=$(nix run nixpkgs#yq-go -- -o=json -I=0 '.postgres_major' ansible/vars.yml)
+          fi
           echo "postgres_versions=$VERSIONS" >> $GITHUB_OUTPUT
 
   publish-staging:
@@ -42,8 +53,15 @@ jobs:
 
       - name: Grab release version
         id: process_release_version
+        env:
+          POSTGRES_VERSION: ${{ inputs.postgresVersion }}
         run: |
-          VERSION=$(nix run nixpkgs#yq-go -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]' ansible/vars.yml)
+          set -eo pipefail
+          if [[ -n "$POSTGRES_VERSION" ]]; then
+            VERSION=$(git show "$POSTGRES_VERSION:ansible/vars.yml" | nix run nixpkgs#yq-go -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]')
+          else
+            VERSION=$(nix run nixpkgs#yq-go -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]' ansible/vars.yml)
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "major_version=$(echo $VERSION | cut -d'.' -f1)" >> "$GITHUB_OUTPUT"
 
@@ -92,8 +110,15 @@ jobs:
 
       - name: Grab release version
         id: process_release_version
+        env:
+          POSTGRES_VERSION: ${{ inputs.postgresVersion }}
         run: |
-          VERSION=$(nix run nixpkgs#yq-go -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]' ansible/vars.yml)
+          set -eo pipefail
+          if [[ -n "$POSTGRES_VERSION" ]]; then
+            VERSION=$(git show "$POSTGRES_VERSION:ansible/vars.yml" | nix run nixpkgs#yq-go -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]')
+          else
+            VERSION=$(nix run nixpkgs#yq-go -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]' ansible/vars.yml)
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "major_version=$(echo $VERSION | cut -d'.' -f1)" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/publish-nix-pgupgrade-scripts.yml
+++ b/.github/workflows/publish-nix-pgupgrade-scripts.yml
@@ -28,8 +28,19 @@ jobs:
       - uses: ./.github/actions/nix-install-ephemeral
       - name: Set PostgreSQL versions
         id: set-versions
+        env:
+          POSTGRES_VERSION: ${{ inputs.postgresVersion }}
         run: |
-          VERSIONS=$(nix run nixpkgs#yq-go -- -o=json -I=0 '.postgres_major' ansible/vars.yml)
+          set -eo pipefail
+          if [[ -n "$POSTGRES_VERSION" ]]; then
+            git rev-parse --verify "$POSTGRES_VERSION" || {
+              echo "Error: git tag '$POSTGRES_VERSION' not found"
+              exit 1
+            }
+            VERSIONS=$(git show "$POSTGRES_VERSION:ansible/vars.yml" | nix run nixpkgs#yq-go -- -o=json -I=0 '.postgres_major')
+          else
+            VERSIONS=$(nix run nixpkgs#yq-go -- -o=json -I=0 '.postgres_major' ansible/vars.yml)
+          fi
           echo "postgres_versions=$VERSIONS" >> $GITHUB_OUTPUT
 
   publish-staging:
@@ -47,8 +58,15 @@ jobs:
 
       - name: Grab release version
         id: process_release_version
+        env:
+          POSTGRES_VERSION: ${{ inputs.postgresVersion }}
         run: |
-          VERSION=$(nix run nixpkgs#yq-go -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]' ansible/vars.yml)
+          set -eo pipefail
+          if [[ -n "$POSTGRES_VERSION" ]]; then
+            VERSION=$(git show "$POSTGRES_VERSION:ansible/vars.yml" | nix run nixpkgs#yq-go -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]')
+          else
+            VERSION=$(nix run nixpkgs#yq-go -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]' ansible/vars.yml)
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Create a tarball containing pg_upgrade scripts
@@ -95,8 +113,15 @@ jobs:
 
       - name: Grab release version
         id: process_release_version
+        env:
+          POSTGRES_VERSION: ${{ inputs.postgresVersion }}
         run: |
-          VERSION=$(nix run nixpkgs#yq-go -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]' ansible/vars.yml)
+          set -eo pipefail
+          if [[ -n "$POSTGRES_VERSION" ]]; then
+            VERSION=$(git show "$POSTGRES_VERSION:ansible/vars.yml" | nix run nixpkgs#yq-go -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]')
+          else
+            VERSION=$(nix run nixpkgs#yq-go -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]' ansible/vars.yml)
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Create a tarball containing pg_upgrade scripts


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The `postgresVersion` `workflow_dispatch` input was left as dead code after #2035 . The input is accepted but silently ignored.  The workflows always read `postgres_major` and `postgres_release` from the current checkout's `ansible/vars.yml`.

The same issue exists in both `publish-nix-pgupgrade-scripts.yml` and `publish-nix-pgupgrade-bin-flake-version.yml`

## What is the new behavior?

When `postgresVersion` is set (via `workflow_dispatch` or `gh workflow run` from `ami-release-nix.yml`), it is treated as a bare git tag name (e.g. `17.6.1.137`, `15.14.1.137`). The workflow:

1. Validates the tag exists (`git rev-parse --verify`), failing with a clear error if not
2. Reads `postgres_major` from that tag's `ansible/vars.yml` to determine which versions to iterate over
3. Reads `postgres_release` from that tag's `ansible/vars.yml` to determine S3 path version strings
4. Tarball/flake-version content always comes from the current checkout, only the version label is read from the tag.

When postgresVersion is not set, behavior is unchanged.  We read from the current checkout's `ansible/vars.yml`.

## Additional context

This enables publishing updated `pg_upgrade` scripts for historical releases whose `ansible/vars.yml` may have had a different set of postgres versions.  Handle input as environment variable to avoid shell injection and -eo pipefail to guard against null.