### PR TITLE
chore: bump admin-mgr to 0.43.3 and cut new AMIs

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.6.0.103-orioledb"
-  postgres17: "17.6.1.146"
-  postgres15: "15.14.1.146"
+  postgresorioledb-17: "17.6.0.104-orioledb"
+  postgres17: "17.6.1.147"
+  postgres15: "15.14.1.147"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1
@@ -61,7 +61,7 @@ postgres_exporter_release_checksum:
   amd64: sha256:cb89fc5bf4485fb554e0d640d9684fae143a4b2d5fa443009bd29c59f9129e84
 
 adminapi_release: "0.111.1"
-adminmgr_release: "0.43.2"
+adminmgr_release: "0.43.3"
 supabase_admin_agent_release: 1.11.2
 supabase_admin_agent_splay: 30s
 


### PR DESCRIPTION
Pre-requisite for the scheduled AMI release: #2277 (pg_upgrade `initdb --allow-group-access`) merged after #2276's version bump, so the current `.146`/`.103` strings correspond to AMIs already cut **without** it. Bumps the three `postgres_release` patches so the release actually carries the change, and bakes `adminmgr_release` 0.43.3 (post-restore pg_wal re-grant) into the image to match the salt pillars.

Part of [INDATA-950](https://linear.app/supabase/issue/INDATA-950/rootless-wal-g-durable-wal-walg-data-permissions-pg-mode-latch-acl)