### PR TITLE
feat(pgbackrest): schedule process-max tuning via systemd timer

### DIFF
--- a/ansible/files/supabase_admin_agent_config/supabase-admin-agent_pgbackrest_tune.service.j2
+++ b/ansible/files/supabase_admin_agent_config/supabase-admin-agent_pgbackrest_tune.service.j2
@@ -1,0 +1,17 @@
+[Unit]
+Description=Recompute pgBackRest process-max via supabase-admin-agent pgbackrest tune
+After=network.target local-fs.target tmp.mount
+Requires=local-fs.target
+# Skips cleanly (not a failure) on instances where pgBackRest isn't enabled.
+ConditionPathExists=/etc/pgbackrest/conf.d/pgbackrest.conf
+
+[Service]
+Type=oneshot
+ExecStart=/opt/supabase-admin-agent/supabase-admin-agent --config /opt/supabase-admin-agent/config.yaml pgbackrest tune
+User=supabase-admin-agent
+Group=supabase-admin-agent
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/files/supabase_admin_agent_config/supabase-admin-agent_pgbackrest_tune.service.j2
+++ b/ansible/files/supabase_admin_agent_config/supabase-admin-agent_pgbackrest_tune.service.j2
@@ -1,6 +1,6 @@
 [Unit]
 Description=Recompute pgBackRest process-max via supabase-admin-agent pgbackrest tune
-After=network.target local-fs.target tmp.mount
+After=local-fs.target tmp.mount
 Requires=local-fs.target
 # Skips cleanly (not a failure) on instances where pgBackRest isn't enabled.
 ConditionPathExists=/etc/pgbackrest/conf.d/pgbackrest.conf
@@ -8,8 +8,11 @@ ConditionPathExists=/etc/pgbackrest/conf.d/pgbackrest.conf
 [Service]
 Type=oneshot
 ExecStart=/opt/supabase-admin-agent/supabase-admin-agent --config /opt/supabase-admin-agent/config.yaml pgbackrest tune
-User=supabase-admin-agent
-Group=supabase-admin-agent
+# pgbackrest subcommands only authorise adminapi or root (cmd/pgbackrest.go's
+# pgbackrestOperationalUserCheck); conf.d is also pgbackrest:postgres 02770,
+# so this needs adminapi's postgres group membership to even read it.
+User=adminapi
+Group=adminapi
 StandardOutput=journal
 StandardError=journal
 

--- a/ansible/files/supabase_admin_agent_config/supabase-admin-agent_pgbackrest_tune.timer.j2
+++ b/ansible/files/supabase_admin_agent_config/supabase-admin-agent_pgbackrest_tune.timer.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run Supabase supabase-admin-agent pgbackrest tune on a schedule
+Requires=supabase-admin-agent_pgbackrest_tune.service
+
+[Timer]
+OnCalendar=*:0/10
+RandomizedDelaySec={{ supabase_admin_agent_splay }}
+AccuracySec=1s
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/ansible/tasks/internal/supabase-admin-agent.yml
+++ b/ansible/tasks/internal/supabase-admin-agent.yml
@@ -113,6 +113,16 @@
     src: files/supabase_admin_agent_config/supabase-admin-agent_salt.service.j2
     dest: /etc/systemd/system/supabase-admin-agent_salt.service
 
+- name: supabase-admin-agent - create pgbackrest tune systemd timer file
+  template:
+    src: files/supabase_admin_agent_config/supabase-admin-agent_pgbackrest_tune.timer.j2
+    dest: /etc/systemd/system/supabase-admin-agent_pgbackrest_tune.timer
+
+- name: supabase-admin-agent - create pgbackrest tune service file
+  template:
+    src: files/supabase_admin_agent_config/supabase-admin-agent_pgbackrest_tune.service.j2
+    dest: /etc/systemd/system/supabase-admin-agent_pgbackrest_tune.service
+
 - name: supabase-admin-agent - reload systemd
   systemd:
     daemon_reload: yes
