### PR TITLE
Support local qemu builds and x86_64 and macos and swvirt...

### DIFF
--- a/.github/actions/nix-install-ephemeral/action.yml
+++ b/.github/actions/nix-install-ephemeral/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: 'AWS region for the Nix binary cache S3 bucket'
     required: false
     default: 'us-east-1'
+  force-clean:
+    description: Whether to delete pre-existing nix paths
+    required: false
+    default: 'false'
   push-to-cache:
     description: 'Whether to push build outputs to the Nix binary cache'
     required: false
@@ -24,6 +28,13 @@ runs:
         aws-region: ${{ inputs.aws-region }}
         output-credentials: true
         role-duration-seconds: 7200
+    - name: Force Clean Pre-Existing Nix Paths
+      if: inputs.force-clean == 'true'
+      shell: bash
+      run: sudo rm -rf /nix /etc/nix "$HOME/.nix-profile" "$HOME/.nix-channels" "$HOME/.config/nix"
+    - name: Ensure /etc/nix exists
+      shell: bash
+      run: sudo mkdir -p /etc/nix
     - name: Setup AWS credentials for Nix
       if: ${{ inputs.push-to-cache == 'true' }}
       shell: bash
@@ -32,7 +43,6 @@ runs:
         sudo -H aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
         sudo -H aws configure set aws_session_token $AWS_SESSION_TOKEN
         sudo -H aws configure set region ${{ inputs.aws-region }}
-        sudo mkdir -p /etc/nix
         sudo -E python -c "import os; file = open('/etc/nix/nix-secret-key', 'w'); file.write(os.environ['NIX_SIGN_SECRET_KEY']); file.close()"
         cat << 'EOF' | sudo tee /etc/nix/upload-to-cache.sh > /dev/null
         #!/usr/bin/env bash

--- a/.github/actions/nix-install-ephemeral/action.yml
+++ b/.github/actions/nix-install-ephemeral/action.yml
@@ -1,14 +1,18 @@
 name: 'Install Nix on ephemeral runners'
 description: 'Installs Nix and sets up AWS credentials to push to the Nix binary cache'
 inputs:
-  push-to-cache:
-    description: 'Whether to push build outputs to the Nix binary cache'
-    required: false
-    default: 'false'
   aws-region:
     description: 'AWS region for the Nix binary cache S3 bucket'
     required: false
     default: 'us-east-1'
+  push-to-cache:
+    description: 'Whether to push build outputs to the Nix binary cache'
+    required: false
+    default: 'false'
+  multi-user:
+    description: Whether to install nix in multi-user mode (default true) or single-user mode
+    required: false
+    default: 'true'
 runs:
   using: 'composite'
   steps:
@@ -44,11 +48,26 @@ runs:
     - name: Install Nix
       shell: bash
       run: |
-        sudo tee /etc/nix/github.nix.conf >/dev/null <<'EOF'
-        access-tokens = github.com=${{ github.token }}
-        EOF
-        chmod 400 /etc/nix/github.nix.conf
-        cat >/tmp/nix-extra.conf <<'NIXCONF'
+        if [[ "${{ inputs.multi-user }}" == true ]]; then
+          daemon=--daemon
+          nixconfdir=/etc/nix
+          path=/nix/var/nix/profiles/default/bin
+          tmpconf=/tmp/nix-extra.conf
+
+          echo 'access-tokens = github.com=${{ github.token }}' | sudo tee $nixconfdir/github.nix.conf >/dev/null
+          sudo chmod 400 $nixconfdir/github.nix.conf
+        else
+          daemon=--no-daemon
+          nixconfdir=$HOME/.config/nix
+          path=$HOME/.nix-profile/bin
+          tmpconf=$nixconfdir/nix.conf # --nix-extra-conf-files is ignored for single-user installs
+
+          mkdir -p "$(dirname $tmpconf)"
+          echo 'access-tokens = github.com=${{ github.token }}' | tee $nixconfdir/github.nix.conf >/dev/null
+          chmod 400 $nixconfdir/github.nix.conf
+        fi
+
+        cat >$tmpconf <<'NIXCONF'
         always-allow-substitutes = true
         extra-experimental-features = flakes nix-command
         extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
@@ -58,21 +77,21 @@ runs:
 
 
         if [[ -e /dev/kvm ]]; then
