### PR TITLE
chore: bump admin-mgr to 0.43.2 and cut new AMIs

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.102-orioledb"
-  postgres17: "17.6.1.145"
-  postgres15: "15.14.1.145"
+  postgresorioledb-17: "17.6.0.103-orioledb"
+  postgres17: "17.6.1.146"
+  postgres15: "15.14.1.146"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1
@@ -61,7 +61,7 @@ postgres_exporter_release_checksum:
   amd64: sha256:cb89fc5bf4485fb554e0d640d9684fae143a4b2d5fa443009bd29c59f9129e84
 
 adminapi_release: "0.111.1"
-adminmgr_release: "0.43.1"
+adminmgr_release: "0.43.2"
 supabase_admin_agent_release: 1.11.2
 supabase_admin_agent_splay: 30s
 


### PR DESCRIPTION
Follow-up to #2275 (0.43.1). 0.43.2 includes admin-mgr #126, which removes the rogue `setfacl -h` that broke the `walg_archive_status` reconcile added in #124.

Bumps `adminmgr_release` to 0.43.2 and the three `postgres_release` patch versions to force fresh AMI builds carrying it. Pairs with salt #687 (pillars pinned to 0.43.2) for INC-661 / INDATA-943.