### PR TITLE
fix(security): insecure nix trusted-users config recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ The project uses Nix as its build system, which provides:
 
 ## Common Tasks
 
+To skip hours of building and download instead, configure the Supabase Postgres Nix binary cache: [nix/docs/binary-cache.md](nix/docs/binary-cache.md).
+
 ### Building Locally
 
 To build PostgreSQL with extensions locally:

--- a/docs/multigres-image.md
+++ b/docs/multigres-image.md
@@ -77,43 +77,33 @@ docker build -f Dockerfile-multigres --target variant-orioledb-17 -t pg-docker-t
 nix run .#docker-image-test -- --no-build --target variant-orioledb-17 Dockerfile-multigres
 ```
 
-### Optional: install nix
+### Install nix
 
 ## Install Nix (Fresh Installation)
 
 We'll use the official Nix installer with a custom configuration that includes our build caches and settings. This works on many platforms, including **aarch64 Linux**, **x86_64 Linux**, and **macOS**.
 
-### Step 1: Create nix.conf
+### Step 1: Create nix.conf.extra
 
-First, create a file named `nix.conf` with the following content:
+First, create a file named `nix.conf.extra` with the following content:
 
 ```
-allowed-users = *
-always-allow-substitutes = true
-auto-optimise-store = false
-build-users-group = nixbld
-builders-use-substitutes = true
-cores = 0
 experimental-features = nix-command flakes
-max-jobs = auto
-netrc-file =
-require-sigs = true
-substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com https://postgrest.cachix.org https://cache.nixos.org/
-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI= postgrest.cachix.org-1:icgW4R15fz1+LqvhPjt4EnX/r19AaqxiVV+1olwlZtI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-trusted-substituters =
-trusted-users = YOUR_USERNAME root
-extra-sandbox-paths =
-extra-substituters =
-```
+extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
+extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=
+ ```
 
