### PR TITLE
INDATA-378-09: ansible: standardize and optimize setup-tuned.yml

### DIFF
--- a/ansible/tasks/setup-tuned.yml
+++ b/ansible/tasks/setup-tuned.yml
@@ -1,8 +1,8 @@
-- name: Install and configure tuned
+- name: tuned - Install and configure tuned
   when:
     - (stage2_nix or nixpkg_mode or debpkg_mode)
   block:
-    - name: Install tuned
+    - name: tuned - Install tuned
       ansible.builtin.apt:
         force_apt_get: true
         name: 'tuned'
@@ -11,7 +11,7 @@
         update_cache: true
       become: true
 
-    - name: Create a tuned profile directory
+    - name: tuned - Create a tuned profile directory
       ansible.builtin.file:
         group: 'root'
         mode: '0755'
@@ -20,7 +20,7 @@
         state: 'directory'
       become: true
 
-    - name: Create a profile symlink for older tuned versions
+    - name: tuned - Create a profile symlink for older tuned versions
       ansible.builtin.file:
         force: true
         group: 'root'
@@ -31,9 +31,8 @@
         state: 'link'
       become: true
 
-    - name: Create a tuned profile
-      become: true
-      community.general.ini_file:
+    - name: tuned - Create a tuned profile
+      ansible.builtin.ini_file:
         create: true
         group: 'root'
         mode: '0644'
@@ -43,10 +42,10 @@
         section: 'main'
         state: 'present'
         value: 'Tuned profile for PostgreSQL'
+      become: true
 
     - name: tuned - Disable Transparent Huge Pages (THP)
-      become: true
-      community.general.ini_file:
+      ansible.builtin.ini_file:
         create: true
         group: 'root'
         mode: '0644'
@@ -56,114 +55,69 @@
         section: 'vm'
         state: 'present'
         value: 'never'
-
-    - name: tuned - Configure all CPUs for maximum performance
       become: true
-      community.general.ini_file:
+
+    - name: tuned - Configure performance
+      ansible.builtin.ini_file:
         create: true
         group: 'root'
         mode: '0644'
         no_extra_spaces: true
-        option: "{{ cpu_item['option'] }}"
+        option: "{{ perf_item['option'] }}"
         path: '/etc/tuned/profiles/postgresql/tuned.conf'
-        section: "{{ cpu_item['section'] }}"
+        section: "{{ perf_item['section'] }}"
         state: 'present'
-        value: "{{ cpu_item['value'] }}"
+        value: "{{ perf_item['value'] }}"
+      become: true
       loop:
-        - { section: 'cpu', option: 'governor', value: 'performance' }
+        - { option: 'governor', section: 'cpu', value: 'performance' }
       loop_control:
-        loop_var: 'cpu_item'
+        loop_var: 'perf_item'
 
     - name: tuned - Configure Intel CPUs for maximum performance
-      become: true
-      community.general.ini_file:
+      ansible.builtin.ini_file:
         create: true
         group: 'root'
         mode: '0644'
         no_extra_spaces: true
-        option: "{{ cpu_item['option'] }}"
+        option: "{{ intel_item['option'] }}"
         path: '/etc/tuned/profiles/postgresql/tuned.conf'
-        section: "{{ cpu_item['section'] }}"
+        section: "{{ intel_item['section'] }}"
         state: 'present'
-        value: "{{ cpu_item['value'] }}"
+        value: "{{ intel_item['value'] }}"
+      become: true
       loop:
-        - { section: 'cpu', option: 'energy_perf_bias', value: 'performance' }
-        - { section: 'cpu', option: 'min_perf_pct',     value: '100' }
+        - { option: 'energy_perf_bias', section: 'cpu', value: 'performance' }
+        - { option: 'min_perf_pct',     section: 'cpu', value: '100' }
       loop_control:
-        loop_var: 'cpu_item'
+        loop_var: 'intel_item'
       when:
-        - ansible_facts['processor'][0] is search("GenuineIntel", ignorecase=True)
+        - ansible_facts['processor'][0] is search('GenuineIntel', ignorecase=True)
 
-    - name: tuned - Set tcp_keepalive_intvl
-      become: true
-      community.general.ini_file:
+    - name: tuned - Set sysctl parameters
+      ansible.builtin.ini_file:
         create: true
         group: 'root'
         mode: '0644'
         no_extra_spaces: true
-        option: 'net.ipv4.tcp_keepalive_intvl'
+        option: "{{ sysctl_item['option'] }}"
         path: '/etc/tuned/profiles/postgresql/tuned.conf'
         section: 'sysctl'
         state: 'present'
-        value: 60
-
-    - name: tuned - Set tcp_keepalive_time
+        value: "{{ sysctl_item['value'] }}"
       become: true
