### PR TITLE
ansible/setup-postgres: Fix initdb misleading names

### DIFF
--- a/ansible/tasks/setup-postgres.yml
+++ b/ansible/tasks/setup-postgres.yml
@@ -266,7 +266,7 @@
   when:
     - stage2_nix
   block:
-    - name: Initialize the database stage2_nix (PG <17)
+    - name: Initialize the database stage2_nix (NOT PG17 NOR PG17-OrioleDB)
       become: true
       become_user: 'postgres'
       ansible.builtin.command:
@@ -279,10 +279,9 @@
         LOCALE_ARCHIVE: /usr/lib/locale/locale-archive
       vars:
         ansible_command_timeout: 60
-      when:
-        - psql_version not in ['psql_17', 'psql_orioledb-17']
+      when: psql_version not in ['psql_17', 'psql_orioledb-17']
 
-    - name: Initialize the database stage2_nix (PG >=17)
+    - name: Initialize the database stage2_nix (PG17 OR PG17-OrioleDB)
       become: true
       become_user: 'postgres'
       ansible.builtin.command:
@@ -295,8 +294,7 @@
         LOCALE_ARCHIVE: /usr/lib/locale/locale-archive
       vars:
         ansible_command_timeout: 60
-      when:
-        - psql_version in ['psql_17', 'psql_orioledb-17']
+      when: psql_version in ['psql_17', 'psql_orioledb-17']
 
 - name: copy PG apparmor profile
   ansible.builtin.copy:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

I did not make the new task names accurately describe what was being done. The conditionals were not changed so we don't have different behavior but the names were better but still wrong. PG<17 and PG>=17 is wrong, the conditions are actually `PG17 or PG17-OrioledDB` vs not.

## What is the new behavior?

Better name. Leaving the PG17+ footgun in for now since I'll be cleaning this up some soon.