### PR TITLE
fix: load supautils in the multigres pgctld config templates

### DIFF
--- a/docker/pgctld/orioledb-postgresql.conf.tmpl
+++ b/docker/pgctld/orioledb-postgresql.conf.tmpl
@@ -229,6 +229,8 @@ default_text_search_config = 'pg_catalog.english'
 
 # - Shared Library Preloading -
 
+session_preload_libraries = 'supautils'
+
 jit_provider = 'llvmjit'		# JIT library to use
 
 # - Other Defaults -
@@ -273,6 +275,9 @@ restart_after_crash = off		# reinitialize after backend crash?
 # User-supplied custom parameters, override any automatically generated ones
 
 # WAL-G specific configurations
+
+# supautils specific configurations
+include = '/etc/postgresql-custom/supautils.conf'
 
 #------------------------------------------------------------------------------
 # CUSTOMIZED OPTIONS

--- a/docker/pgctld/postgresql.conf.tmpl
+++ b/docker/pgctld/postgresql.conf.tmpl
@@ -229,6 +229,8 @@ default_text_search_config = 'pg_catalog.english'
 
 # - Shared Library Preloading -
 
+session_preload_libraries = 'supautils'
+
 shared_preload_libraries = 'pg_stat_statements, pgaudit, plpgsql, plpgsql_check, pg_cron, pg_net, auto_explain, pg_tle, plan_filter, supabase_vault'
 
 jit_provider = 'llvmjit'		# JIT library to use
@@ -275,6 +277,9 @@ restart_after_crash = off		# reinitialize after backend crash?
 # User-supplied custom parameters, override any automatically generated ones
 
 # WAL-G specific configurations
+
+# supautils specific configurations
+include = '/etc/postgresql-custom/supautils.conf'
 
 #------------------------------------------------------------------------------
 # CUSTOMIZED OPTIONS

--- a/docs/multigres-image.md
+++ b/docs/multigres-image.md
@@ -19,6 +19,7 @@ dependencies, copies config files, and runs database migrations.
 | Config source | `/etc/postgresql/postgresql.conf` | Same |
 | Data directory | `/var/lib/postgresql/data` | Same |
 | pgsodium | Enabled | **Not enabled** (extension not created) |
+| supautils | Enabled | Enabled |
 | supabase_vault | Enabled | Enabled |
 | pgsodium_getkey.sh | Present | Present (required by vault at startup) |
 

--- a/nix/packages/docker-image-inputs.nix
+++ b/nix/packages/docker-image-inputs.nix
@@ -34,6 +34,9 @@ let
         (root + "/ansible/files/postgresql_extension_custom_scripts")
         (root + "/ansible/files/walg_helper_scripts")
 
+        # pgctld config templates + wrapper script (copied into the multigres image)
+        (root + "/docker/pgctld")
+
         # Database migrations (copied into images)
         (root + "/migrations/db")
       ];

