### PR TITLE
Bandaid for darwin runners being disconnected

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -40,17 +40,14 @@ jobs:
       - name: Checkout Repo
         if: ${{ matrix.attr != '' }}
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - name: Install nix (ephemeral)
-        if: ${{ matrix.attr != '' && matrix.runs_on.group != 'self-hosted-runners-nix' }}
+      - name: Install nix
+        if: ${{ matrix.attr != '' }}
         uses: ./.github/actions/nix-install-ephemeral
         with:
           push-to-cache: 'true'
         env:
           DEV_AWS_ROLE: ${{ secrets.DEV_AWS_ROLE }}
           NIX_SIGN_SECRET_KEY: ${{ secrets.NIX_SIGN_SECRET_KEY }}
-      - name: Install nix (self-hosted)
-        if: ${{ matrix.attr != '' && matrix.runs_on.group == 'self-hosted-runners-nix' }}
-        uses: ./.github/actions/nix-install-self-hosted
       - name: nix build
         if: ${{ matrix.attr != '' }}
         uses: ./.github/actions/nix-build-retry
@@ -74,17 +71,14 @@ jobs:
       - name: Checkout Repo
         if: ${{ matrix.attr != '' }}
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - name: Install nix (ephemeral)
-        if: ${{ matrix.attr != '' && matrix.runs_on.group != 'self-hosted-runners-nix' }}
+      - name: Install nix
+        if: ${{ matrix.attr != '' }}
         uses: ./.github/actions/nix-install-ephemeral
         with:
           push-to-cache: 'true'
         env:
           DEV_AWS_ROLE: ${{ secrets.DEV_AWS_ROLE }}
           NIX_SIGN_SECRET_KEY: ${{ secrets.NIX_SIGN_SECRET_KEY }}
-      - name: Install nix (self-hosted)
-        if: ${{ matrix.attr != '' && matrix.runs_on.group == 'self-hosted-runners-nix' }}
-        uses: ./.github/actions/nix-install-self-hosted
       - name: nix build
         if: ${{ matrix.attr != '' }}
         uses: ./.github/actions/nix-build-retry
@@ -106,8 +100,16 @@ jobs:
       - name: Checkout Repo
         if: ${{ matrix.attr != '' }}
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - name: Install nix
-        if: ${{ matrix.attr != '' }}
+      - name: Install nix (ephemeral)
+        if: ${{ matrix.attr != '' && matrix.runs_on.group != 'self-hosted-runners-nix' }}
+        uses: ./.github/actions/nix-install-ephemeral
+        with:
+          push-to-cache: 'true'
+        env:
+          DEV_AWS_ROLE: ${{ secrets.DEV_AWS_ROLE }}
+          NIX_SIGN_SECRET_KEY: ${{ secrets.NIX_SIGN_SECRET_KEY }}
+      - name: Install nix (self-hosted)
+        if: ${{ matrix.attr != '' && matrix.runs_on.group == 'self-hosted-runners-nix' }}
         uses: ./.github/actions/nix-install-self-hosted
       - name: nix build
         if: ${{ matrix.attr != '' }}
@@ -134,7 +136,12 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Install nix
         if: ${{ matrix.attr != '' }}
-        uses: ./.github/actions/nix-install-self-hosted
+        uses: ./.github/actions/nix-install-ephemeral
+        with:
+          push-to-cache: 'true'
+        env:
+          DEV_AWS_ROLE: ${{ secrets.DEV_AWS_ROLE }}
+          NIX_SIGN_SECRET_KEY: ${{ secrets.NIX_SIGN_SECRET_KEY }}
       - name: nix build
         if: ${{ matrix.attr != '' }}
         uses: ./.github/actions/nix-build-retry

--- a/nix/packages/github-matrix/github_matrix.py
+++ b/nix/packages/github-matrix/github_matrix.py
@@ -229,17 +229,17 @@ def is_large_pkg(pkg: NixEvalJobsOutput) -> bool:
     return "big-parallel" in pkg.get("requiredSystemFeatures", [])
 
 
