### PR TITLE
chore: bump to pg_net 0.20.4

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.099-orioledb"
-  postgres17: "17.6.1.142"
-  postgres15: "15.14.1.142"
+  postgresorioledb-17: "17.6.0.100-orioledb"
+  postgres17: "17.6.1.143"
+  postgres15: "15.14.1.143"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1

--- a/nix/ext/versions.json
+++ b/nix/ext/versions.json
@@ -342,6 +342,13 @@
         "17"
       ],
       "hash": "sha256-uOy/ESRKXngAyDTLHEQ81ZxZCfdtqoP9OxsqzyQJdEY="
+    },
+    "0.20.4": {
+      "postgresql": [
+        "15",
+        "17"
+      ],
+      "hash": "sha256-wtNihaJX9NlTEC/uoaCeA6gNwiGCU3mr2qun8KI2kyY="
     }
   },
   "pgaudit": {


### PR DESCRIPTION
No SQL changes, C-only fixes. This bumps pg_net from 0.20.3 to 0.20.4:

- supabase/pg_net#264 — fix: worker crash loop when a schema named `net` exists without the extension (customer-impacting; see Linear)
- supabase/pg_net#262 — build: could not build with pg versions older than 16 on macos

**Depends on** supabase/pg_net#265 (version bump) being merged and the `v0.20.4` tag being cut — draft until then. The nix hash was computed from the bump branch's tree; will re-verify it against the actual tag before marking ready for review.

Linear: https://linear.app/supabase/issue/PSQL-1372/release-pg-net-fix-for-worker-crash-loop