-          echo 'extra-system-features = kvm' >>/tmp/nix-extra.conf
+          echo 'extra-system-features = kvm' >>$tmpconf
         fi
 
         if [[ "${{ inputs.push-to-cache }}" == true ]]; then
-          echo 'post-build-hook = /etc/nix/upload-to-cache.sh' >>/tmp/nix-extra.conf
+          echo 'post-build-hook = /etc/nix/upload-to-cache.sh' >>$tmpconf
         fi
 
-        echo '!include /etc/nix/github.nix.conf' >>/tmp/nix-extra.conf
+        echo "!include $nixconfdir/github.nix.conf" >>$tmpconf
 
-        curl -L https://releases.nixos.org/nix/nix-2.34.6/install | sh -s -- --daemon --yes --nix-extra-conf-file /tmp/nix-extra.conf
+        curl -L https://releases.nixos.org/nix/nix-2.34.6/install | sh -s -- $daemon --yes --nix-extra-conf-file $tmpconf
 
-        cat /etc/nix/nix.conf
+        sudo cat $nixconfdir/nix.conf
 
         # Add nix to PATH for subsequent steps
-        echo "/nix/var/nix/profiles/default/bin" >> "$GITHUB_PATH"
+        echo "$path" >> "$GITHUB_PATH"
     - name: Print Nix version
       shell: bash
       run: nix --version

--- a/.github/actions/nix-install-ephemeral/action.yml
+++ b/.github/actions/nix-install-ephemeral/action.yml
@@ -44,18 +44,28 @@ runs:
     - name: Install Nix
       shell: bash
       run: |
-        sudo tee /tmp/nix-extra.conf > /dev/null <<'NIXCONF'
+        sudo tee /etc/nix/github.nix.conf >/dev/null <<'EOF'
+        access-tokens = github.com=${{ github.token }}
+        EOF
+        chmod 400 /etc/nix/github.nix.conf
+        cat >/tmp/nix-extra.conf <<'NIXCONF'
         always-allow-substitutes = true
-        extra-experimental-features = nix-command flakes
-        extra-system-features = kvm
+        extra-experimental-features = flakes nix-command
+        extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
+        extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=
         max-jobs = 4
-        substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com
-        trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
         NIXCONF
 
-        if [ "${{ inputs.push-to-cache }}" = "true" ]; then
-          echo "post-build-hook = /etc/nix/upload-to-cache.sh" | sudo tee -a /tmp/nix-extra.conf > /dev/null
+
+        if [[ -e /dev/kvm ]]; then
+          echo 'extra-system-features = kvm' >>/tmp/nix-extra.conf
         fi
+
+        if [[ "${{ inputs.push-to-cache }}" == true ]]; then
+          echo 'post-build-hook = /etc/nix/upload-to-cache.sh' >>/tmp/nix-extra.conf
+        fi
+
+        echo '!include /etc/nix/github.nix.conf' >>/tmp/nix-extra.conf
 
         curl -L https://releases.nixos.org/nix/nix-2.34.6/install | sh -s -- --daemon --yes --nix-extra-conf-file /tmp/nix-extra.conf
 
@@ -63,15 +73,6 @@ runs:
 
         # Add nix to PATH for subsequent steps
         echo "/nix/var/nix/profiles/default/bin" >> "$GITHUB_PATH"
-        # Source the daemon profile so nix works in this step too
-        . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-    - name: Configure Nix with GitHub token
-      shell: bash
-      env:
-        GH_TOKEN: ${{ github.token }}
-      run: |
-        echo "access-tokens = github.com=$GH_TOKEN" | sudo tee -a /etc/nix/nix.conf > /dev/null
-        sudo systemctl restart nix-daemon || true
     - name: Print Nix version
       shell: bash
       run: nix --version

--- a/.github/workflows/qemu-image-build.yml
+++ b/.github/workflows/qemu-image-build.yml
@@ -71,7 +71,7 @@ jobs:
           multi-user: "false"
 
       - name: Build QEMU artifact
-        run: nix run .#build-qemu-image "${{ matrix.postgres_version }}" arm64
+        run: BUILD_QEMU_IMAGE_HW_VIRT_ONLY=1 nix run .#build-qemu-image "${{ matrix.postgres_version }}" arm64
 
       - name: Grab release version
         id: process_release_version

