### PR TITLE
feat(auth-deployments): bump auth version to v2.193.0

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.101-orioledb"
-  postgres17: "17.6.1.144"
-  postgres15: "15.14.1.144"
+  postgresorioledb-17: "17.6.0.102-orioledb"
+  postgres17: "17.6.1.145"
+  postgres15: "15.14.1.145"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1
@@ -25,10 +25,10 @@ postgrest_release: "14.5" # keep this as a string, otherwise gets treated as yam
 postgrest_arm_release_checksum: sha256:70c07ff875710538903c9b6b6de00e126250e335da25b0ff7d1b13bb4c94bf41
 postgrest_x86_release_checksum: sha256:ab5cc7e974d4940447991804588cfb8b3f7b2c57b691f0905df04d51ede69470
 
-gotrue_release: 2.190.0
-gotrue_release_checksum: sha1:7ceab0d91ebc68792afb58d07cfb73e1505de882
-gotrue_arm_release_checksum: sha1:7ceab0d91ebc68792afb58d07cfb73e1505de882
-gotrue_x86_release_checksum: sha1:56725ea31e32601dd5861f2e6f5d1e3cfd72299b
+gotrue_release: 2.193.0
+gotrue_release_checksum: sha1:631e0e4f4d1ef58bd532a27fe3ba4743d02d7b30
+gotrue_arm_release_checksum: sha1:631e0e4f4d1ef58bd532a27fe3ba4743d02d7b30
+gotrue_x86_release_checksum: sha1:e0790fd029afe16247505507e8307a58f9a852bd
 
 aws_cli_release: 2.23.11
 


### PR DESCRIPTION
Bumps auth version to v2.193.0.

Auth v2.193.0 release information:
- date: 2026-07-13T18:36:12Z
- tag: v2.193.0
- url: https://github.com/supabase/auth/releases/tag/v2.193.0