### PR TITLE
chore: bump admin binary versions + postgres_release for fresh AMIs (INDATA-1007)

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -11,7 +11,7 @@ postgres_major:
 # Full version strings for each major version
 postgres_release:
   postgresorioledb-17: "17.9.0.006-orioledb"
-  postgres17: "17.6.1.152"
+  postgres17: "17.6.1.153"
   postgres15: "15.14.1.153"
 
 # Non Postgres Extensions

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.9.0.006-orioledb"
-  postgres17: "17.6.1.153"
-  postgres15: "15.14.1.153"
+  postgresorioledb-17: "17.9.0.005-orioledb"
+  postgres17: "17.6.1.152"
+  postgres15: "15.14.1.152"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.9.0.004-orioledb"
-  postgres17: "17.6.1.151"
-  postgres15: "15.14.1.151"
+  postgresorioledb-17: "17.9.0.006-orioledb"
+  postgres17: "17.6.1.152"
+  postgres15: "15.14.1.153"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1
@@ -60,9 +60,9 @@ postgres_exporter_release_checksum:
   arm64: sha256:29ba62d538b92d39952afe12ee2e1f4401250d678ff4b354ff2752f4321c87a0
   amd64: sha256:cb89fc5bf4485fb554e0d640d9684fae143a4b2d5fa443009bd29c59f9129e84
 
-adminapi_release: "0.111.1"
-adminmgr_release: "0.43.5"
-supabase_admin_agent_release: 1.11.2
+adminapi_release: "0.112.1"
+adminmgr_release: "0.43.6"
+supabase_admin_agent_release: 1.14.4
 supabase_admin_agent_splay: 30s
 
 vector_x86_deb: https://packages.timber.io/vector/0.48.X/vector_0.48.0-1_amd64.deb


### PR DESCRIPTION
Aligns the on-host admin binary versions with the INDATA-1007 releases and bumps `postgres_release` (patch, from develop) to cut fresh AMIs that bake them in.

**Admin binaries** (`vars.yml`):
- `adminapi_release` 0.111.1 → **0.112.1**
- `adminmgr_release` 0.43.5 → **0.43.6**
- `supabase_admin_agent_release` 1.11.2 → **1.14.4** (large catch-up — SAA had moved independently; matches the salt pillars)

**postgres_release patch bumps** (sequential from develop):
- orioledb 004 → **005**, pg17 151 → **152**, pg15 151 → **152**

Bumped from develop deliberately. Note: an unmerged PR (PSQL-1413 / supautils 3.2.3) has tagged builds at these same numbers from its branch — if it lands first, whoever's second resolves the `postgres_release` conflict by bumping above.

https://linear.app/supabase/issue/INDATA-1007/non-atomic-writes-to-etcwal-gconfigjson-can-leave-an-emptystub-config