--- a/.github/workflows/qemu-image-build.yml
+++ b/.github/workflows/qemu-image-build.yml
@@ -3,11 +3,11 @@ name: Build QEMU image
 on:
   push:
     paths:
-      - '.github/workflows/qemu-image-build.yml'
-      - 'qemu-arm64-nix.pkr.hcl'
-      - 'common-nix.vars.pkr.hcl'
-      - 'ansible/vars.yml'
-      - 'scripts/*'
+      - .github/workflows/qemu-image-build.yml
+      - ansible/vars.yml
+      - nix/packages/build-qemu-image/*
+      - qemu-arm64-nix.pkr.hcl
+      - scripts/*
   workflow_dispatch:
 
 permissions:
@@ -64,35 +64,20 @@ jobs:
           echo "POSTGRES_MAJOR_VERSION=${{ matrix.postgres_version }}" >> $GITHUB_ENV
           echo "EXECUTION_ID=${{ github.run_id }}-${{ matrix.postgres_version }}" >> $GITHUB_ENV
 
-      - name: Generate common-nix.vars.pkr.hcl
-        run: |
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.45.1/yq_linux_arm64 -o yq && chmod +x yq
-          PG_VERSION=$(./yq '.postgres_release["postgres'${{ matrix.postgres_version }}'"]' ansible/vars.yml)
-          PG_VERSION=$(echo "$PG_VERSION" | tr -d '"')  # Remove any surrounding quotes
-          echo 'postgres-version = "'$PG_VERSION'"' > common-nix.vars.pkr.hcl
-          echo 'postgres_major_version = "'$POSTGRES_MAJOR_VERSION'"' >> common-nix.vars.pkr.hcl
-          # Ensure there's a newline at the end of the file
-          echo "" >> common-nix.vars.pkr.hcl
-
-      # TODO (darora): not quite sure why I'm having to uninstall and re-install these deps, but the build fails w/o this
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get remove -y qemu-efi-aarch64 cloud-image-utils qemu-system-arm qemu-utils
-          sudo apt-get install -y qemu-efi-aarch64 cloud-image-utils qemu-system-arm qemu-utils
+      - name: Install Nix
+        uses: ./.github/actions/nix-install-ephemeral
+        with:
+          force-clean: "true"
+          multi-user: "false"
 
       - name: Build QEMU artifact
-        run: |
-          make init
-          GIT_SHA=${{github.sha}}
-          export PACKER_LOG=1
-          packer build -var "git_sha=${GIT_SHA}" -var-file="common-nix.vars.pkr.hcl" qemu-arm64-nix.pkr.hcl
+        run: nix run .#build-qemu-image "${{ matrix.postgres_version }}"
 
       - name: Grab release version
         id: process_release_version
         run: |
-          VERSION=$(cat common-nix.vars.pkr.hcl | sed -e 's/postgres-version = "\(.*\)"/\1/g')
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          PG_VERSION=$(nix run nixpkgs#yq -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]' ansible/vars.yml)
+          echo "version=$PG_VERSION" >> $GITHUB_OUTPUT
 
       - name: configure aws credentials - staging
         if: ${{ github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/release/') }}
@@ -110,7 +95,7 @@ jobs:
         env:
           IMAGE_TAG: ${{ steps.process_release_version.outputs.version }}
         run: |
-          docker build -f Dockerfile-kubernetes -t "postgres:$IMAGE_TAG" .
+          docker build -f Dockerfile-kubernetes -t "postgres:$IMAGE_TAG" packer-work-qemu-*
 
       - name: Push docker image to Amazon ECR
         if: ${{ github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/release/') }}

--- a/.github/workflows/qemu-image-build.yml
+++ b/.github/workflows/qemu-image-build.yml
@@ -6,7 +6,7 @@ on:
       - .github/workflows/qemu-image-build.yml
       - ansible/vars.yml
       - nix/packages/build-qemu-image/*
-      - qemu-arm64-nix.pkr.hcl
+      - qemu.pkr.hcl
       - scripts/*
   workflow_dispatch:
 
@@ -71,7 +71,7 @@ jobs:
           multi-user: "false"
 
       - name: Build QEMU artifact
-        run: nix run .#build-qemu-image "${{ matrix.postgres_version }}"
+        run: nix run .#build-qemu-image "${{ matrix.postgres_version }}" arm64
 
       - name: Grab release version
         id: process_release_version

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 # ansible related
 ansible/image-manifest*.json
 
+# packer related
+packer-work-*/
+
 # python related
 *$py.class
 *.py[cod]
