### PR TITLE
feat: backport experiment for x86 prior to 17.6.1.029 starting with 17.6.1.025

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,7 +10,7 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.099-orioledb"
+  postgresorioledb-17: "17.6.0.099-orioledb-x86-backport"
   postgres17: "17.6.1.025-x86-backport"
   postgres15: "15.14.1.025-x86-backport"
 

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -11,8 +11,8 @@ postgres_major:
 # Full version strings for each major version
 postgres_release:
   postgresorioledb-17: "17.6.0.099-orioledb"
-  postgres17: "17.6.1.142"
-  postgres15: "15.14.1.142"
+  postgres17: "17.6.1.025-x86-backport"
+  postgres15: "15.14.1.025-x86-backport"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1


### PR DESCRIPTION
We're going to try and do a staging release of 17.6.1.025-x86-test and see if we can modify our resize/restore functionality to use this image to restore to from existing arm 17.6.1.025. If that works we will look at a way to backfill these images

