### PR TITLE
INDATA-841: restrict to system journal for pgbouncer logs

### DIFF
--- a/ansible/files/fail2ban_config/jail-pgbouncer.conf.j2
+++ b/ansible/files/fail2ban_config/jail-pgbouncer.conf.j2
@@ -3,5 +3,5 @@ enabled = true
 port    = 6543
 protocol = tcp
 filter = pgbouncer
-backend = systemd[journalflags=1]
+backend = systemd
 maxretry = 3


### PR DESCRIPTION
Instead of checking all journal files, restrict to the system journal to reduce the system load from fail2ban.