@@ -21,5 +24,4 @@ venv/
 #nix related
 common-nix.vars.pkr.hcl
 db/schema.sql
-nixos.qcow2
 result*

--- a/Dockerfile-kubernetes
+++ b/Dockerfile-kubernetes
@@ -1,6 +1,6 @@
 FROM alpine:3.23
 
-ADD ./output-cloudimg/packer-cloudimg /disk/image.qcow2
+ADD output-cloudimg/packer-cloudimg /disk/image.qcow2
 
 RUN apk add --no-cache qemu-system-aarch64 qemu-img openssh-client aavmf virtiofsd \
     && truncate -s 64M /root/varstore.img \

--- a/ansible/tasks/internal/supabase-admin-agent.yml
+++ b/ansible/tasks/internal/supabase-admin-agent.yml
@@ -68,13 +68,6 @@
     arch: "arm64"
   when: platform == "arm64"
 
-- name: install gpg explicitly for qemu artifacts
-  become: yes
-  apt:
-    pkg:
-      - gpg
-  when: qemu_mode is defined
-
 - name: Download supabase-admin-agent archive
   get_url:
     url: "https://supabase-public-artifacts-bucket.s3.amazonaws.com/supabase-admin-agent/v{{ supabase_admin_agent_release }}/supabase-admin-agent-{{ supabase_admin_agent_release }}-linux-{{ arch }}.tar.gz"

--- a/ansible/tasks/setup-system.yml
+++ b/ansible/tasks/setup-system.yml
@@ -76,14 +76,6 @@
         owner: 'root'
         group: 'root'
 
-- name: Install other useful tools
-  ansible.builtin.apt:
-    pkg:
-      - less
-    update_cache: true
-  when:
-    - qemu_mode is defined
-
 - name: Set the platform arch as a fact
   ansible.builtin.set_fact:
     platform: "{{ 'amd64' if ansible_facts['architecture'] == 'x86_64' else 'arm64' }}"

--- a/ebssurrogate/scripts/qemu-bootstrap-nix.sh
+++ b/ebssurrogate/scripts/qemu-bootstrap-nix.sh
@@ -22,7 +22,20 @@ function waitfor_boot_finished {
 }
 
 function install_packages {
-	apt-get update && sudo apt-get install software-properties-common e2fsprogs nfs-common locales iptables arptables ebtables ufw logrotate -y
+	apt-get update
+	apt-get install -y \
+		arptables \
+		e2fsprogs \
+		ebtables \
+		gpg \
+		iptables \
+		less \
+		locales \
+		logrotate \
+		nfs-common \
+		software-properties-common \
+		ufw \
+		;
 	# TODO (darora): temporarily disabling while Launchpad is under ddos attack and very frequently timing out
 	# add-apt-repository --yes --update ppa:ansible/ansible &&
 	sudo apt-get install ansible -y

--- a/nix/packages/build-qemu-image/build-qemu-image.sh
+++ b/nix/packages/build-qemu-image/build-qemu-image.sh
@@ -11,6 +11,12 @@ if [ -z "$postgres_major_version" ]; then
 	exit 1
 fi
 
+case $(uname -o) in
+Darwin) accel=hvf ;;
+GNU/Linux) accel=kvm ;;
+*) echo "Error: Invalid os '$(uname -o)'. Must be Darwin or Linux" >&2 && exit 1 ;;
+esac
+
 declare -A host2arch=([aarch64]=arm64 [x86_64]=amd64)
 host=${host2arch[$(uname -m)]}
 arch=${2:-$host}
