### PR TITLE
chore(nix): remove maintainers field from package definitions

### DIFF
--- a/nix/cargo-pgrx/default.nix
+++ b/nix/cargo-pgrx/default.nix
@@ -51,7 +51,6 @@ let
         homepage = "https://github.com/pgcentralfoundation/pgrx";
         changelog = "https://github.com/pgcentralfoundation/pgrx/releases/tag/v${version}";
         license = licenses.mit;
-        maintainers = with maintainers; [ happysalada ];
         mainProgram = "cargo-pgrx";
       };
     };

--- a/nix/docs/adding-new-package.md
+++ b/nix/docs/adding-new-package.md
@@ -42,7 +42,6 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Open-source vector similarity search for Postgres";
     homepage = "https://github.com/${src.owner}/${src.repo}";
-    maintainers = [ "olirice" ];
     platforms = postgresql.meta.platforms;
     license = licenses.postgresql;
   };

--- a/nix/ext/gdal.nix
+++ b/nix/ext/gdal.nix
@@ -62,13 +62,6 @@ stdenv.mkDerivation rec {
     description = "Translator library for raster geospatial data formats (PostGIS-focused build)";
     homepage = "https://www.gdal.org/";
     license = licenses.mit;
-    maintainers =
-      with maintainers;
-      teams.geospatial.members
-      ++ [
-        marcweber
-        dotlambda
-      ];
     platforms = platforms.unix;
   };
 }

--- a/nix/ext/pgmq/default.nix
+++ b/nix/ext/pgmq/default.nix
@@ -91,7 +91,6 @@ let
       meta = with lib; {
         description = "A lightweight message queue. Like AWS SQS and RSMQ but on Postgres.";
         homepage = "https://github.com/tembo-io/pgmq";
-        maintainers = with maintainers; [ olirice ];
         inherit (postgresql.meta) platforms;
         license = licenses.postgresql;
       };

--- a/nix/ext/plpgsql-check.nix
+++ b/nix/ext/plpgsql-check.nix
@@ -92,7 +92,6 @@ let
         homepage = "https://github.com/okbob/plpgsql_check";
         changelog = "https://github.com/okbob/plpgsql_check/releases/tag/v${version}";
         license = licenses.mit;
-        maintainers = [ maintainers.marsam ];
         inherit (postgresql.meta) platforms;
       };
     };

--- a/nix/ext/supautils.nix
+++ b/nix/ext/supautils.nix
@@ -28,7 +28,6 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "PostgreSQL extension for enhanced security";
     homepage = "https://github.com/supabase/${pname}";
-    maintainers = with maintainers; [ steve-chavez ];
     platforms = postgresql.meta.platforms;
     license = licenses.postgresql;
   };

--- a/nix/pgbouncer.nix
+++ b/nix/pgbouncer.nix
@@ -47,7 +47,6 @@ stdenv.mkDerivation rec {
       replaceStrings [ "." ] [ "_" ] version
     }";
     license = licenses.isc;
-    maintainers = with maintainers; [ _1000101 ];
     platforms = platforms.all;
   };
 }

--- a/nix/postgresql/generic.nix
+++ b/nix/postgresql/generic.nix
@@ -350,14 +350,6 @@ let
         license = licenses.postgresql;
         changelog = "https://www.postgresql.org/docs/release/${finalAttrs.version}/";
         teams = [ ];
-        maintainers = with maintainers; [
-          thoughtpolice
-          danbst
-          globin
-          ivan
-          ma27
-          wolfgangwalther
-        ];
         pkgConfigModules = [
           "libecpg"
           "libecpg_compat"


### PR DESCRIPTION
The `maintainers` meta field is for the maintainer of the *package definition*, not the upstream package. In this repo those definitions are implicitly maintained by the Supabase team, so the field only carried over upstream/nixpkgs maintainers who don't actually own these definitions.

Removes it from all package definitions and from the `adding-new-package.md` example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)