### PR TITLE
fix(github-matrix): report nix eval errors instead of crashing with NameError

### DIFF
--- a/nix/packages/github-matrix/github_matrix.py
+++ b/nix/packages/github-matrix/github_matrix.py
@@ -187,7 +187,7 @@ def process_nix_eval_jobs_stdout(
     for line in stdout.splitlines():
         result = parse_nix_eval_line(line, drv_paths)
         if result.is_err():
-            errors_list.append(result._value)
+            errors.append(result._value)
         elif result._value is not None:
             packages.append(result._value)
 


### PR DESCRIPTION
Fix renamed var in `github-matrix.py`.
```
NameError: name 'errors_list' is not defined
```

It crashes if there is content in stderr and silently swalliows the underlying error, eg: https://github.com/supabase/postgres/actions/runs/29872362852/job/88775188861