### PR TITLE
ci: Do not force building of stage1 ami

### DIFF
--- a/.github/actions/build-ami/action.yml
+++ b/.github/actions/build-ami/action.yml
@@ -11,9 +11,6 @@ inputs:
   arch:
     description: Architecture to build AMI for (amd64|arm64)
     required: true
-  force:
-    description: Force building stage1 AMI
-    required: false
   git_sha:
     description: 'Git SHA for this build'
     required: true
@@ -77,10 +74,6 @@ runs:
         GIT_SHA: ${{ inputs.git_sha }}
       run: |
         echo "::group::AMI Build: Stage 1"
-
-        if [[ -n "${{ inputs.force }}" ]]; then
-          export BUILD_AMI_NIX_FORCE_BUILD_STAGE1="${{ inputs.force }}"
-        fi
 
         nix run .#build-ami -- stage1 ${{ inputs.arch }} \
           -var "ami_name=${{ inputs.ami_name_prefix }}" \

--- a/.github/workflows/ami-release-nix.yml
+++ b/.github/workflows/ami-release-nix.yml
@@ -94,7 +94,6 @@ jobs:
           ami_name_prefix: ${{ matrix.target.ami_name_prefix }}
           ami_regions: '["${{ env.AWS_REGION }}"]'
           arch: ${{ matrix.target.arch }}
-          force: "true"
           git_sha: ${{ github.sha }}
           instance_type: ${{ matrix.target.instance_type }}
           postgres_version: ${{ matrix.postgres_version }}


### PR DESCRIPTION
## What kind of change does this PR introduce?

DevEx

## What is the current behavior?

We always try to build the stage1 AMI for the Release AMI Nix workflow. This means
Release AMI Nix jobs can't easily be re-run to try to get past flaky build processes after stage1 has been pushed.

## What is the new behavior?

We don't force build stage1 AMIs in Release AMI Nix (same as the other workflows) so we can easily re-run failed jobs.

## Additional context

Ran into this when I tried to re-run the 1st run and all of the jobs of 2nd run failed, https://github.com/supabase/postgres/actions/runs/28819708674/attempts/2