### PR TITLE
fix: rewire postgresVersion input in pg_upgrade publish workflows

### DIFF
--- a/.github/workflows/publish-nix-pgupgrade-bin-flake-version.yml
+++ b/.github/workflows/publish-nix-pgupgrade-bin-flake-version.yml
@@ -23,8 +23,19 @@ jobs:
 
       - name: Set PostgreSQL versions
         id: set-versions
+        env:
+          POSTGRES_VERSION: ${{ inputs.postgresVersion }}
         run: |
-          VERSIONS=$(nix run nixpkgs#yq-go -- -o=json -I=0 '.postgres_major' ansible/vars.yml)
+          set -eo pipefail
+          if [[ -n "$POSTGRES_VERSION" ]]; then
+            git rev-parse --verify "$POSTGRES_VERSION" || {
+              echo "Error: git tag '$POSTGRES_VERSION' not found"
+              exit 1
+            }
+            VERSIONS=$(git show "$POSTGRES_VERSION:ansible/vars.yml" | nix run nixpkgs#yq-go -- -o=json -I=0 '.postgres_major')
+          else
+            VERSIONS=$(nix run nixpkgs#yq-go -- -o=json -I=0 '.postgres_major' ansible/vars.yml)
+          fi
           echo "postgres_versions=$VERSIONS" >> $GITHUB_OUTPUT
 
   publish-staging:
@@ -42,8 +53,15 @@ jobs:
 
       - name: Grab release version
         id: process_release_version
+        env:
+          POSTGRES_VERSION: ${{ inputs.postgresVersion }}
         run: |
-          VERSION=$(nix run nixpkgs#yq-go -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]' ansible/vars.yml)
+          set -eo pipefail
+          if [[ -n "$POSTGRES_VERSION" ]]; then
+            VERSION=$(git show "$POSTGRES_VERSION:ansible/vars.yml" | nix run nixpkgs#yq-go -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]')
+          else
+            VERSION=$(nix run nixpkgs#yq-go -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]' ansible/vars.yml)
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "major_version=$(echo $VERSION | cut -d'.' -f1)" >> "$GITHUB_OUTPUT"
 
@@ -92,8 +110,15 @@ jobs:
 
       - name: Grab release version
         id: process_release_version
+        env:
+          POSTGRES_VERSION: ${{ inputs.postgresVersion }}
         run: |
-          VERSION=$(nix run nixpkgs#yq-go -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]' ansible/vars.yml)
+          set -eo pipefail
+          if [[ -n "$POSTGRES_VERSION" ]]; then
+            VERSION=$(git show "$POSTGRES_VERSION:ansible/vars.yml" | nix run nixpkgs#yq-go -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]')
+          else
+            VERSION=$(nix run nixpkgs#yq-go -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]' ansible/vars.yml)
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "major_version=$(echo $VERSION | cut -d'.' -f1)" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/publish-nix-pgupgrade-scripts.yml
+++ b/.github/workflows/publish-nix-pgupgrade-scripts.yml
@@ -28,8 +28,19 @@ jobs:
       - uses: ./.github/actions/nix-install-ephemeral
       - name: Set PostgreSQL versions
         id: set-versions
+        env:
+          POSTGRES_VERSION: ${{ inputs.postgresVersion }}
         run: |
-          VERSIONS=$(nix run nixpkgs#yq-go -- -o=json -I=0 '.postgres_major' ansible/vars.yml)
+          set -eo pipefail
+          if [[ -n "$POSTGRES_VERSION" ]]; then
+            git rev-parse --verify "$POSTGRES_VERSION" || {
+              echo "Error: git tag '$POSTGRES_VERSION' not found"
+              exit 1
+            }
+            VERSIONS=$(git show "$POSTGRES_VERSION:ansible/vars.yml" | nix run nixpkgs#yq-go -- -o=json -I=0 '.postgres_major')
+          else
+            VERSIONS=$(nix run nixpkgs#yq-go -- -o=json -I=0 '.postgres_major' ansible/vars.yml)
+          fi
           echo "postgres_versions=$VERSIONS" >> $GITHUB_OUTPUT
 
   publish-staging:
@@ -47,8 +58,15 @@ jobs:
 
       - name: Grab release version
         id: process_release_version
+        env:
+          POSTGRES_VERSION: ${{ inputs.postgresVersion }}
         run: |
-          VERSION=$(nix run nixpkgs#yq-go -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]' ansible/vars.yml)
+          set -eo pipefail
+          if [[ -n "$POSTGRES_VERSION" ]]; then
+            VERSION=$(git show "$POSTGRES_VERSION:ansible/vars.yml" | nix run nixpkgs#yq-go -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]')
+          else
+            VERSION=$(nix run nixpkgs#yq-go -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]' ansible/vars.yml)
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Create a tarball containing pg_upgrade scripts
@@ -95,8 +113,15 @@ jobs:
 
       - name: Grab release version
         id: process_release_version
+        env:
+          POSTGRES_VERSION: ${{ inputs.postgresVersion }}
         run: |
-          VERSION=$(nix run nixpkgs#yq-go -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]' ansible/vars.yml)
+          set -eo pipefail
+          if [[ -n "$POSTGRES_VERSION" ]]; then
+            VERSION=$(git show "$POSTGRES_VERSION:ansible/vars.yml" | nix run nixpkgs#yq-go -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]')
+          else
+            VERSION=$(nix run nixpkgs#yq-go -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]' ansible/vars.yml)
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Create a tarball containing pg_upgrade scripts


### PR DESCRIPTION
This adds #2225 to `release/17.6` in order to allow us to rebuild the pg-upgrade-scripts tarball for production to include #2220 .  Those are the only 2 commits that exist in `release/17.6` that differ from tag `17.6.1.127` and are the fixes we need.

As soon as this PR is merged we'll need to terminate the 'other' Nix jobs that are triggered by pushing to `release/*`, and ONLY allow https://github.com/supabase/postgres/actions/workflows/publish-nix-pgupgrade-scripts.yml to continue.

This was validated via https://github.com/supabase/postgres/actions/runs/27762146904/job/82140324060 for staging and confirmed that staging is working as expected.