-      community.general.ini_file:
-        create: true
-        group: 'root'
-        mode: '0644'
-        no_extra_spaces: true
-        option: 'net.ipv4.tcp_keepalive_time'
-        path: '/etc/tuned/profiles/postgresql/tuned.conf'
-        section: 'sysctl'
-        state: 'present'
-        value: 1800
-
-    # Reserve ports to prevent they are used as random srcports:
-    # 3000: postgrest, 3001: postgrest-admin, 8085: adminapi, 9122: pgbouncer_exporter, 9187: postgres_exporter, 9999: vector
-    - name: tuned - Set ip_local_reserved_ports
-      become: true
-      community.general.ini_file:
-        create: true
-        group: 'root'
-        mode: '0644'
-        no_extra_spaces: true
-        option: 'net.ipv4.ip_local_reserved_ports'
-        path: '/etc/tuned/profiles/postgresql/tuned.conf'
-        section: 'sysctl'
-        state: 'present'
-        value: '3000,3001,8085,9122,9187,9999'
-
-    - name: tuned - Set ip_local_port_range
-      become: true
-      community.general.ini_file:
-        create: true
-        group: 'root'
-        mode: '0644'
-        no_extra_spaces: true
-        option: 'net.ipv4.ip_local_port_range'
-        path: '/etc/tuned/profiles/postgresql/tuned.conf'
-        section: 'sysctl'
-        state: 'present'
-        value: '1025 65000'
-
-    - name: tuned - Set vm.panic_on_oom
-      become: true
-      community.general.ini_file:
-        create: true
-        group: 'root'
-        mode: '0644'
-        no_extra_spaces: true
-        option: 'vm.panic_on_oom'
-        path: '/etc/tuned/profiles/postgresql/tuned.conf'
-        section: 'sysctl'
-        state: 'present'
-        value: 1
+      loop:
+        - { option: 'net.ipv4.tcp_keepalive_intvl',      value: '60' }
+        - { option: 'net.ipv4.tcp_keepalive_time',       value: '1800' }
+        - { option: 'net.ipv4.ip_local_reserved_ports', value: '3000,3001,8085,9122,9187,9999' }
+        - { option: 'net.ipv4.ip_local_port_range',     value: '1025 65000' }
+        - { option: 'vm.panic_on_oom',                   value: '1' }
+        - { option: 'net.core.somaxconn',                value: '16834' }
+      loop_control:
+        loop_var: 'sysctl_item'
 
     - name: tuned - Set kernel.panic=10
-      become: true
-      community.general.ini_file:
+      ansible.builtin.ini_file:
         create: true
         group: 'root'
         mode: '0644'
@@ -172,30 +126,17 @@
         path: '/etc/tuned/profiles/postgresql/tuned.conf'
         section: 'sysctl'
         state: 'present'
-        value: 10
+        value: '10'
+      become: true
       when:
         - (debpkg_mode or nixpkg_mode)
-
-    - name: tuned - Set net.core.somaxconn
-      become: true
-      community.general.ini_file:
-        create: true
-        group: 'root'
-        mode: '0644'
-        no_extra_spaces: true
-        option: 'net.core.somaxconn'
-        path: '/etc/tuned/profiles/postgresql/tuned.conf'
-        section: 'sysctl'
-        state: 'present'
-        value: 16834
 
     - name: tuned - Enable zswap if swap is present
       when:
         - ansible_facts['swaptotal_mb'] > 0
       block:
         - name: tuned - Decrease the kernel swappiness
-          become: true
-          community.general.ini_file:
+          ansible.builtin.ini_file:
             create: true
             group: 'root'
             mode: '0644'
@@ -204,14 +145,15 @@
             path: '/etc/tuned/profiles/postgresql/tuned.conf'
             section: 'sysctl'
             state: 'present'
-            value: 10
+            value: '10'
+          become: true
 
         - name: tuned - Load zstd compressor module
-          become: true
           community.general.modprobe:
             name: 'zstd'
             persistent: 'present'
             state: 'present'
+          become: true
 
         - name: tuned - Configure and enable zswap
           ansible.builtin.shell:
@@ -224,7 +166,7 @@
           loop_control:
             loop_var: 'zswap_item'
 
-    - name: Activate the tuned service
+    - name: tuned - Activate the tuned service
       ansible.builtin.systemd_service:
         daemon_reload: true
         enabled: true
@@ -232,9 +174,10 @@
         state: "{{ 'restarted' if stage2_nix else 'stopped' }}"
       become: true
 
-    - name: Activate the PostgreSQL tuned profile
+    - name: tuned - Activate the PostgreSQL tuned profile
       ansible.builtin.command:
-        cmd: tuned-adm profile postgresql
+        cmd: 'tuned-adm profile postgresql'
       become: true
       changed_when: false
-      when: stage2_nix
+      when:
+        - stage2_nix


### PR DESCRIPTION
Continues the INDATA-378 series by standardizing task names, applying coding directives (FQCNs, sorting, quoting), and optimizing tasks via loops in setup-tuned.yml.