### PR TITLE
Add postgresql-unit extension

### DIFF
--- a/nix/ext/postgresql-unit.nix
+++ b/nix/ext/postgresql-unit.nix
@@ -1,0 +1,39 @@
+{ lib, stdenv, fetchFromGitHub, postgresql, flex, bison }:
+
+stdenv.mkDerivation rec {
+  pname = "postgresql-unit";
+  version = "7.10";
+  name = "postgresql-unit";
+  buildInputs = [ postgresql ];
+  nativeBuildInputs = [ flex bison ];
+
+  src = fetchFromGitHub {
+    owner = "df7cb";
+    repo = pname;
+    rev = "${version}";
+    hash = "sha256-glVyW0n34I3QArlTscV+p1/sfhIfFbeH192rf9uYJp0=";
+  };
+
+
+  installPhase = ''
+    mkdir -p $out/{lib,share/postgresql/extension}
+
+    # Fix the @MODULEDIR@ / postgresql path reference
+    substituteInPlace *.sql \
+      --replace "${postgresql}/share/postgresql/extension/" "$out/share/postgresql/extension/"
+
+    cp *.so $out/lib
+    cp *.sql $out/share/postgresql/extension
+    cp *.data $out/share/postgresql/extension
+    cp *.control $out/share/postgresql/extension
+
+  '';
+
+  meta = with lib; {
+    description = "Unit testing framework for PostgreSQL";
+    homepage = "https://github.com/${src.owner}/${src.repo}";
+    maintainers = [ "df7cb" ];
+    platforms = postgresql.meta.platforms;
+    license = licenses.postgresql;
+  };
+}

--- a/nix/ext/postgresql-unit.nix
+++ b/nix/ext/postgresql-unit.nix
@@ -30,10 +30,9 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "Unit testing framework for PostgreSQL";
+    description = "postgresql-unit implements a PostgreSQL datatype for SI units, plus byte.";
     homepage = "https://github.com/${src.owner}/${src.repo}";
-    maintainers = [ "df7cb" ];
     platforms = postgresql.meta.platforms;
-    license = licenses.postgresql;
+    license = licenses.gpl3;
   };
 }

--- a/nix/packages/postgres.nix
+++ b/nix/packages/postgres.nix
@@ -50,6 +50,7 @@
         ../ext/wrappers/default.nix
         ../ext/supautils.nix
         ../ext/plv8
+        ../ext/postgresql-unit.nix
       ];
 
       #Where we import and build the orioledb extension, we add on our custom extensions


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds postgresql-unit extension

## What is the current behavior?

Extension is not available for use

## What is the new behavior?

Extension is available for use

## Additional context

postgresql-unit implements a PostgreSQL datatype for [SI units](https://en.wikipedia.org/wiki/International_System_of_Units), plus byte. The eight base units can be combined to arbitrarily complex derived units using operators defined in the PostgreSQL type system