-def is_kvm_pkg(pkg: NixEvalJobsOutput) -> bool:
-    """Determine if a package requires KVM"""
-    return "kvm" in pkg.get("requiredSystemFeatures", [])
+def is_virt_pkg(pkg: NixEvalJobsOutput) -> bool:
+    """Determine if a package requires hardware virtualization capabilities"""
+    return bool({"apple-virt", "kvm"} & set(pkg.get("requiredSystemFeatures", [])))
 
 
 def get_runner_for_package(pkg: NixEvalJobsOutput) -> RunsOnConfig | None:
     """Determine the appropriate GitHub Actions runner for a package.
 
     Priority order:
-    1. KVM packages on Darwin → self-hosted runners
-    2. KVM packages on Linux → ephemeral runners
+    1. VM packages on Darwin → self-hosted runners
+    2. VM packages on Linux → ephemeral runners
     3. Large packages on Linux → 32vcpu ephemeral runners
     4. Darwin packages → self-hosted runners
     5. Default → ephemeral runners
@@ -254,7 +254,7 @@ def get_runner_for_package(pkg: NixEvalJobsOutput) -> RunsOnConfig | None:
 
     specs = Specs()
 
-    match (is_kvm_pkg(pkg), is_large_pkg(pkg), os, arch):
+    match (is_virt_pkg(pkg), is_large_pkg(pkg), os, arch):
         case (_, _, "darwin", "aarch64"):
             return {"group": "self-hosted-runners-nix", "labels": ["aarch64-darwin"]}
 

--- a/nix/packages/github-matrix/github_matrix.py
+++ b/nix/packages/github-matrix/github_matrix.py
@@ -161,11 +161,11 @@ def parse_nix_eval_line(
 
 def run_nix_eval_jobs(
     cmd: List[str],
-) -> Tuple[List[NixEvalJobsOutput], List[str], List[NixEvalError]]:
+) -> Tuple[str, List[str]]:
     """Run nix-eval-jobs and return parsed package data, warnings, and errors.
 
     Returns:
