### PR TITLE
fix(pg_upgrade): guard wrappers server-options patch on supabase_vault (PSQL-1387)

### DIFF
--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/complete.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/complete.sh
@@ -66,6 +66,7 @@ function execute_wrappers_patch {
     vault_secrets RECORD;
   BEGIN
     IF EXISTS (SELECT FROM pg_extension WHERE extname = 'wrappers')
+      AND EXISTS (SELECT FROM pg_extension WHERE extname = 'supabase_vault')
       AND EXISTS (SELECT FROM pg_available_extension_versions WHERE name = 'wrappers' AND version NOT IN (
       '0.1.0',
       '0.1.1',

--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/complete.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/complete.sh
@@ -357,6 +357,22 @@ function start_vacuum_analyze {
 	echo "Upgrade job completed"
 }
 
+case $# in
+0) ;;
+1)
+	if ! declare -F "$1" >/dev/null; then
+		echo "Error: unknown function $1" >&2
+		exit 1
+	fi
+	$1
+	exit
+	;;
+*)
+	echo "Error: $(basename "$0") takes 0 args or a function to call, got $*" >&2
+	exit 1
+	;;
+esac
+
 trap cleanup ERR
 
 echo "C.UTF-8 UTF-8" >/etc/locale.gen

--- a/nix/ext/tests/wrappers-regression-PSQL-1387.nix
+++ b/nix/ext/tests/wrappers-regression-PSQL-1387.nix
@@ -60,6 +60,6 @@ pkgs.testers.runNixOSTest {
           assert test.run_sql(sql) != "1", "supabase_vault must be absent"
 
       with subtest("Check Patch Wrappers Without Vault"):
-          server.succeed("! ${pgUpgradeScripts}/complete.sh execute_wrappers_patch")
+          server.succeed("${pgUpgradeScripts}/complete.sh execute_wrappers_patch")
     '';
 }

--- a/nix/ext/tests/wrappers-regression-PSQL-1387.nix
+++ b/nix/ext/tests/wrappers-regression-PSQL-1387.nix
@@ -1,0 +1,65 @@
+{ self, pkgs }:
+let
+  pname = "wrappers";
+  system = pkgs.pkgsLinux.stdenv.hostPlatform.system;
+  testLib = import ./lib.nix { inherit self pkgs; };
+
+  pgUpgradeScripts = builtins.path {
+    path = ../../../ansible/files/admin_api_scripts/pg_upgrade_scripts;
+    name = "pg_upgrade_scripts";
+  };
+
+  testsLibPy = pkgs.runCommand "extension-test-lib" { } ''
+    module_dir="$out/${pkgs.python3.sitePackages}/pg_nix_test_lib"
+    mkdir -p "$module_dir"
+    cp ${./lib.py} "$module_dir/__init__.py"
+    touch "$module_dir/py.typed"
+  '';
+
+  versions = builtins.toJSON { "15" = self.legacyPackages.${system}.psql_15.exts.${pname}.versions; };
+in
+pkgs.testers.runNixOSTest {
+  name = "wrappers-regression-PSQL-1387";
+  extraPythonPackages = _: [ testsLibPy ];
+  nodes.server = {
+    imports = [
+      (testLib.makeSupabaseTestConfig {
+        majorVersion = "15";
+      })
+    ];
+  };
+  testScript =
+    { ... }:
+    # python
+    ''
+      import json
+      from pathlib import Path
+      from pg_nix_test_lib import PostgresExtensionTest
+
+      versions = json.loads("""${versions}""")
+      sql_test_directory = Path("${../../tests}")
+
+      start_all()
+      server.wait_for_unit("supabase-db-init.service")
+
+      test = PostgresExtensionTest(server, "${pname}", versions, sql_test_directory, True)
+
+      with subtest("Prepare Regression Scenario"):
+          last_version = test.check_install_last_version("15")
+          test.run_sql("""
+              CREATE EXTENSION postgres_fdw;
+              CREATE SERVER wrappers_upgrade_test FOREIGN DATA WRAPPER postgres_fdw
+              OPTIONS (host 'localhost');
+          """)
+          sql = "SELECT 1 FROM pg_foreign_server WHERE srvname = 'wrappers_upgrade_test';"
+          assert test.run_sql(sql) == "1"
+
+          # ensure supabase_vault is not enable, this is the error condition
+          test.run_sql("DROP EXTENSION supabase_vault;")
+          sql = "SELECT 1 FROM pg_extension WHERE extname = 'supabase_vault';"
+          assert test.run_sql(sql) != "1", "supabase_vault must be absent"
+
+      with subtest("Check Patch Wrappers Without Vault"):
+          server.succeed("! ${pgUpgradeScripts}/complete.sh execute_wrappers_patch")
+    '';
+}


### PR DESCRIPTION
`execute_wrappers_patch` loops foreign servers and references vault.secrets, but was only gated on the wrappers extension. A project with wrappers and a foreign server but no supabase_vault extension enabled hits
```
relation "vault.secrets" does notexist
``` 
error which aborts the pg_upgrade and forces a rollback due to `run_sql` returning an error which trips the `set -e` early in the script. `run_sql` returns an error even though theres no `-v ON_ERROR_STOP` because its executing a single statement will use the return/exit status of the last statement as its exit code (this is same thing that bash does by default, ignores errors within script and uses return status of last statement as its return).