### PR TITLE
hotfix: backfill x86 ami 17.6.1.104

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.099-orioledb"
-  postgres17: "17.6.1.142"
-  postgres15: "15.14.1.142"
+  postgresorioledb-17: "17.6.0.099-orioledb-ignore1"
+  postgres17: "17.6.1.104-backfill"
+  postgres15: "15.14.1.142-ignore1"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.099-orioledb-ignore1"
-  postgres17: "17.6.1.104-backfill"
-  postgres15: "15.14.1.142-ignore1"
+  postgresorioledb-17: "17.6.0.099-orioledb-ignore11"
+  postgres17: "17.6.1.104-backfill2"
+  postgres15: "15.14.1.142-ignore11"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -1,6 +1,9 @@
 { self, inputs, ... }:
 {
-  imports = [ ./postgres.nix ];
+  imports = [
+    ./postgres.nix
+    ./hotfix-pin.nix
+  ];
   perSystem =
     {
       inputs',

--- a/nix/packages/hotfix-pin.nix
+++ b/nix/packages/hotfix-pin.nix
@@ -42,6 +42,7 @@
     {
       packages = lib.optionalAttrs pkgs.stdenv.isLinux {
         "psql_17/bin" = lib.mkForce psql_old_with_latest_supautils;
+        "psql_17_cli/bin" = lib.mkForce postgres_old."psql_17_cli/bin";
         postgresql_17_debug = lib.mkForce postgres_old.postgresql_17_debug;
         postgresql_17_src = lib.mkForce postgres_old.postgresql_17_src;
         supabase-groonga = lib.mkForce postgres_old.supabase-groonga;

--- a/nix/packages/hotfix-pin.nix
+++ b/nix/packages/hotfix-pin.nix
@@ -1,0 +1,50 @@
+{ ... }:
+{
+  perSystem =
+    {
+      self',
+      lib,
+      pkgs,
+      system,
+      ...
+    }:
+    let
+      # Rebuild old release as an x86_64 linux AMI.
+      # Reuse old packages from the legacy flake to avoid version differences in postgresql and extensions.
+      postgres_old =
+        # tag 17.6.1.104
+        (builtins.getFlake "github:supabase/postgres/2997c92770dd85e6450e3e2c7d2c843f4717f492")
+        .packages.${system};
+
+      psql_old_with_latest_supautils =
+        let
+          oldPsql = postgres_old."psql_17/bin";
+          supautils = self'.legacyPackages.psql_17.exts.supautils;
+        in
+        pkgs.runCommand "${oldPsql.name}-supautils-${supautils.version}"
+          {
+            inherit (oldPsql) version;
+            nativeBuildInputs = [ pkgs.jq ];
+          }
+          ''
+            cp -a ${oldPsql}/. $out/
+            chmod -R u+w $out
+            rm -f $out/lib/supautils${pkgs.stdenv.hostPlatform.extensions.sharedLibrary}
+            ln -s ${supautils}/lib/* $out/lib/
+
+            # update receipt
+            jq --arg version '${supautils.version}' \
+              '(.extensions[] | select(.name == "supautils") | .version) = $version' \
+              $out/receipt.json > $out/receipt.json.tmp
+            mv $out/receipt.json.tmp $out/receipt.json
+          '';
+    in
+    {
+      packages = lib.optionalAttrs pkgs.stdenv.isLinux {
+        "psql_17/bin" = lib.mkForce psql_old_with_latest_supautils;
+        postgresql_17_debug = lib.mkForce postgres_old.postgresql_17_debug;
+        postgresql_17_src = lib.mkForce postgres_old.postgresql_17_src;
+        supabase-groonga = lib.mkForce postgres_old.supabase-groonga;
+      };
+    };
+}


### PR DESCRIPTION
Never merge this.
Release x86 ami for postgres 17.6.1.104-backfill.