### PR TITLE
chore: bump admin-mgr to 0.43.1 and cut new AMIs

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.101-orioledb"
-  postgres17: "17.6.1.144"
-  postgres15: "15.14.1.144"
+  postgresorioledb-17: "17.6.0.102-orioledb"
+  postgres17: "17.6.1.145"
+  postgres15: "15.14.1.145"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1
@@ -61,7 +61,7 @@ postgres_exporter_release_checksum:
   amd64: sha256:cb89fc5bf4485fb554e0d640d9684fae143a4b2d5fa443009bd29c59f9129e84
 
 adminapi_release: "0.111.1"
-adminmgr_release: "0.41.5"
+adminmgr_release: "0.43.1"
 supabase_admin_agent_release: 1.11.2
 supabase_admin_agent_splay: 30s
 


### PR DESCRIPTION
Bumps `adminmgr_release` to 0.43.1 (INDATA-943 `walg_archive_status` reconciliation, admin-mgr #124) and bumps the three `postgres_release` patch versions to force fresh AMI builds carrying it.

Rolls out alongside salt #687 (fleet-wide ACL safety net + prod/staging pillar bumps to 0.43.1) for INC-661.