### PR TITLE
HOTFIX: build x86 image for old version

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.099-orioledb"
-  postgres17: "17.6.1.142"
-  postgres15: "15.14.1.142"
+  postgresorioledb-17: "17.6.0.099-orioledb-ignore"
+  postgres17: "17.6.1.013-backfill"
+  postgres15: "15.14.1.142-ignore"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -1,6 +1,9 @@
 { self, inputs, ... }:
 {
-  imports = [ ./postgres.nix ];
+  imports = [
+    ./postgres.nix
+    ./legacy-pins.nix
+  ];
   perSystem =
     {
       inputs',

--- a/nix/packages/legacy-pins.nix
+++ b/nix/packages/legacy-pins.nix
@@ -1,0 +1,26 @@
+{ ... }:
+{
+  perSystem =
+    {
+      lib,
+      pkgs,
+      system,
+      ...
+    }:
+    let
+      # Rebuild old 17.6.1.013 release as an x86_64 linux AMI.
+      # Reuse old packages from the legacy flake to avoid version differences in postgresql and extensions.
+      postgres_17_6_1_013 =
+        # tag 17.6.1.013
+        (builtins.getFlake "github:supabase/postgres/e4308280107035cf7a2590d696aed0e9713bed3a")
+        .packages.${system};
+    in
+    {
+      packages = lib.optionalAttrs pkgs.stdenv.isLinux {
+        "psql_17/bin" = lib.mkForce postgres_17_6_1_013."psql_17/bin";
+        postgresql_17_debug = lib.mkForce postgres_17_6_1_013.postgresql_17_debug;
+        postgresql_17_src = lib.mkForce postgres_17_6_1_013.postgresql_17_src;
+        supabase-groonga = lib.mkForce postgres_17_6_1_013.supabase-groonga;
+      };
+    };
+}


### PR DESCRIPTION
HOTFIX to build 17.6.1.013 x86 ami
closed in favor of https://github.com/supabase/postgres/pull/2254