### PR TITLE
ami: Re-arrange some values

### DIFF
--- a/.github/actions/build-ami/action.yml
+++ b/.github/actions/build-ami/action.yml
@@ -52,7 +52,7 @@ runs:
       id: set-execution-id
       shell: bash
       run: |
-        PACKER_EXECUTION_ID="${{ github.run_id }}-${{ inputs.postgres_version }}-${{ inputs.arch }}"
+        PACKER_EXECUTION_ID="${{ inputs.postgres_version }}-${{ inputs.arch }}-${{ github.run_id }}"
         echo "PACKER_EXECUTION_ID=$PACKER_EXECUTION_ID" >> $GITHUB_ENV
         echo "execution_id=$PACKER_EXECUTION_ID" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/ami-release-nix.yml
+++ b/.github/workflows/ami-release-nix.yml
@@ -89,7 +89,7 @@ jobs:
         id: build-ami
         uses: ./.github/actions/build-ami
         with:
-          ami_name_prefix: "supabase-postgres-${{ github.run_id }}-${{ matrix.target.arch }}"
+          ami_name_prefix: "supabase-postgres-${{ matrix.target.arch }}"
           ami_regions: '["${{ env.AWS_REGION }}"]'
           arch: ${{ matrix.target.arch }}
           force: "true"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Recently created AMIs that were created by running `build-ami` nix package (_should_ be all AMIs...) have the GHA run id in the name. This is a change in naming scheme for the `Release AMI Nix` based AMIs which customers will ultimately see. Its not too useful for them and not something that I intended to change. This also causes issues in internal tooling which should be fixed but needs a band-aid for now.

## What is the new behavior?

No GHA Run ID in the AMI name, preserving naming schemed used by `Release AMI Nix`. Should not be an issue for other workflows since they weren't really looking at the ami name for anything.