### PR TITLE
feat(nix): expose per-version extension derivations via passthru

### DIFF
--- a/nix/ext/hypopg.nix
+++ b/nix/ext/hypopg.nix
@@ -98,6 +98,7 @@ buildEnv {
   '';
 
   passthru = {
+    perVersion = lib.mapAttrs (name: value: build name value.hash) versionsToUse;
     versions = versionsBuilt;
     numberOfVersions = numberOfVersionsBuilt;
     inherit pname latestOnly;

--- a/nix/ext/index_advisor.nix
+++ b/nix/ext/index_advisor.nix
@@ -83,6 +83,7 @@ pkgs.buildEnv {
   ];
 
   passthru = {
+    perVersion = lib.mapAttrs (name: value: build name value.hash) versionsToUse;
     versions = versionsBuilt;
     numberOfVersions = numberOfVersionsBuilt;
     inherit pname latestOnly;

--- a/nix/ext/pg-safeupdate.nix
+++ b/nix/ext/pg-safeupdate.nix
@@ -83,6 +83,7 @@ pkgs.buildEnv {
   '';
 
   passthru = {
+    perVersion = lib.mapAttrs (name: value: build name value.hash) versionsToUse;
     versions = versionsBuilt;
     numberOfVersions = numberOfVersionsBuilt;
     inherit pname latestOnly;

--- a/nix/ext/pg_cron/default.nix
+++ b/nix/ext/pg_cron/default.nix
@@ -116,6 +116,7 @@ buildEnv {
   };
 
   passthru = {
+    perVersion = lib.mapAttrs (name: value: build name value) versionsToUse;
     versions = versionsBuilt;
     numberOfVersions = numberOfVersionsBuilt;
     inherit switch-ext-version latestOnly;

--- a/nix/ext/pg_net.nix
+++ b/nix/ext/pg_net.nix
@@ -145,6 +145,7 @@ pkgs.buildEnv {
   '';
 
   passthru = {
+    perVersion = lib.mapAttrs (name: value: build name value.hash) versionsToUse;
     versions = versionsBuilt;
     numberOfVersions = numberOfVersionsBuilt;
     inherit pname latestOnly;

--- a/nix/ext/pg_partman.nix
+++ b/nix/ext/pg_partman.nix
@@ -100,6 +100,7 @@ pkgs.buildEnv {
   '';
 
   passthru = {
+    perVersion = lib.mapAttrs (name: value: build name value.hash) versionsToUse;
     versions = versionsBuilt;
     numberOfVersions = numberOfVersionsBuilt;
     inherit switch-ext-version libName latestOnly;

--- a/nix/ext/pg_repack.nix
+++ b/nix/ext/pg_repack.nix
@@ -140,6 +140,7 @@ buildEnv {
   '';
 
   passthru = {
+    perVersion = lib.mapAttrs (name: value: build name value.hash) versionsToUse;
     versions = versionsBuilt;
     numberOfVersions = numberOfVersionsBuilt;
     inherit pname latestOnly;

--- a/nix/ext/pg_tle.nix
+++ b/nix/ext/pg_tle.nix
@@ -111,6 +111,7 @@ buildEnv {
   '';
 
   passthru = {
+    perVersion = lib.mapAttrs (name: value: build name value.hash) versionsToUse;
     versions = versionsBuilt;
     numberOfVersions = numberOfVersionsBuilt;
     inherit pname latestOnly;

--- a/nix/ext/pgaudit.nix
+++ b/nix/ext/pgaudit.nix
@@ -240,6 +240,7 @@ buildEnv {
   '';
 
   passthru = {
+    perVersion = lib.mapAttrs (name: value: build name value.hash) versionsToUse;
     versions = versionsBuilt;
     numberOfVersions = numberOfVersionsBuilt;
     inherit pname latestOnly;

--- a/nix/ext/pgmq/default.nix
+++ b/nix/ext/pgmq/default.nix
@@ -104,6 +104,7 @@ buildEnv {
   pathsToLink = [ "/share/postgresql/extension" ];
 
   passthru = {
+    perVersion = lib.mapAttrs (name: value: build name value.hash) versionsToUse;
     versions = versionsBuilt;
     numberOfVersions = numberOfVersionsBuilt;
     inherit pname latestOnly;

--- a/nix/ext/pgroonga/default.nix
+++ b/nix/ext/pgroonga/default.nix
@@ -181,6 +181,7 @@ buildEnv {
   '';
 
   passthru = {
+    perVersion = lib.mapAttrs (name: value: build name value.hash) versionsToUse;
     versions = versionsBuilt;
     numberOfVersions = numberOfVersionsBuilt;
     inherit pname latestOnly;

--- a/nix/ext/pgrouting/default.nix
+++ b/nix/ext/pgrouting/default.nix
@@ -153,6 +153,7 @@ buildEnv {
   '';
 
   passthru = {
+    perVersion = lib.mapAttrs (name: value: build name value.hash) versionsToUse;
     versions = versionsBuilt;
     numberOfVersions = numberOfVersionsBuilt;
     inherit pname latestOnly;

--- a/nix/ext/pgsodium.nix
+++ b/nix/ext/pgsodium.nix
@@ -112,6 +112,7 @@ pkgs.buildEnv {
   '';
 
   passthru = {
+    perVersion = lib.mapAttrs (name: value: build name value.hash) versionsToUse;
     versions = versionsBuilt;
     numberOfVersions = numberOfVersionsBuilt;
     inherit pname latestOnly;

--- a/nix/ext/pgsql-http.nix
+++ b/nix/ext/pgsql-http.nix
@@ -113,6 +113,7 @@ pkgs.buildEnv {
   '';
 
   passthru = {
+    perVersion = lib.mapAttrs (name: value: build name value.hash) versionsToUse;
     versions = versionsBuilt;
     numberOfVersions = numberOfVersionsBuilt;
     inherit pname latestOnly;

--- a/nix/ext/pgvector.nix
+++ b/nix/ext/pgvector.nix
@@ -96,6 +96,7 @@ pkgs.buildEnv {
   '';
 
   passthru = {
+    perVersion = lib.mapAttrs (name: value: build name value.hash) versionsToUse;
     versions = versionsBuilt;
     numberOfVersions = numberOfVersionsBuilt;
     inherit pname latestOnly;

--- a/nix/ext/plv8/default.nix
+++ b/nix/ext/plv8/default.nix
@@ -238,6 +238,7 @@ buildEnv {
   '';
 
   passthru = {
+    perVersion = lib.mapAttrs (name: value: build name value.hash) versionsToUse;
     versions = versionsBuilt;
     numberOfVersions = numberOfVersionsBuilt;
     inherit pname latestOnly;

--- a/nix/ext/postgis.nix
+++ b/nix/ext/postgis.nix
@@ -256,6 +256,7 @@ in
   '';
 
   passthru = {
+    perVersion = lib.mapAttrs (name: value: build name value.hash) versionsToUse;
     versions = versionsBuilt;
     numberOfVersions = numberOfVersionsBuilt;
     inherit pname latestOnly;

--- a/nix/ext/vault.nix
+++ b/nix/ext/vault.nix
@@ -99,6 +99,7 @@ pkgs.buildEnv {
   '';
 
   passthru = {
+    perVersion = lib.mapAttrs (name: value: build name value.hash) versionsToUse;
     versions = versionsBuilt;
     numberOfVersions = numberOfVersionsBuilt;
     inherit pname latestOnly;


### PR DESCRIPTION
Adds `passthru.perVersion` (`version -> single-version derivation`) to each multi-version extension (18 files, one line each).

The per-version attrset already existed inline as the input to each extension's `buildEnv` — this just surfaces it instead of discarding it. No change to any `buildEnv` output or extension identity; `exts.<name>` is still the same derivation, now carrying `.perVersion."<version>"` whose `outPath` is the lean single-version store path.

This is the prerequisite for the extension catalog in the profile-based version-switching work — it lets the catalog reference a single `(extension, version)` store path directly, with no buildEnv copy and no IFD.

Part of [PSQL-1530](https://linear.app/supabase/issue/PSQL-1530/use-profiles-for-multi-version-extensions).