### PR TITLE
chore: bump admin-api to 0.107.3 and postgres patch versions

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.094-orioledb"
-  postgres17: "17.6.1.137"
-  postgres15: "15.14.1.137"
+  postgresorioledb-17: "17.6.0.095-orioledb"
+  postgres17: "17.6.1.138"
+  postgres15: "15.14.1.138"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1
@@ -60,7 +60,7 @@ postgres_exporter_release_checksum:
   arm64: sha256:29ba62d538b92d39952afe12ee2e1f4401250d678ff4b354ff2752f4321c87a0
   amd64: sha256:cb89fc5bf4485fb554e0d640d9684fae143a4b2d5fa443009bd29c59f9129e84
 
-adminapi_release: "0.107.0"
+adminapi_release: "0.107.3"
 adminmgr_release: "0.38.1"
 supabase_admin_agent_release: 1.11.2
 supabase_admin_agent_splay: 30s


### PR DESCRIPTION
Bumps admin-api from 0.107.0 to 0.107.3 and increments the build patch number for each Postgres version:

- postgres15: 15.14.1.137 -> 15.14.1.138
- postgres17: 17.6.1.137 -> 17.6.1.138
- postgresorioledb-17: 17.6.0.094 -> 17.6.0.095