-**Important**: Replace `YOUR_USERNAME` with your actual username in the `trusted-users` line.
+> [!CAUTION]
+> DO NOT add anyone to `trusted-users` in `/etc/nix/nix.conf` as it [grants root without password](https://nix.dev/manual/nix/stable/command-ref/conf-file.html#conf-trusted-users). Instead, add the binary cache to `extra-substituters` and `extra-trusted-public-keys`.
+
+Read about the binary cache in [/nix/docs/binary-cache.md](/nix/docs/binary-cache.md).
 
 ### Step 2: Install Nix 2.34.6
 
 Run the following command to install Nix 2.34.6 (the version used in CI) with the custom configuration:
 
 ```bash
-curl -L https://releases.nixos.org/nix/nix-2.34.6/install | sh -s -- --daemon --yes --nix-extra-conf-file ./nix.conf
+curl -L https://releases.nixos.org/nix/nix-2.34.6/install | sh -s -- --daemon --yes --nix-extra-conf-file ./nix.conf.extra
 ```
 
 This will install Nix with our build caches pre-configured, which should eliminate substituter-related errors.
@@ -133,8 +123,6 @@ nix (Nix) 2.34.6
 
 
 ### Test only (image already built)
-
-
 
 ```bash
 nix run .#docker-image-test -- --no-build --target variant-17 Dockerfile-multigres

--- a/flake.nix
+++ b/flake.nix
@@ -1,10 +1,9 @@
 {
   description = "Prototype tooling for deploying PostgreSQL";
   nixConfig = {
+    # Skip rebuilding all the packages, download instead.
+    # See nix/docs/binary-cache.nix to set it up.
     extra-substituters = [ "https://nix-postgres-artifacts.s3.amazonaws.com" ];
-    extra-trusted-public-keys = [
-      "nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI="
-    ];
   };
   inputs = {
     devshell.url = "github:numtide/devshell";

--- a/nix/docs/binary-cache.md
+++ b/nix/docs/binary-cache.md
@@ -1,0 +1,60 @@
+# Using the Nix binary cache
+
+If you don't use the binary cache, it might take hours to build stuff you could just download, already built by CI.
+
+## NixOS or nix-darwin or system-manager
+
+Add this to your system configuration:
+
+```nix
+{
+  nix.settings.extra-substituters = [
+    "https://nix-postgres-artifacts.s3.amazonaws.com"
+  ];
+  nix.settings.extra-trusted-public-keys = [
+    "nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI="
+  ];
+}
+```
+
+Switch to the new configuration:
+
+```sh
+sudo nixos-rebuild switch
+# or
+sudo nix-darwin switch
+```
+
+## Nix without NixOS or nix-darwin
+
+If you don't have an immutable system configuration, you'll need to edit the nix config manually.
+
+Edit this file:
+
+```text
+/etc/nix/nix.conf
+```
+
+Extend it with this:
+
+```conf
+extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
+extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=
+```
+
+> [!CAUTION]
+> DO NOT add anyone to `trusted-users` in `/etc/nix/nix.conf` as it [grants root without password](https://nix.dev/manual/nix/stable/command-ref/conf-file.html#conf-trusted-users). Instead, add the binary cache to `extra-substituters` and `extra-trusted-public-keys`.
+
+Restart the nix daemon to load the new config:
+
+**On macOS:**
+```bash
+sudo launchctl stop org.nixos.nix-daemon
+sudo launchctl start org.nixos.nix-daemon
+```
+
+**On Linux (systemd):**
+```bash
+sudo systemctl restart nix-daemon
+```
+

--- a/nix/docs/start-here.md
+++ b/nix/docs/start-here.md
@@ -14,24 +14,18 @@ If you already have the official Nix installer (not Determinate Systems) install
 
 ### Step 1: Edit /etc/nix/nix.conf
 
-Add or update the following configuration in `/etc/nix/nix.conf`:
+Extend the following configuration in `/etc/nix/nix.conf`:
 
-```
-allowed-users = *
-always-allow-substitutes = true
-auto-optimise-store = false
-build-users-group = nixbld
-builders-use-substitutes = true
-cores = 0
+```conf
 experimental-features = nix-command flakes
-max-jobs = auto
-require-sigs = true
-substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com https://postgrest.cachix.org https://cache.nixos.org/
-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI= postgrest.cachix.org-1:icgW4R15fz1+LqvhPjt4EnX/r19AaqxiVV+1olwlZtI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-trusted-users = YOUR_USERNAME root
+extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
+extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=
 ```
 
-**Important**: Replace `YOUR_USERNAME` with your actual username in the `trusted-users` line.
+> [!CAUTION]
+> DO NOT add anyone to `trusted-users` in `/etc/nix/nix.conf` as it [grants root without password](https://nix.dev/manual/nix/stable/command-ref/conf-file.html#conf-trusted-users). Instead, add the binary cache to `extra-substituters` and `extra-trusted-public-keys`.
+
+Read about the binary cache in [/nix/docs/binary-cache.md](/nix/docs/binary-cache.md).
 
 ### Step 2: Restart the Nix Daemon
 
@@ -56,24 +50,18 @@ We'll use the official Nix installer with a custom configuration that includes o
 
 ### Step 1: Create nix.conf
 
-First, create a file named `nix.conf` with the following content:
+First, create a file named `nix.conf.extra` with the following content:
 
-```
-allowed-users = *
-always-allow-substitutes = true
-auto-optimise-store = false
-build-users-group = nixbld
-builders-use-substitutes = true
-cores = 0
+```conf
 experimental-features = nix-command flakes
-max-jobs = auto
-require-sigs = true
-substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com https://postgrest.cachix.org https://cache.nixos.org/
-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI= postgrest.cachix.org-1:icgW4R15fz1+LqvhPjt4EnX/r19AaqxiVV+1olwlZtI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-trusted-users = YOUR_USERNAME root
+extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
+extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=
 ```
 
-**Important**: Replace `YOUR_USERNAME` with your actual username in the `trusted-users` line.
+> [!CAUTION]
+> DO NOT add anyone to `trusted-users` in `/etc/nix/nix.conf` as it [grants root without password](https://nix.dev/manual/nix/stable/command-ref/conf-file.html#conf-trusted-users). Instead, add the binary cache to `extra-substituters` and `extra-trusted-public-keys`.
+
+Read about the binary cache in [/nix/docs/binary-cache.md](/nix/docs/binary-cache.md).
 
 ### Step 2: Install Nix 2.34.6
 

--- a/nix/hosts/darwin-nixostest/darwin-configuration.nix
+++ b/nix/hosts/darwin-nixostest/darwin-configuration.nix
@@ -73,11 +73,7 @@ in
       "nix-command"
       "flakes"
     ];
-    always-allow-substitutes = true;
-    max-jobs = "auto";
-    trusted-users = [ "@admin" ];
     extra-substituters = [ "https://nix-postgres-artifacts.s3.amazonaws.com" ];
-    extra-trusted-substituters = [ "https://nix-postgres-artifacts.s3.amazonaws.com" ];
     extra-trusted-public-keys = [
       "nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI="
     ];


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix insecure config recommendation. Add nix binary cache documentation.

## What is the current behavior?

`trusted-users` is recommended

## What is the new behavior?

`trusted-users` is warned against

## Additional context

https://nix.dev/manual/nix/stable/command-ref/conf-file.html#conf-trusted-users
https://github.com/NixOS/nix/issues/9649#issuecomment-1868001568

Fixes https://github.com/supabase/postgres/issues/1622
Related: https://linear.app/supabase/issue/PSQL-1323/insecure-nix-cache-config-recommendation-in-docs