### PR TITLE
chore(admin): bump admin-api 0.111.1 / admin-mgr 0.41.5 in AMI build

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.100-orioledb"
-  postgres17: "17.6.1.143"
-  postgres15: "15.14.1.143"
+  postgresorioledb-17: "17.6.0.101-orioledb"
+  postgres17: "17.6.1.144"
+  postgres15: "15.14.1.144"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1
@@ -60,8 +60,8 @@ postgres_exporter_release_checksum:
   arm64: sha256:29ba62d538b92d39952afe12ee2e1f4401250d678ff4b354ff2752f4321c87a0
   amd64: sha256:cb89fc5bf4485fb554e0d640d9684fae143a4b2d5fa443009bd29c59f9129e84
 
-adminapi_release: "0.109.1"
-adminmgr_release: "0.40.0"
+adminapi_release: "0.111.1"
+adminmgr_release: "0.41.5"
 supabase_admin_agent_release: 1.11.2
 supabase_admin_agent_splay: 30s
 


### PR DESCRIPTION
Bakes the restore-poll fast-fail fix into new AMIs.

**Component versions**
`adminapi_release` 0.109.1 → **0.111.1**
`adminmgr_release` 0.40.0 → **0.41.5**

**AMI release patch bumps** (so new AMIs are cut with the change)
`postgresorioledb-17` 17.6.0.100 → **17.6.0.101**
`postgres17` 17.6.1.143 → **17.6.1.144**
`postgres15` 15.14.1.143 → **15.14.1.144**

Ships: removal of the `NRestarts` `"failing"` false-positive (admin-api) + the trustworthy restore-failure sentinel (admin-mgr). Pairs with the salt pillar bump (supabase/salt#673).

Refs: INDATA-914. Merged: supabase/supabase-admin-api#353, supabase/admin-mgr#122.

> *🤖 Generated with incident.io as part of [INC-657](https://app.incident.io/~/incidents/657)*