### PR TITLE
chore: bump admin-mgr 0.43.5 + postgres_release patch to cut AMIs (INDATA-986)

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.9.0.003-orioledb"
-  postgres17: "17.6.1.150"
-  postgres15: "15.14.1.150"
+  postgresorioledb-17: "17.9.0.004-orioledb"
+  postgres17: "17.6.1.151"
+  postgres15: "15.14.1.151"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1
@@ -61,7 +61,7 @@ postgres_exporter_release_checksum:
   amd64: sha256:cb89fc5bf4485fb554e0d640d9684fae143a4b2d5fa443009bd29c59f9129e84
 
 adminapi_release: "0.111.1"
-adminmgr_release: "0.43.3"
+adminmgr_release: "0.43.5"
 supabase_admin_agent_release: 1.11.2
 supabase_admin_agent_splay: 30s
 


### PR DESCRIPTION
**Do not merge until admin-mgr 0.43.5 is published to S3.**

Bumps `adminmgr_release` to 0.43.5 and the `postgres_release` patch versions (orioledb `003→004`, pg17 / pg15 `150→151`) to cut new AMIs carrying admin-mgr 0.43.5 (INDATA-986 — force-stop before wipe). Rebased on develop, so the patch numbers are bumped above develop's current release; the AMI jumps 0.43.3→0.43.5 (0.43.4 only ever shipped via the salt pillar).

https://linear.app/supabase/issue/INDATA-986/admin-mgr-dont-hard-fail-a-restore-when-salt-cancels-the-pre-wipe
