### PR TITLE
feat: add `USING heap` to pg_cron installation script

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.099-orioledb"
-  postgres17: "17.6.1.142"
-  postgres15: "15.14.1.142"
+  postgresorioledb-17: "17.6.0.100-orioledb"
+  postgres17: "17.6.1.143"
+  postgres15: "15.14.1.143"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1

--- a/nix/ext/pg_cron/pg_cron-heap-tables.patch
+++ b/nix/ext/pg_cron/pg_cron-heap-tables.patch
@@ -1,0 +1,26 @@
+diff --git a/pg_cron--1.2--1.3.sql b/pg_cron--1.2--1.3.sql
+index b1e6a68..f4b94e7 100644
+--- a/pg_cron--1.2--1.3.sql
++++ b/pg_cron--1.2--1.3.sql
+@@ -12,7 +12,7 @@ CREATE TABLE cron.job_run_details (
+ 	return_message text,
+ 	start_time timestamptz,
+ 	end_time timestamptz
+-);
++) USING heap;
+ 
+ GRANT SELECT ON cron.job_run_details TO public;
+ GRANT DELETE ON cron.job_run_details TO public;
+diff --git a/pg_cron.sql b/pg_cron.sql
+index 2de23f4..e843ac7 100644
+--- a/pg_cron.sql
++++ b/pg_cron.sql
+@@ -23,7 +23,7 @@ CREATE TABLE cron.job (
+ 	nodeport int not null default pg_catalog.inet_server_port(),
+ 	database text not null default pg_catalog.current_database(),
+ 	username text not null default current_user
+-);
++) USING heap;
+ GRANT SELECT ON cron.job TO public;
+ ALTER TABLE cron.job ENABLE ROW LEVEL SECURITY;
+ CREATE POLICY cron_job_policy ON cron.job USING (username OPERATOR(pg_catalog.=) current_user);

--- a/nix/ext/versions.json
+++ b/nix/ext/versions.json
@@ -114,7 +114,10 @@
         "orioledb-17"
       ],
       "rev": "v1.6.4",
-      "hash": "sha256-t1DpFkPiSfdoGG2NgNT7g1lkvSooZoRoUrix6cBID40="
+      "hash": "sha256-t1DpFkPiSfdoGG2NgNT7g1lkvSooZoRoUrix6cBID40=",
+      "patches": [
+        "pg_cron-heap-tables.patch"
+      ]
     }
   },
   "pg_graphql": {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix `pg_cron`'s installation script and add `USING heap` to create heap tables. Otherwise smoke tests fails for orioledb tests with the error:
```
2026-06-27T12:00:03.943209Z ERROR supadev::run:execute_sql_with_connection{allow_failures=false conn.label=direct conn.host=db.xvnsysuyfaosipddgvhm.supabase.red conn.port=5432}: supadev::psql: error=psql failed with code 3: ERROR:  attempted to delete invisible tuple
```

## What is the current behavior?

ORI-172

## What is the new behavior?

The installation script will have the following statement:
```
CREATE TABLE cron.job (
	jobid bigint primary key default pg_catalog.nextval('cron.jobid_seq'),
	schedule text not null,
	command text not null,
	nodename text not null default 'localhost',
	nodeport int not null default pg_catalog.inet_server_port(),
	database text not null default pg_catalog.current_database(),
	username text not null default current_user
) USING heap;
```

## Additional context

Add any other context or screenshots.