-        Tuple of (packages, warnings_list, errors_list)
+        Tuple of (stdout, warnings_list)
     """
     print(f"Running: {' '.join(cmd)}", file=sys.stderr)
 
@@ -177,17 +177,6 @@ def run_nix_eval_jobs(
         cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, env=env
     )
     stdout_data, stderr_data = process.communicate()
-
-    # Parse stdout for packages
-    packages: List[NixEvalJobsOutput] = []
-    drv_paths: Set[str] = set()
-    errors_list: List[NixEvalError] = []
-    for line in stdout_data.splitlines():
-        result = parse_nix_eval_line(line, drv_paths)
-        if result.is_err():
-            errors_list.append(result._value)
-        elif result._value is not None:
-            packages.append(result._value)
 
     # Parse stderr for warnings (lines starting with "warning:")
     warnings_list: List[str] = []
@@ -203,7 +192,24 @@ def run_nix_eval_jobs(
             title="Process Failure",
         )
 
-    return packages, warnings_list, errors_list
+    return stdout_data, warnings_list
+
+
+def process_nix_eval_jobs_stdout(
+    stdout: str,
+) -> Tuple[List[NixEvalJobsOutput], List[NixEvalError]]:
+    # Parse stdout for packages
+    packages: List[NixEvalJobsOutput] = []
+    drv_paths: Set[str] = set()
+    errors: List[NixEvalError] = []
+    for line in stdout.splitlines():
+        result = parse_nix_eval_line(line, drv_paths)
+        if result.is_err():
+            errors_list.append(result._value)
+        elif result._value is not None:
+            packages.append(result._value)
+
+    return packages, errors
 
 
 def is_extension_pkg(pkg: NixEvalJobsOutput) -> bool:
@@ -298,17 +304,32 @@ def main() -> None:
         help="Number of parallel eval jobs. Defaults to the number of logical CPUs in the system.",
     )
     parser.add_argument(
+        "--stdin",
+        action="store_true",
+        help="Read nix-eval-jobs output from stdin instead of executing process",
+    )
+    parser.add_argument(
+        "--stdout",
+        action="store_true",
+        help="Send matrix as json to stdout",
+    )
+    parser.add_argument(
         "flake_outputs", nargs="+", help="Nix flake outputs to evaluate"
     )
 
     args = parser.parse_args()
 
-    cmd = build_nix_eval_command(
-        args.nb_eval_jobs_workers, args.max_memory_size, args.flake_outputs
-    )
+    if args.stdin:
+        nix_eval_output, warnings_list = sys.stdin.read(), []
+    else:
+        cmd = build_nix_eval_command(
+            args.nb_eval_jobs_workers,
+            args.max_memory_size,
+            args.flake_outputs,
+        )
+        nix_eval_output, warnings_list = run_nix_eval_jobs(cmd)
 
-    # Run evaluation and collect packages, warnings, and errors
-    packages, warnings_list, errors_list = run_nix_eval_jobs(cmd)
+    packages, errors_list = process_nix_eval_jobs_stdout(nix_eval_output)
     gh_action_packages = sort_pkgs_by_closures(packages)
 
     def clean_package_for_output(pkg: NixEvalJobsOutput) -> GitHubActionPackage:
@@ -405,6 +426,8 @@ def main() -> None:
 
     if errors_list:
         sys.exit(1)
+    elif args.stdout:
+        print(json.dumps(gh_output))
     else:
         formatted_msg = f"Generated GitHub Actions matrix: {json.dumps(gh_output, indent=2)}".replace(
             "\n", "%0A"

--- a/nix/packages/github-matrix/github_matrix.py
+++ b/nix/packages/github-matrix/github_matrix.py
@@ -239,10 +239,9 @@ def get_runner_for_package(pkg: NixEvalJobsOutput) -> RunsOnConfig | None:
 
     Priority order:
     1. VM packages on Darwin → self-hosted runners
-    2. VM packages on Linux → ephemeral runners
-    3. Large packages on Linux → 32vcpu ephemeral runners
-    4. Darwin packages → self-hosted runners
-    5. Default → ephemeral runners
+    2. VM packages on Linux  → 16vcpu blacksmith runners
+    3. Large packages on D/L → 12/32vcpu blacksmith runners
+    5. Default Darwin/Linux  → 6/8vcpu blacksmith runners
     """
 
     system = pkg["system"]
@@ -255,22 +254,25 @@ def get_runner_for_package(pkg: NixEvalJobsOutput) -> RunsOnConfig | None:
     specs = Specs()
 
     match (is_virt_pkg(pkg), is_large_pkg(pkg), os, arch):
-        case (_, _, "darwin", "aarch64"):
-            return {"group": "self-hosted-runners-nix", "labels": ["aarch64-darwin"]}
-
         # kvm
+        case (True, _, "darwin", "aarch64"):
+            return {"group": "self-hosted-runners-nix", "labels": ["aarch64-darwin"]}
         case (True, _, "linux", "aarch64"):
             specs = Specs(16, "ubuntu-2404-arm")
         case (True, _, "linux", "x86_64"):
-            specs = Specs(8, "ubuntu-2404")
+            specs = Specs(16, "ubuntu-2404")
 
         # large
+        case (_, True, "darwin", "aarch64"):
+            specs = Specs(12, "macos-26")
         case (_, True, "linux", "aarch64"):
             specs = Specs(32, "ubuntu-2404-arm")
         case (_, True, "linux", "x86_64"):
             specs = Specs(32, "ubuntu-2404")
 
         # default
+        case (_, _, "darwin", "aarch64"):
+            specs = Specs(6, "macos-26")
         case (_, _, "linux", "aarch64"):
             specs = Specs(8, "ubuntu-2404-arm")
         case (_, _, "linux", "x86_64"):

