### PR TITLE
Release AMI: Hard code ami_name_prefix for now

### DIFF
--- a/.github/workflows/ami-release-nix.yml
+++ b/.github/workflows/ami-release-nix.yml
@@ -49,9 +49,11 @@ jobs:
           - arch: amd64
             instance_type: c6i.4xlarge
             runner: blacksmith-2vcpu-ubuntu-2404
+            ami_name_prefix: supabase-postgres-x86_64
           - arch: arm64
             instance_type: c6g.4xlarge
             runner: blacksmith-2vcpu-ubuntu-2404-arm
+            ami_name_prefix: supabase-postgres-arm64
     runs-on: ${{ matrix.target.runner }}
     timeout-minutes: 150
 
@@ -89,7 +91,7 @@ jobs:
         id: build-ami
         uses: ./.github/actions/build-ami
         with:
-          ami_name_prefix: "supabase-postgres-${{ matrix.target.arch }}"
+          ami_name_prefix: ${{ matrix.target.ami_name_prefix }}
           ami_regions: '["${{ env.AWS_REGION }}"]'
           arch: ${{ matrix.target.arch }}
           force: "true"

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.097-orioledb"
-  postgres17: "17.6.1.140"
-  postgres15: "15.14.1.140"
+  postgresorioledb-17: "17.6.0.098-orioledb"
+  postgres17: "17.6.1.141"
+  postgres15: "15.14.1.141"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

I changed the arch in the AMI by mistake, need to keep old naming scheme for separate tooling.

## What is the new behavior?

Use `x86_64` instead `amd64` like before.