@@ -19,13 +25,13 @@ amd64)
 	qemu=$(which qemu-system-x86_64)
 	code=${qemu%/bin/*}/share/qemu/edk2-x86_64-code.fd
 	vars=${qemu%/bin/*}/share/qemu/edk2-i386-vars.fd
-	machine=q35
+	machine=q35,accel=$accel
 	;;
 arm64)
 	qemu=$(which qemu-system-aarch64)
 	code=${qemu%/bin/*}/share/qemu/edk2-aarch64-code.fd
 	vars=${qemu%/bin/*}/share/qemu/edk2-arm-vars.fd
-	machine=virt,gic-version=3
+	machine=virt,accel=$accel,gic-version=max,highmem=on
 	;;
 *) echo "Error: Invalid arch '$arch'. Must be 'amd64' or 'arm64'" >&2 && exit 1 ;;
 esac

--- a/nix/packages/build-qemu-image/build-qemu-image.sh
+++ b/nix/packages/build-qemu-image/build-qemu-image.sh
@@ -11,9 +11,24 @@ if [ -z "$postgres_major_version" ]; then
 	exit 1
 fi
 
-qemu=$(which qemu-system-aarch64)
-code=${qemu%/bin/*}/share/qemu/edk2-aarch64-code.fd
-vars=${qemu%/bin/*}/share/qemu/edk2-arm-vars.fd
+declare -A host2arch=([aarch64]=arm64 [x86_64]=amd64)
+host=${host2arch[$(uname -m)]}
+arch=${2:-$host}
+case $arch in
+amd64)
+	qemu=$(which qemu-system-x86_64)
+	code=${qemu%/bin/*}/share/qemu/edk2-x86_64-code.fd
+	vars=${qemu%/bin/*}/share/qemu/edk2-i386-vars.fd
+	machine=q35
+	;;
+arm64)
+	qemu=$(which qemu-system-aarch64)
+	code=${qemu%/bin/*}/share/qemu/edk2-aarch64-code.fd
+	vars=${qemu%/bin/*}/share/qemu/edk2-arm-vars.fd
+	machine=virt,gic-version=3
+	;;
+*) echo "Error: Invalid arch '$arch'. Must be 'amd64' or 'arm64'" >&2 && exit 1 ;;
+esac
 
 workdir=$(mktemp -d packer-work-qemu-XXXXXX)
 install --mode 444 "$code" "$workdir/ovmf_code.fd"
@@ -27,10 +42,13 @@ cloud-localds "$workdir/seeds-cloudimg.iso" user-data-cloudimg meta-data
 
 export LC_ALL=C.UTF-8
 export TZ=UTC
-packer init qemu-arm64-nix.pkr.hcl
+packer init qemu.pkr.hcl
 PACKER_LOG=${PACKER_LOG:-1} packer build \
+	-var "arch=$arch" \
 	-var "git_sha=$git_sha" \
+	-var "machine=$machine" \
 	-var "postgres-version=$postgres_version" \
 	-var "postgres_major_version=$postgres_major_version" \
+	-var "qemu_binary=$qemu" \
 	-var "workdir=$workdir" \
-	qemu-arm64-nix.pkr.hcl
+	qemu.pkr.hcl

--- a/nix/packages/build-qemu-image/build-qemu-image.sh
+++ b/nix/packages/build-qemu-image/build-qemu-image.sh
@@ -1,0 +1,36 @@
+# shellcheck shell=bash
+
+# nix-built qemu resolves its libraries via RPATH; an inherited
+# LD_LIBRARY_PATH (e.g. from a devshell) can inject a mismatched glibc and
+# break `qemu-system-* --version`, so drop it.
+unset LD_LIBRARY_PATH
+
+postgres_major_version=${1:-}
+if [ -z "$postgres_major_version" ]; then
+	echo "Usage: build-qemu-image <postgres-major-version> [arch]" >&2
+	exit 1
+fi
+
+qemu=$(which qemu-system-aarch64)
+code=${qemu%/bin/*}/share/qemu/edk2-aarch64-code.fd
+vars=${qemu%/bin/*}/share/qemu/edk2-arm-vars.fd
+
+workdir=$(mktemp -d packer-work-qemu-XXXXXX)
+install --mode 444 "$code" "$workdir/ovmf_code.fd"
+install --mode 644 "$vars" "$workdir/ovmf_vars.fd" # qemu writes to the vars pflash during boot
+
+git_sha=${GIT_SHA:-$(git rev-parse HEAD)}
+postgres_version=$(yq -r ".postgres_release[\"postgres$postgres_major_version\"]" ansible/vars.yml)
+
+# Build the cloud-init seed ISO before invoking packer.
+cloud-localds "$workdir/seeds-cloudimg.iso" user-data-cloudimg meta-data
+
+export LC_ALL=C.UTF-8
+export TZ=UTC
+packer init qemu-arm64-nix.pkr.hcl
+PACKER_LOG=${PACKER_LOG:-1} packer build \
+	-var "git_sha=$git_sha" \
+	-var "postgres-version=$postgres_version" \
+	-var "postgres_major_version=$postgres_major_version" \
+	-var "workdir=$workdir" \
+	qemu-arm64-nix.pkr.hcl

--- a/nix/packages/build-qemu-image/build-qemu-image.sh
+++ b/nix/packages/build-qemu-image/build-qemu-image.sh
@@ -25,16 +25,25 @@ amd64)
 	qemu=$(which qemu-system-x86_64)
 	code=${qemu%/bin/*}/share/qemu/edk2-x86_64-code.fd
 	vars=${qemu%/bin/*}/share/qemu/edk2-i386-vars.fd
-	machine=q35,accel=$accel
 	;;
 arm64)
 	qemu=$(which qemu-system-aarch64)
 	code=${qemu%/bin/*}/share/qemu/edk2-aarch64-code.fd
 	vars=${qemu%/bin/*}/share/qemu/edk2-arm-vars.fd
-	machine=virt,accel=$accel,gic-version=max,highmem=on
 	;;
 *) echo "Error: Invalid arch '$arch'. Must be 'amd64' or 'arm64'" >&2 && exit 1 ;;
 esac
+
+case $arch:$(uname -m) in
+amd64:aarch64) machine=q35 cpu=qemu64 ;;
+amd64:x86_64) machine=q35 cpu=host ;;
+arm64:aarch64) machine=virt,gic-version=max,highmem=on cpu=host ;;
+arm64:x86_64) machine=virt,gic-version=max,highmem=on cpu=cortex-a76 ;;
+esac
+machine+=,accel=$accel
+if [[ -z ${BUILD_QEMU_IMAGE_HW_VIRT_ONLY:-} ]]; then
+	machine+=:tcg
+fi
 
 workdir=$(mktemp -d packer-work-qemu-XXXXXX)
 install --mode 444 "$code" "$workdir/ovmf_code.fd"
@@ -51,6 +60,7 @@ export TZ=UTC
 packer init qemu.pkr.hcl
 PACKER_LOG=${PACKER_LOG:-1} packer build \
 	-var "arch=$arch" \
+	-var "cpu=$cpu" \
 	-var "git_sha=$git_sha" \
 	-var "machine=$machine" \
 	-var "postgres-version=$postgres_version" \

--- a/nix/packages/build-qemu-image/default.nix
+++ b/nix/packages/build-qemu-image/default.nix
@@ -1,0 +1,23 @@
+{
+  cloud-utils,
+  coreutils,
+  gitMinimal,
+  packer,
+  qemu,
+  writeShellApplication,
+  yq,
+}:
+writeShellApplication {
+  name = "build-qemu-image";
+
+  runtimeInputs = [
+    cloud-utils
+    coreutils
+    gitMinimal
+    packer
+    qemu
+    yq
+  ];
+
+  text = builtins.readFile ./build-qemu-image.sh;
+}

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -44,6 +44,7 @@
       packages = (
         {
           build-ami = pkgs.callPackage ./build-ami.nix { packer = self'.packages.packer; };
+          build-qemu-image = pkgs.callPackage ./build-qemu-image { packer = self'.packages.packer; };
           build-test-ami = pkgs.callPackage ./build-test-ami.nix { packer = self'.packages.packer; };
           cleanup-ami = pkgs.callPackage ./cleanup-ami.nix { };
           dbmate-tool = pkgs.callPackage ./dbmate-tool.nix { inherit (self.supabase) defaults; };

--- a/qemu-arm64-nix.pkr.hcl
+++ b/qemu-arm64-nix.pkr.hcl
@@ -12,6 +12,11 @@ variable "postgres_major_version" {
   default = ""
 }
 
+# Working dir to pick up non-source files and put output files
+variable "workdir" {
+  type = string
+}
+
 packer {
   required_plugins {
     qemu = {
@@ -21,36 +26,18 @@ packer {
   }
 }
 
-source "null" "dependencies" {
-  communicator = "none"
-}
-
-build {
-  name = "cloudimg.deps"
-  sources = [
-    "source.null.dependencies"
-  ]
-
-  provisioner "shell-local" {
-    inline = [
-      "cp /usr/share/AAVMF/AAVMF_VARS.fd AAVMF_VARS.fd",
-      "cloud-localds seeds-cloudimg.iso user-data-cloudimg meta-data"
-    ]
-    inline_shebang = "/bin/bash -e"
-  }
-}
-
 source "qemu" "cloudimg" {
-  boot_wait      = "2s"
-  cpus           = 8
-  disk_image     = true
-  disk_size      = "15G"
-  format         = "qcow2"
-  headless       = true
-  http_directory = "http"
-  iso_checksum   = "file:https://cloud-images.ubuntu.com/minimal/releases/noble/release/SHA256SUMS"
-  iso_url        = "https://cloud-images.ubuntu.com/minimal/releases/noble/release/ubuntu-24.04-minimal-cloudimg-arm64.img"
-  memory         = 40000
+  boot_wait        = "2s"
+  cpus             = 8
+  disk_image       = true
+  disk_size        = "15G"
+  format           = "qcow2"
+  headless         = true
+  http_directory   = "http"
+  iso_checksum     = "file:https://cloud-images.ubuntu.com/minimal/releases/noble/release/SHA256SUMS"
+  iso_url          = "https://cloud-images.ubuntu.com/minimal/releases/noble/release/ubuntu-24.04-minimal-cloudimg-arm64.img"
+  memory           = 40000
+  output_directory = "${var.workdir}/output-cloudimg"
   qemu_img_args {
     convert = ["-o", "compression_type=zstd"]
   }
@@ -59,10 +46,10 @@ source "qemu" "cloudimg" {
     ["-machine", "virt,gic-version=3"],
     ["-cpu", "host"],
     ["-device", "virtio-gpu-pci"],
-    ["-drive", "if=pflash,format=raw,id=ovmf_code,readonly=on,file=/usr/share/AAVMF/AAVMF_CODE.fd"],
-    ["-drive", "if=pflash,format=raw,id=ovmf_vars,file=AAVMF_VARS.fd"],
-    ["-drive", "file=output-cloudimg/packer-cloudimg,if=virtio,format=qcow2,discard=on,detect-zeroes=unmap"],
-    ["-drive", "file=seeds-cloudimg.iso,format=raw"],
+    ["-drive", "if=pflash,format=raw,id=ovmf_code,readonly=on,file=${var.workdir}/ovmf_code.fd"],
+    ["-drive", "if=pflash,format=raw,id=ovmf_vars,file=${var.workdir}/ovmf_vars.fd"],
+    ["-drive", "file=${var.workdir}/output-cloudimg/packer-cloudimg,if=virtio,format=qcow2,discard=on,detect-zeroes=unmap"],
+    ["-drive", "file=${var.workdir}/seeds-cloudimg.iso,format=raw"],
     ["--enable-kvm"]
   ]
   shutdown_command       = "sudo -S shutdown -P now"

--- a/qemu.pkr.hcl
+++ b/qemu.pkr.hcl
@@ -38,7 +38,7 @@ packer {
   required_plugins {
     qemu = {
       source  = "github.com/hashicorp/qemu"
-      version = "1.1.5"
+      version = "1.1.6"
     }
   }
 }

--- a/qemu.pkr.hcl
+++ b/qemu.pkr.hcl
@@ -17,6 +17,19 @@ variable "workdir" {
   type = string
 }
 
+# Arch-specific values supplied by build-qemu-image
+variable "arch" {
+  type = string
+}
+
+variable "machine" {
+  type = string
+}
+
+variable "qemu_binary" {
+  type = string
+}
+
 packer {
   required_plugins {
     qemu = {
@@ -35,21 +48,21 @@ source "qemu" "cloudimg" {
   headless         = true
   http_directory   = "http"
   iso_checksum     = "file:https://cloud-images.ubuntu.com/minimal/releases/noble/release/SHA256SUMS"
-  iso_url          = "https://cloud-images.ubuntu.com/minimal/releases/noble/release/ubuntu-24.04-minimal-cloudimg-arm64.img"
+  iso_url          = "https://cloud-images.ubuntu.com/minimal/releases/noble/release/ubuntu-24.04-minimal-cloudimg-${var.arch}.img"
   memory           = 40000
   output_directory = "${var.workdir}/output-cloudimg"
   qemu_img_args {
     convert = ["-o", "compression_type=zstd"]
   }
-  qemu_binary = "qemu-system-aarch64"
+  qemu_binary = var.qemu_binary
   qemuargs = [
-    ["-machine", "virt,gic-version=3"],
+    ["-machine", var.machine],
     ["-cpu", "host"],
     ["-device", "virtio-gpu-pci"],
     ["-drive", "if=pflash,format=raw,id=ovmf_code,readonly=on,file=${var.workdir}/ovmf_code.fd"],
     ["-drive", "if=pflash,format=raw,id=ovmf_vars,file=${var.workdir}/ovmf_vars.fd"],
     ["-drive", "file=${var.workdir}/output-cloudimg/packer-cloudimg,if=virtio,format=qcow2,discard=on,detect-zeroes=unmap"],
-    ["-drive", "file=${var.workdir}/seeds-cloudimg.iso,format=raw"],
+    ["-drive", "file=${var.workdir}/seeds-cloudimg.iso,format=raw,if=virtio"],
     ["--enable-kvm"]
   ]
   shutdown_command       = "sudo -S shutdown -P now"

--- a/qemu.pkr.hcl
+++ b/qemu.pkr.hcl
@@ -22,6 +22,10 @@ variable "arch" {
   type = string
 }
 
+variable "cpu" {
+  type = string
+}
+
 variable "machine" {
   type = string
 }
@@ -57,7 +61,7 @@ source "qemu" "cloudimg" {
   qemu_binary = var.qemu_binary
   qemuargs = [
     ["-machine", var.machine],
-    ["-cpu", "host"],
+    ["-cpu", var.cpu],
     ["-device", "virtio-gpu-pci"],
     ["-drive", "if=pflash,format=raw,id=ovmf_code,readonly=on,file=${var.workdir}/ovmf_code.fd"],
     ["-drive", "if=pflash,format=raw,id=ovmf_vars,file=${var.workdir}/ovmf_vars.fd"],

--- a/qemu.pkr.hcl
+++ b/qemu.pkr.hcl
@@ -49,7 +49,7 @@ source "qemu" "cloudimg" {
   http_directory   = "http"
   iso_checksum     = "file:https://cloud-images.ubuntu.com/minimal/releases/noble/release/SHA256SUMS"
   iso_url          = "https://cloud-images.ubuntu.com/minimal/releases/noble/release/ubuntu-24.04-minimal-cloudimg-${var.arch}.img"
-  memory           = 40000
+  memory           = 4096 # MiB
   output_directory = "${var.workdir}/output-cloudimg"
   qemu_img_args {
     convert = ["-o", "compression_type=zstd"]
@@ -63,7 +63,6 @@ source "qemu" "cloudimg" {
     ["-drive", "if=pflash,format=raw,id=ovmf_vars,file=${var.workdir}/ovmf_vars.fd"],
     ["-drive", "file=${var.workdir}/output-cloudimg/packer-cloudimg,if=virtio,format=qcow2,discard=on,detect-zeroes=unmap"],
     ["-drive", "file=${var.workdir}/seeds-cloudimg.iso,format=raw,if=virtio"],
-    ["--enable-kvm"]
   ]
   shutdown_command       = "sudo -S shutdown -P now"
   ssh_handshake_attempts = 500
@@ -72,7 +71,6 @@ source "qemu" "cloudimg" {
   ssh_username           = "ubuntu"
   ssh_wait_timeout       = "1h"
   use_backing_file       = false
-  accelerator            = "kvm"
 }
 
 build {

--- a/scripts/90-cleanup-qemu.sh
+++ b/scripts/90-cleanup-qemu.sh
@@ -34,9 +34,12 @@ elif [ -n "$(command -v apt-get)" ]; then
 		libicu-dev \
 		libcgal-dev \
 		libgcc-9-dev \
-		libgcc-8-dev \
 		ansible \
 		snapd
+
+	if [[ $(uname -m) == aarch64 ]]; then
+		apt-get -y remove --purge libgcc-8-dev
+	fi
 
 	# add-apt-repository --yes --remove ppa:ansible/ansible
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Its a pain to try to run the qemu builds locally. We have hard coded paths to FW files and aren't using nix for any of the deps. As written we can't even run these locally since it assumes a linux aarch64 machine, not what any supabase employ has.

## What is the new behavior?

We now run packer using a wrapper nix package, similar to build-ami, so that we have deps and can refer to firmware files easily. I've also added x86_64 support so those of us that have a bare-metal linux x86_64 machine can run the packer build and test ansible files. Finally, I made it so the qemu config packer runs isn't tied to linux and can run on macos, qemu is cross platform and has no issues using apple hvf instead of kvm.

## Additional Context

Fixes PSQL-1418