--- a/nix/packages/github-matrix/github_matrix.py
+++ b/nix/packages/github-matrix/github_matrix.py
@@ -12,6 +12,7 @@ from typing import (
     Dict,
     List,
     Literal,
+    NamedTuple,
     NotRequired,
     Optional,
     Set,
@@ -24,7 +25,6 @@ from github_action_utils import debug, notice, error, set_output, warning
 from result import Err, Ok, Result
 
 System = Literal["x86_64-linux", "aarch64-linux", "aarch64-darwin"]
-RunnerType = Literal["ephemeral", "self-hosted"]
 
 
 class NixEvalJobsOutput(TypedDict):
@@ -65,24 +65,6 @@ class NixEvalError(TypedDict):
 
     attr: str
     error: str
-
-
-BUILD_RUNNER_MAP: Dict[RunnerType, Dict[System, RunsOnConfig]] = {
-    "ephemeral": {
-        "aarch64-linux": {
-            "labels": ["blacksmith-8vcpu-ubuntu-2404-arm"],
-        },
-        "x86_64-linux": {
-            "labels": ["blacksmith-8vcpu-ubuntu-2404"],
-        },
-    },
-    "self-hosted": {
-        "aarch64-darwin": {
-            "group": "self-hosted-runners-nix",
-            "labels": ["aarch64-darwin"],
-        },
-    },
-}
 
 
 def build_nix_eval_command(
@@ -262,28 +244,39 @@ def get_runner_for_package(pkg: NixEvalJobsOutput) -> RunsOnConfig | None:
     4. Darwin packages → self-hosted runners
     5. Default → ephemeral runners
     """
+
     system = pkg["system"]
+    arch, os = system.split("-")
 
-    if is_kvm_pkg(pkg):
-        if system == "aarch64-darwin":
-            return BUILD_RUNNER_MAP["self-hosted"]["aarch64-darwin"]
-        if system == "aarch64-linux":
-            return {"labels": ["blacksmith-16vcpu-ubuntu-2404-arm"]}
-        runConfig = BUILD_RUNNER_MAP["ephemeral"].get(system)
-        if runConfig is None:
-            raise ValueError(
-                f"No ephemeral runner with kvm support available for system: {system}"
-            )
-        return runConfig
+    class Specs(NamedTuple):
+        vcpu: int = 0
+        osv: str = None
 
-    if is_large_pkg(pkg) and system in ("x86_64-linux", "aarch64-linux"):
-        suffix = "-arm" if system == "aarch64-linux" else ""
-        return {"labels": [f"blacksmith-32vcpu-ubuntu-2404{suffix}"]}
+    specs = Specs()
 
-    if system == "aarch64-darwin":
-        return BUILD_RUNNER_MAP["self-hosted"]["aarch64-darwin"]
+    match (is_kvm_pkg(pkg), is_large_pkg(pkg), os, arch):
+        case (_, _, "darwin", "aarch64"):
+            return {"group": "self-hosted-runners-nix", "labels": ["aarch64-darwin"]}
 
-    return BUILD_RUNNER_MAP["ephemeral"].get(system)
+        # kvm
+        case (True, _, "linux", "aarch64"):
+            specs = Specs(16, "ubuntu-2404-arm")
+        case (True, _, "linux", "x86_64"):
+            specs = Specs(8, "ubuntu-2404")
+
+        # large
+        case (_, True, "linux", "aarch64"):
+            specs = Specs(32, "ubuntu-2404-arm")
+        case (_, True, "linux", "x86_64"):
+            specs = Specs(32, "ubuntu-2404")
+
+        # default
+        case (_, _, "linux", "aarch64"):
+            specs = Specs(8, "ubuntu-2404-arm")
+        case (_, _, "linux", "x86_64"):
+            specs = Specs(8, "ubuntu-2404")
+
+    return {"labels": [f"blacksmith-{specs.vcpu}vcpu-{specs.osv}"]}
 
 
 def main() -> None:

--- a/nix/packages/github-matrix/tests/test_github_matrix.py
+++ b/nix/packages/github-matrix/tests/test_github_matrix.py
@@ -8,7 +8,7 @@ from github_matrix import (
     NixEvalJobsOutput,
     get_runner_for_package,
     is_extension_pkg,
-    is_kvm_pkg,
+    is_virt_pkg,
     is_large_pkg,
     parse_nix_eval_line,
     sort_pkgs_by_closures,
@@ -70,29 +70,21 @@ class TestIsLargePkg:
         assert is_large_pkg(pkg) is expected
 
 
-class TestIsKvmPkg:
-    def test_kvm_package(self):
+class TestIsVirtPkg:
+    @pytest.mark.parametrize(
+        "feat,expected",
+        [
+            ("", False),
+            ("apple-virt", True),
+            ("big-parallel", False),
+            ("kvm", True),
+        ],
+    )
+    def test_is_virt_pkg(self, feat, expected):
         pkg: NixEvalJobsOutput = {
-            "attr": "packages.x86_64-linux.vm-test",
-            "attrPath": ["packages", "x86_64-linux", "vm-test"],
-            "cacheStatus": "notBuilt",
-            "drvPath": "/nix/store/test.drv",
-            "name": "vm-test",
-            "system": "x86_64-linux",
-            "requiredSystemFeatures": ["kvm"],
+            "requiredSystemFeatures": [feat],
         }
-        assert is_kvm_pkg(pkg) is True
-
-    def test_non_kvm_package(self):
-        pkg: NixEvalJobsOutput = {
-            "attr": "packages.x86_64-linux.psql_15",
-            "attrPath": ["packages", "x86_64-linux", "psql_15"],
-            "cacheStatus": "notBuilt",
-            "drvPath": "/nix/store/test.drv",
-            "name": "postgresql-16.0",
-            "system": "x86_64-linux",
-        }
-        assert is_kvm_pkg(pkg) is False
+        assert is_virt_pkg(pkg) is expected
 
 
 class TestNixOSCheck:
@@ -124,7 +116,7 @@ class TestGetRunnerForPackage:
         [
             (
                 "aarch64-darwin",
-                "kvm",
+                "apple-virt",
                 {"group": "self-hosted-runners-nix", "labels": ["aarch64-darwin"]},
             ),
             (

--- a/nix/packages/github-matrix/tests/test_github_matrix.py
+++ b/nix/packages/github-matrix/tests/test_github_matrix.py
@@ -122,12 +122,12 @@ class TestGetRunnerForPackage:
             (
                 "aarch64-darwin",
                 "big-parallel",
-                {"group": "self-hosted-runners-nix", "labels": ["aarch64-darwin"]},
+                {"labels": ["blacksmith-12vcpu-macos-26"]},
             ),
             (
                 "aarch64-darwin",
                 None,
-                {"group": "self-hosted-runners-nix", "labels": ["aarch64-darwin"]},
+                {"labels": ["blacksmith-6vcpu-macos-26"]},
             ),
             (
                 "aarch64-linux",
@@ -147,7 +147,7 @@ class TestGetRunnerForPackage:
             (
                 "x86_64-linux",
                 "kvm",
-                {"labels": ["blacksmith-8vcpu-ubuntu-2404"]},
+                {"labels": ["blacksmith-16vcpu-ubuntu-2404"]},
             ),
             (
                 "x86_64-linux",

--- a/nix/packages/github-matrix/tests/test_github_matrix.py
+++ b/nix/packages/github-matrix/tests/test_github_matrix.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+import json
+
 import pytest
 
 from github_matrix import (
@@ -8,6 +10,7 @@ from github_matrix import (
     is_extension_pkg,
     is_kvm_pkg,
     is_large_pkg,
+    parse_nix_eval_line,
     sort_pkgs_by_closures,
 )
 
@@ -90,6 +93,29 @@ class TestIsKvmPkg:
             "system": "x86_64-linux",
         }
         assert is_kvm_pkg(pkg) is False
+
+
+class TestNixOSCheck:
+    @pytest.mark.parametrize(
+        "system,expected",
+        [
+            ("aarch64-darwin", False),
+            ("aarch64-linux", True),
+            ("x86_64-linux", False),
+        ],
+    )
+    def test_system(self, system, expected):
+        check = {
+            "attr": f"attr-{system}",
+            "drvPath": f"test_{system}",
+            "system": system,
+            "requiredSystemFeatures": ["nixos-test"],
+        }
+        result = parse_nix_eval_line(json.dumps(check), set())
+        if expected:
+            assert result._value is not None
+        else:
+            assert result._value is None
 
 
 class TestGetRunnerForPackage:

--- a/nix/packages/github-matrix/tests/test_github_matrix.py
+++ b/nix/packages/github-matrix/tests/test_github_matrix.py
@@ -119,124 +119,65 @@ class TestNixOSCheck:
 
 
 class TestGetRunnerForPackage:
-    def test_kvm_package_x86_64_linux(self):
-        pkg: NixEvalJobsOutput = {
-            "attr": "packages.x86_64-linux.vm-test",
-            "attrPath": ["packages", "x86_64-linux", "vm-test"],
-            "cacheStatus": "notBuilt",
-            "drvPath": "/nix/store/test.drv",
-            "name": "vm-test",
-            "system": "x86_64-linux",
-            "requiredSystemFeatures": ["kvm"],
-        }
-        result = get_runner_for_package(pkg)
-        assert result == {
-            "labels": ["blacksmith-8vcpu-ubuntu-2404"],
-        }
-
-    def test_kvm_package_aarch64_linux(self):
-        pkg: NixEvalJobsOutput = {
-            "attr": "packages.aarch64-linux.vm-test",
-            "attrPath": ["packages", "aarch64-linux", "vm-test"],
-            "cacheStatus": "notBuilt",
-            "drvPath": "/nix/store/test.drv",
-            "name": "vm-test",
-            "system": "aarch64-linux",
-            "requiredSystemFeatures": ["kvm"],
-        }
-        result = get_runner_for_package(pkg)
-        assert result == {
-            "labels": ["blacksmith-16vcpu-ubuntu-2404-arm"],
-        }
-
-    def test_large_package_x86_64_linux(self):
-        pkg: NixEvalJobsOutput = {
-            "attr": "legacyPackages.x86_64-linux.psql_15.exts.postgis",
-            "attrPath": [
-                "legacyPackages",
-                "x86_64-linux",
-                "psql_15",
-                "exts",
-                "postgis",
-            ],
-            "cacheStatus": "notBuilt",
-            "drvPath": "/nix/store/test.drv",
-            "name": "postgis",
-            "system": "x86_64-linux",
-            "requiredSystemFeatures": ["big-parallel"],
-        }
-        result = get_runner_for_package(pkg)
-        assert result == {"labels": ["blacksmith-32vcpu-ubuntu-2404"]}
-
-    def test_large_package_aarch64_linux(self):
-        pkg: NixEvalJobsOutput = {
-            "attr": "legacyPackages.aarch64-linux.psql_15.exts.pg_graphql",
-            "attrPath": [
-                "legacyPackages",
+    @pytest.mark.parametrize(
+        "system,feature,expected",
+        [
+            (
+                "aarch64-darwin",
+                "kvm",
+                {"group": "self-hosted-runners-nix", "labels": ["aarch64-darwin"]},
+            ),
+            (
+                "aarch64-darwin",
+                "big-parallel",
+                {"group": "self-hosted-runners-nix", "labels": ["aarch64-darwin"]},
+            ),
+            (
+                "aarch64-darwin",
+                None,
+                {"group": "self-hosted-runners-nix", "labels": ["aarch64-darwin"]},
+            ),
+            (
                 "aarch64-linux",
-                "psql_15",
-                "exts",
-                "pg_graphql",
-            ],
-            "cacheStatus": "notBuilt",
-            "drvPath": "/nix/store/test.drv",
-            "name": "pg_graphql",
-            "system": "aarch64-linux",
-            "requiredSystemFeatures": ["big-parallel"],
-        }
-        result = get_runner_for_package(pkg)
-        assert result == {"labels": ["blacksmith-32vcpu-ubuntu-2404-arm"]}
-
-    def test_darwin_package(self):
-        pkg: NixEvalJobsOutput = {
-            "attr": "legacyPackages.aarch64-darwin.psql_15",
-            "attrPath": ["legacyPackages", "aarch64-darwin", "psql_15"],
-            "cacheStatus": "notBuilt",
-            "drvPath": "/nix/store/test.drv",
-            "name": "postgresql-16.0",
-            "system": "aarch64-darwin",
-        }
-        result = get_runner_for_package(pkg)
-        assert result == {
-            "group": "self-hosted-runners-nix",
-            "labels": ["aarch64-darwin"],
-        }
-
-    def test_default_x86_64_linux(self):
-        pkg: NixEvalJobsOutput = {
-            "attr": "legacyPackages.x86_64-linux.psql_15.exts.pg_cron",
-            "attrPath": [
-                "legacyPackages",
-                "x86_64-linux",
-                "psql_15",
-                "exts",
-                "pg_cron",
-            ],
-            "cacheStatus": "notBuilt",
-            "drvPath": "/nix/store/test.drv",
-            "name": "pg_cron",
-            "system": "x86_64-linux",
-        }
-        result = get_runner_for_package(pkg)
-        assert result == {"labels": ["blacksmith-8vcpu-ubuntu-2404"]}
-
-    def test_default_aarch64_linux(self):
-        pkg: NixEvalJobsOutput = {
-            "attr": "legacyPackages.aarch64-linux.psql_15.exts.pg_cron",
-            "attrPath": [
-                "legacyPackages",
+                "kvm",
+                {"labels": ["blacksmith-16vcpu-ubuntu-2404-arm"]},
+            ),
+            (
                 "aarch64-linux",
-                "psql_15",
-                "exts",
-                "pg_cron",
-            ],
-            "cacheStatus": "notBuilt",
-            "drvPath": "/nix/store/test.drv",
-            "name": "pg_cron",
-            "system": "aarch64-linux",
+                "big-parallel",
+                {"labels": ["blacksmith-32vcpu-ubuntu-2404-arm"]},
+            ),
+            (
+                "aarch64-linux",
+                None,
+                {"labels": ["blacksmith-8vcpu-ubuntu-2404-arm"]},
+            ),
+            (
+                "x86_64-linux",
+                "kvm",
+                {"labels": ["blacksmith-8vcpu-ubuntu-2404"]},
+            ),
+            (
+                "x86_64-linux",
+                "big-parallel",
+                {"labels": ["blacksmith-32vcpu-ubuntu-2404"]},
+            ),
+            (
+                "x86_64-linux",
+                None,
+                {"labels": ["blacksmith-8vcpu-ubuntu-2404"]},
+            ),
+        ],
+    )
+    def test_get_runner_for_package(self, system, feature, expected):
+        pkg: NixEvalJobsOutput = {
+            "system": system,
         }
+        if feature:
+            pkg["requiredSystemFeatures"] = [feature]
+
         result = get_runner_for_package(pkg)
-        assert result == {"labels": ["blacksmith-8vcpu-ubuntu-2404-arm"]}
+        assert result == expected
 
 
 class TestSortPkgsByClosures:


### PR DESCRIPTION
## What kind of change does this PR introduce?

CI env fix

## What is the current behavior?

self hosted bare metal macos darwin runners are showing up as offline.

## What is the new behavior?

Lets use blacksmith runners for anything that doesn't explicitly required virtualization. Less management/headaches this way.

## Additional context

Still need to get these fixed up for the "kvm" tests that will come up at some point, also waiting on info from Blacksmith about running these virt cases on their runners.