--- a/nix/packages/docker-image-test.nix
+++ b/nix/packages/docker-image-test.nix
@@ -337,8 +337,39 @@ writeShellApplication {
         fi
         log_info "  ✓ pgctld start --pooler-dir $pooler_dir"
 
+        # 5. session_preload_libraries must include supautils — pgctld renders
+        # postgresql.conf from a separate template
+        # (/etc/pgctld-custom/*.conf.tmpl) than the static
+        # /etc/postgresql/postgresql.conf the SQL regression suite uses, so
+        # that suite alone can't catch supautils being missing from the
+        # template.
+        local session_pl
+        session_pl=$(docker exec -e PGPASSWORD="$POSTGRES_PASSWORD" "$container" sh -c "
+            psql -U $POSTGRES_USER -d postgres -h $pooler_dir/pg_sockets \
+                -tAc \"SHOW session_preload_libraries;\" 2>&1") || true
+        if ! echo "$session_pl" | grep -q "supautils"; then
+            log_error "  supautils not in session_preload_libraries (got: $session_pl)"
+            log_error "  Check that the pgctld config template sets session_preload_libraries = 'supautils'"
+            exit 1
+        fi
+        log_info "  ✓ session_preload_libraries contains supautils"
+
+        # 6. supautils.conf's actual policy must be loaded (not just the
+        # library) — supautils.policy_grants should contain the
+        # realtime.messages grant real supautils.conf.j2 defines.
+        local policy_grants
+        policy_grants=$(docker exec -e PGPASSWORD="$POSTGRES_PASSWORD" "$container" sh -c "
+            psql -U $POSTGRES_USER -d postgres -h $pooler_dir/pg_sockets \
+                -tAc \"SHOW supautils.policy_grants;\" 2>&1") || true
+        if ! echo "$policy_grants" | grep -q "realtime.messages"; then
+            log_error "  supautils.policy_grants missing expected policy (got: $policy_grants)"
+            log_error "  Check that the pgctld config template includes /etc/postgresql-custom/supautils.conf"
+            exit 1
+        fi
+        log_info "  ✓ supautils.conf policy loaded (policy_grants set)"
+
         if [[ "$version" == "multigres-orioledb-17" ]]; then
-            # 5. /usr/local/bin/pgctld must be a wrapper script (not a plain symlink)
+            # 7. /usr/local/bin/pgctld must be a wrapper script (not a plain symlink)
             local first_line
             first_line=$(docker exec "$container" sh -c "head -1 /usr/local/bin/pgctld")
             if [[ "$first_line" != "#!/bin/sh" ]]; then
@@ -347,7 +378,7 @@ writeShellApplication {
             fi
             log_info "  ✓ /usr/local/bin/pgctld is a wrapper script"
 
-            # 6. shared_preload_libraries must include orioledb — injected by wrapper, no flags needed
+            # 8. shared_preload_libraries must include orioledb — injected by wrapper, no flags needed
             local spl
             spl=$(docker exec -e PGPASSWORD="$POSTGRES_PASSWORD" "$container" sh -c "
                 psql -U $POSTGRES_USER -d postgres -h $pooler_dir/pg_sockets \
@@ -359,7 +390,7 @@ writeShellApplication {
             fi
             log_info "  ✓ shared_preload_libraries contains orioledb"
 
-            # 7. default_table_access_method must be orioledb
+            # 9. default_table_access_method must be orioledb
             local tam
             tam=$(docker exec -e PGPASSWORD="$POSTGRES_PASSWORD" "$container" sh -c "
                 psql -U $POSTGRES_USER -d postgres -h $pooler_dir/pg_sockets \


### PR DESCRIPTION
`pgctld` renders `postgresql.conf` for multigres clusters from a static template (`docker/pgctld/*.tmpl`), which omitted `session_preload_libraries = 'supautils'` and the `include` of `supautils.conf` that the standard images set via `ansible/tasks/internal/supautils.yml`. The `.so` and `supautils.conf` were already in the image but never wired up, so supautils silently never loaded on multigres clusters.

- Adds the same two directives to both pgctld templates (vanilla + OrioleDB), mirroring the standard images exactly.
- Adds a check (`nix/packages/docker-image-test.nix`) that verifies `session_preload_libraries` and `supautils.policy_grants` after `pgctld init`/`start`, for both variants — the SQL regression suite alone can't catch this since it runs against the static `/etc/postgresql/postgresql.conf`, not the pgctld-rendered config.
- Documents supautils parity in `docs/multigres-image.md`.
- **CI fix:** `nix/packages/docker-image-inputs.nix` gates the Docker Image Test workflow but didn't track `docker/pgctld/`, even though `Dockerfile-multigres` copies the pgctld templates from there — so changes to those templates (including this fix) never triggered the multigres test job. Added `docker/pgctld` to the tracked fileset.

No `CREATE EXTENSION supautils` needed: it has no `.control` file (see `nix/ext/supautils.nix`, `migrations/db/migrations/20260413000000_fix-authenticator-session-preload-libraries.sql`) — it's a preload-only library, same as the standard images.