### PR TITLE
chore: bump supautils to 3.2.3 + postgres_release patch to cut AMIs (PSQL-1413)

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.9.0.004-orioledb"
-  postgres17: "17.6.1.151"
-  postgres15: "15.14.1.151"
+  postgresorioledb-17: "17.9.0.005-orioledb"
+  postgres17: "17.6.1.152"
+  postgres15: "15.14.1.152"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1

--- a/nix/ext/supautils.nix
+++ b/nix/ext/supautils.nix
@@ -8,7 +8,7 @@
 stdenv.mkDerivation rec {
   pname = "supautils";
   name = pname;
-  version = "3.2.2";
+  version = "3.2.3";
 
   buildInputs = [ postgresql ];
 
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     owner = "supabase";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-Oi35fel2Yp58eHsWVOXtxAo/s0RAbUxJEBxPrYRK+cs=";
+    hash = "sha256-KpI7F9Hv0PlqGfLAoj0WnIfdttqeXYxzMmk1xqhfw7w=";
   };
 
   installPhase = ''


### PR DESCRIPTION
Bumps `nix/ext/supautils.nix` to [supautils v3.2.3](https://github.com/supabase/supautils/releases/tag/v3.2.3) and the `postgres_release` patch versions (orioledb `004→005`, pg17 / pg15 `151→152`) to cut new AMIs carrying the fix.

supautils 3.2.3 fixes a segfault on `GRANT`/`REVOKE` role membership with `current_user`/`session_user`/`public` grantees (supabase/supautils#205, customer report SU-419080), plus late-validation fixes for `supautils.constrained_extensions` and `supautils.extensions_parameter_overrides`.

Existing fleet gets 3.2.3 via a separate `supabase/salt` pillar bump (follow-up PR).

https://linear.app/supabase/issue/PSQL-1413/fix-supautils-crash-on-grant-to-current-user
