### PR TITLE
testing: version-diff CI job

### DIFF
--- a/nix/packages/postgres.nix
+++ b/nix/packages/postgres.nix
@@ -250,6 +250,13 @@
     in
     {
       packages = binPackages;
-      legacyPackages = basePackages // slimPackages // cliPackages;
+      legacyPackages = basePackages // slimPackages // cliPackages // {
+        # DO NOT MERGE, TESTING: dummy package to exercise the version-diff CI job.
+        version-diff-test-dummy = pkgs.writeTextFile {
+          name = "version-diff-test-dummy-1.0.0";
+          text = "testing version-diff workflow\n";
+          destination = "/share/version-diff-test-dummy";
+        };
+      };
     };
 }


### PR DESCRIPTION
DO NOT MERGE, TESTING.

Adds a trivial, self-contained `legacyPackages` package (`version-diff-test-dummy`) purely to exercise the new `version-diff`/`version-diff-comment` jobs from #2299 and confirm the PR comment renders correctly for a real (non-empty) diff.

Base is `ci/nix-version-diff` (not `develop`) so the version-diff workflow changes are present without duplicating that diff here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)