### PR TITLE
chore: format testinfra/test_ami_nix.py

### DIFF
--- a/testinfra/test_ami_nix.py
+++ b/testinfra/test_ami_nix.py
@@ -1087,8 +1087,7 @@ def test_custom_overrides_take_precedence_over_generated_optimizations(host):
 
     def assert_command_succeeded(result, action):
         assert result["succeeded"], (
-            f"{action} failed.\n"
-            f"stdout: {result['stdout']}\nstderr: {result['stderr']}"
+            f"{action} failed.\nstdout: {result['stdout']}\nstderr: {result['stderr']}"
         )
 
     def backup_name(path):


### PR DESCRIPTION
`treefmt` fails on develop since #2178 — `testinfra/test_ami_nix.py:1089` has an implicit f-string concatenation that the formatter wants joined. This makes `pre-commit-run` / `treefmt-check` fail on every open PR (first seen on #2289, which doesn't touch this file). One-hunk format-only change, output taken verbatim from the [failing check's diff](https://github.com/supabase/postgres/actions/runs/29827009935/job/88625282888).
