### PR TITLE
Fix flaky initdb step in stage2 of AMI build

### DIFF
--- a/ansible/tasks/internal/install-salt.yml
+++ b/ansible/tasks/internal/install-salt.yml
@@ -57,7 +57,6 @@
     update_cache: yes
 
 - name: Pin salt packages at major version
-  tags: mmlb
   ansible.builtin.copy:
     content: |
       Package: salt-common salt-minion

--- a/ansible/tasks/setup-postgres.yml
+++ b/ansible/tasks/setup-postgres.yml
@@ -250,16 +250,11 @@
   when:
     - nixpkg_mode
 
-- name: Check psql_version and modify supautils.conf and postgresql.conf if necessary
+- name: Run initdb (stage2_nix)
   when:
     - stage2_nix
   block:
-    - name: Check if psql_version is psql_orioledb
-      ansible.builtin.set_fact:
-        is_psql_17: "{{ psql_version in ['psql_17'] }}"
-        is_psql_oriole: "{{ psql_version in ['psql_orioledb-17'] }}"
-
-    - name: Initialize the database stage2_nix (non-orioledb)
+    - name: Initialize the database stage2_nix (PG <17)
       become: true
       become_user: 'postgres'
       ansible.builtin.command:
@@ -273,10 +268,9 @@
       vars:
         ansible_command_timeout: 60
       when:
-        - not is_psql_oriole
-        - not is_psql_17
+        - psql_version not in ['psql_17', 'psql_orioledb-17']
 
-    - name: Initialize the database stage2_nix (orioledb)
+    - name: Initialize the database stage2_nix (PG >=17)
       become: true
       become_user: 'postgres'
       ansible.builtin.command:
@@ -290,7 +284,7 @@
       vars:
         ansible_command_timeout: 60
       when:
-        - (is_psql_oriole or is_psql_17)
+        - psql_version in ['psql_17', 'psql_orioledb-17']
 
 - name: copy PG apparmor profile
   ansible.builtin.copy:

--- a/ansible/tasks/setup-postgres.yml
+++ b/ansible/tasks/setup-postgres.yml
@@ -250,6 +250,18 @@
   when:
     - nixpkg_mode
 
+- name: Ensure /data configured for production runtime
+  when:
+    - stage2_nix
+  ansible.posix.mount:
+    src: "UUID={{ ansible_mounts | selectattr('mount', 'equalto', '/data') | map(attribute='uuid') | first }}"
+    path: /data
+    fstype: ext4
+    opts: defaults,discard,nofail,x-systemd.device-timeout=5s
+    dump: "0"
+    passno: "2"
+    state: mounted
+
 - name: Run initdb (stage2_nix)
   when:
     - stage2_nix

--- a/ebssurrogate/scripts/surrogate-bootstrap-nix.sh
+++ b/ebssurrogate/scripts/surrogate-bootstrap-nix.sh
@@ -236,7 +236,7 @@ function pull_docker {
 function create_fstab {
 	FMT="%-42s %-11s %-5s %-17s %-5s %s"
 	local ROOT_LINE=$(findmnt -no SOURCE /mnt | xargs blkid -o export | awk -v FMT="${FMT}" '/^UUID=/ { printf(FMT, $0, "/", "ext4", "defaults,discard", "0", "1" ) }')
-	local DATA_LINE=$(findmnt -no SOURCE /mnt/data | xargs blkid -o export | awk -v FMT="${FMT}" '/^UUID=/ { printf(FMT, $0, "/data", "ext4", "defaults,discard,nofail,x-systemd.device-timeout=5s", "0", "2" ) }')
+	local DATA_LINE=$(findmnt -no SOURCE /mnt/data | xargs blkid -o export | awk -v FMT="${FMT}" '/^UUID=/ { printf(FMT, $0, "/data", "ext4", "defaults,discard", "0", "2" ) }')
 	local SWAP_LINE=$(printf "$FMT" "/swapfile" "none" "swap" "sw" "0" "0")
 
 	local EFI_LINE=""


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

AMI stage2 builds are flaky due to racing of wait for /data disk and the device being present, causing initdb to fail.

## What is the new behavior?

The `nofail,x-systemd.device-timeout=5s` added in 942d095 is now applied in ansible during stage2 instead.