### PR TITLE
fix: correct config path in AMI precedence smoke test

### DIFF
--- a/testinfra/test_ami_nix.py
+++ b/testinfra/test_ami_nix.py
@@ -1075,15 +1075,28 @@ def test_postgrest_read_only_session_attrs(host):
 def test_custom_overrides_take_precedence_over_generated_optimizations(host):
     """Verify CLI-managed PostgreSQL config overrides generated optimizations.
 
-    This reproduces the hosted AMI regression where a generated optimization in
-    conf.d could take precedence over /etc/postgresql-custom/custom-overrides.conf
-    after PostgreSQL restarted.
+    postgresql.conf includes generated-optimizations.conf before
+    custom-overrides.conf (both flat under /etc/postgresql-custom/, includes
+    uncommented during the AMI build), so the custom override wins. include_dir
+    conf.d comes after both, so anything in conf.d beats them by include order
+    — a hosted incident happened when generated-optimizations.conf was placed
+    in conf.d and silently overrode CLI-managed config. This test guards both
+    sides of that contract: the flat-file precedence, and that the AMI ships
+    no conf.d copy of generated-optimizations.conf.
     """
     ssh = host["ssh"]
     backup_dir = "/tmp/pg-config-precedence-test"
     custom_conf = "/etc/postgresql-custom/custom-overrides.conf"
-    generated_conf = "/etc/postgresql-custom/conf.d/generated-optimizations.conf"
+    generated_conf = "/etc/postgresql-custom/generated-optimizations.conf"
+    confd_generated_conf = "/etc/postgresql-custom/conf.d/generated-optimizations.conf"
     config_files = [custom_conf, generated_conf]
+
+    confd_check = run_ssh_command(ssh, f"sudo test -e {confd_generated_conf}")
+    assert not confd_check["succeeded"], (
+        f"{confd_generated_conf} exists on the AMI; conf.d is included after "
+        "custom-overrides.conf, so a generated-optimizations.conf there "
+        "overrides CLI-managed config"
+    )
 
     def assert_command_succeeded(result, action):
         assert result["succeeded"], (
@@ -1165,9 +1178,8 @@ def test_custom_overrides_take_precedence_over_generated_optimizations(host):
             """
             set -eu
             CUSTOM_CONF=/etc/postgresql-custom/custom-overrides.conf
-            GENERATED_CONF=/etc/postgresql-custom/conf.d/generated-optimizations.conf
+            GENERATED_CONF=/etc/postgresql-custom/generated-optimizations.conf
 
-            sudo mkdir -p "$(dirname "$GENERATED_CONF")"
             printf '%s\n' 'max_connections = 111' |
                 sudo tee "$GENERATED_CONF" > /dev/null
             printf '%s\n' 'max_connections = 112' |


### PR DESCRIPTION
## Summary
- `test_custom_overrides_take_precedence_over_generated_optimizations` (added in 3ec53e80, #2178) has been failing on every `test-ami-nix` job on `develop` (e.g. [run 29870145034](https://github.com/supabase/postgres/actions/runs/29870145034)) with `assert '111' == '112'`.
- Test bug, not an AMI regression: it wrote `generated-optimizations.conf` into `/etc/postgresql-custom/conf.d/`, but in production that file is flat at `/etc/postgresql-custom/generated-optimizations.conf`, included before `custom-overrides.conf` — so the custom override wins, and the test's `conf.d` placement just made the wrong file win instead.
- `conf.d` is included last, so it beats both flat files by design — that's the real vector behind the hosted incident #2178 was guarding against, and the AMI build never places the file there.

## Changes
- Point the test at the real flat production path.
- Add an assertion that `/etc/postgresql-custom/conf.d/generated-optimizations.conf` does not exist on the AMI, guarding the actual incident vector at this layer.

## Test plan
- [x] `test-ami-nix` matrix passes on this branch (was failing on `develop` for all 6 jobs)