### PR TITLE
feat(ansible): add kernel sysctl tuning params to tuned profile

### DIFF
--- a/ansible/tasks/setup-tuned.yml
+++ b/ansible/tasks/setup-tuned.yml
@@ -111,8 +111,6 @@
           value: '1048576'
         - option: 'fs.file-max'
           value: '312139770'
-        - option: 'kernel.panic'
-          value: '10'
         - option: 'kernel.panic_on_oom'
           value: '1'
         - option: 'kernel.panic_on_oops'
@@ -141,6 +139,21 @@
           value: '1'
       loop_control:
         loop_var: 'sysctl_item'
+
+    - name: 'tuned - Set kernel.panic=10'  # noqa: name[casing]
+      community.general.ini_file:
+        create: true
+        group: 'root'
+        mode: '0644'
+        no_extra_spaces: true
+        option: 'kernel.panic'
+        path: '/etc/tuned/profiles/postgresql/tuned.conf'
+        section: 'sysctl'
+        state: 'present'
+        value: '10'
+      become: true
+      when:
+        - (debpkg_mode or nixpkg_mode)
 
     - name: 'tuned - Enable zswap if swap is present'  # noqa: name[casing]
       when:

--- a/ansible/tasks/setup-tuned.yml
+++ b/ansible/tasks/setup-tuned.yml
@@ -111,6 +111,22 @@
           value: '1048576'
         - option: 'fs.file-max'
           value: '312139770'
+        - option: 'kernel.panic'
+          value: '10'
+        - option: 'kernel.panic_on_oom'
+          value: '1'
+        - option: 'kernel.panic_on_oops'
+          value: '1'
+        - option: 'kernel.sched_autogroup_enabled'
+          value: '0'
+        - option: 'kernel.sem'
+          value: '250 512000 100 2048'
+        - option: 'kernel.shmall'
+          value: '18446744073692700000'
+        - option: 'kernel.shmmax'
+          value: '18446744073692700000'
+        - option: 'kernel.shmmni'
+          value: '4096'
         - option: 'net.core.somaxconn'
           value: '16834'
         - option: 'net.ipv4.ip_local_port_range'
@@ -125,21 +141,6 @@
           value: '1'
       loop_control:
         loop_var: 'sysctl_item'
-
-    - name: 'tuned - Set kernel.panic=10'  # noqa: name[casing]
-      community.general.ini_file:
-        create: true
-        group: 'root'
-        mode: '0644'
-        no_extra_spaces: true
-        option: 'kernel.panic'
-        path: '/etc/tuned/profiles/postgresql/tuned.conf'
-        section: 'sysctl'
-        state: 'present'
-        value: '10'
-      become: true
-      when:
-        - (debpkg_mode or nixpkg_mode)
 
     - name: 'tuned - Enable zswap if swap is present'  # noqa: name[casing]
       when:

--- a/ansible/tasks/setup-tuned.yml
+++ b/ansible/tasks/setup-tuned.yml
@@ -111,8 +111,6 @@
           value: '1048576'
         - option: 'fs.file-max'
           value: '312139770'
-        - option: 'kernel.panic_on_oom'
-          value: '1'
         - option: 'kernel.panic_on_oops'
           value: '1'
         - option: 'kernel.sched_autogroup_enabled'


### PR DESCRIPTION
## Summary

Adds a set of kernel-level `sysctl` tuning parameters to the `postgresql` tuned profile (`ansible/tasks/setup-tuned.yml`). These settings harden the host for predictable failure behavior and align shared-memory / IPC limits with PostgreSQL's needs.

## Changes

New entries added to the main `sysctl` loop of the tuned profile:

| Parameter | Value | Purpose |
|-----------|-------|---------|
| `kernel.panic_on_oops` | `1` | Treat a kernel oops as a panic for fail-fast recovery |
| `kernel.sched_autogroup_enabled` | `0` | Disable autogroup scheduling for consistent backend CPU sharing |
| `kernel.sem` | `250 512000 100 2048` | SysV semaphore limits sized for many backends |
| `kernel.shmall` | `18446744073692700000` | Effectively unlimited total shared memory pages |
| `kernel.shmmax` | `18446744073692700000` | Effectively unlimited max single shared memory segment |
| `kernel.shmmni` | `4096` | Raise the max number of shared memory segments |

`kernel.panic=10` is **not** part of this loop — it remains its own task gated by `(debpkg_mode or nixpkg_mode)`, unchanged from `develop`, so `stage2_nix`-only builds retain their prior behavior.

## Why these benefit PostgreSQL

**Predictable failure & faster recovery (`kernel.panic_on_oops`)**
On a managed database host, a wedged kernel is worse than a fast restart. `panic_on_oops=1` converts an ambiguous, hung oops state into a clean panic, which — combined with the profile's existing `kernel.panic=10` (auto-reboot) and `vm.panic_on_oom=1` — bounds downtime and lets orchestration/HA detect and replace a node deterministically instead of waiting on a hung host.

**Scheduler determinism (`kernel.sched_autogroup_enabled=0`)**
Autogrouping batches tasks by session/TTY, which can starve PostgreSQL's many cooperating backend processes of fair CPU time under load. Disabling it gives the scheduler a flatter view of the backends, improving latency consistency for connection-heavy workloads.

**Shared memory limits (`kernel.shmmax`, `kernel.shmall`, `kernel.shmmni`)**
PostgreSQL allocates its main shared memory region (shared_buffers, lock tables, etc.) at startup. While modern PostgreSQL uses POSIX `mmap`/huge pages for most of this, generously sized SysV limits remove a class of startup failures (`could not create shared memory segment`) for large-memory instances and large `shared_buffers` configurations. Setting `shmmax`/`shmall` to effectively unlimited and raising `shmmni` future-proofs the host across instance sizes. (`shmmax` is in bytes, `shmall` in pages; both are set to ~2^64 and are therefore effectively unbounded.)

**IPC semaphores (`kernel.sem`)**
PostgreSQL consumes SysV semaphores proportional to `max_connections` (plus autovacuum workers and background processes). The `250 512000 100 2048` tuple (`SEMMSL SEMMNS SEMOPM SEMMNI`) raises semaphore headroom so high `max_connections` instances start cleanly instead of failing with semaphore exhaustion.