@@ -123,3 +133,12 @@
     name: supabase-admin-agent_salt
     enabled: no
     state: stopped
+
+# Always on, unlike the salt timer above: ConditionPathExists on the service
+# unit is the safety gate (skips cleanly on instances without pgBackRest
+# enabled), so there's no separate manual enable step needed for this one.
+- name: supabase-admin-agent - ENABLE pgbackrest tune timer
+  systemd:
+    name: supabase-admin-agent_pgbackrest_tune.timer
+    enabled: yes
+    state: started

--- a/audit-specs/baselines/prod-deployed/files-systemd-deployed.yml
+++ b/audit-specs/baselines/prod-deployed/files-systemd-deployed.yml
@@ -145,6 +145,18 @@ file:
     group: '0'
     mode: '0644'
     owner: '0'
+  /etc/systemd/system/supabase-admin-agent_pgbackrest_tune.service:
+    exists: true
+    filetype: file
+    group: '0'
+    mode: '0644'
+    owner: '0'
+  /etc/systemd/system/supabase-admin-agent_pgbackrest_tune.timer:
+    exists: true
+    filetype: file
+    group: '0'
+    mode: '0644'
+    owner: '0'
   /etc/systemd/system/supabase-admin-agent_salt.service:
     exists: true
     filetype: file

--- a/audit-specs/baselines/prod-deployed/service-deployed.yml
+++ b/audit-specs/baselines/prod-deployed/service-deployed.yml
@@ -224,7 +224,7 @@ service:
     enabled: false
     running: false
   supabase-admin-agent_pgbackrest_tune:
-    enabled: true
+    enabled: false
     running: false
   supabase-admin-agent_salt:
     enabled: false

--- a/audit-specs/baselines/prod-deployed/service-deployed.yml
+++ b/audit-specs/baselines/prod-deployed/service-deployed.yml
@@ -223,6 +223,9 @@ service:
   sshd-keygen:
     enabled: false
     running: false
+  supabase-admin-agent_pgbackrest_tune:
+    enabled: true
+    running: false
   supabase-admin-agent_salt:
     enabled: false
     running: false


### PR DESCRIPTION
## Summary

- `pgbackrest tune` recomputes process-max from the host's live vCPU count but was only ever invoked at `pgbackrest enable`/`setup-replica` time, so values went stale after a compute resize.
- Adds a `supabase-admin-agent_pgbackrest_tune` timer/service pair (10-minute cadence, cloned from the existing salt timer) that re-runs tune on a schedule.
- Service is gated with `ConditionPathExists=/etc/pgbackrest/conf.d/pgbackrest.conf` so it skips cleanly (not failed) on instances without pgBackRest enabled — no coordination needed with whatever enables/disables the feature. Timer is enabled by default since that condition is the actual safety gate.
- Updates the `prod-deployed` audit-spec baselines for the two new unit files.

The originally proposed approach (call `pgbackrest tune` directly from the `admin-mgr` resize-compute flow) doesn't apply: `admin-mgr` has no resize-compute code, and the actual flow (`platform`'s worker) has no remote-exec path into the instance to invoke an instance-local command. A scheduled timer sidesteps that entirely and also covers the "cron fallback" question raised in the ticket — it's both the trigger and the fallback.

Resolves INDATA-997

## Test plan

- [ ] Build a test AMI/QEMU image via this repo's build process
- [ ] Boot with pgBackRest enabled; confirm `supabase-admin-agent_pgbackrest_tune.timer` is `active (waiting)` and `computed_globals.conf` matches the host's actual vCPU count
- [ ] Boot without pgBackRest enabled; confirm the service reports condition-skipped, not failed
- [ ] Run a resize-compute flow against a real instance (`/smokeit`) and confirm `computed_globals.conf` updates within one timer tick after the post-resize reboot