### PR TITLE
chore: bump to release

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.9.0.004-orioledb"
-  postgres17: "17.6.1.151"
-  postgres15: "15.14.1.151"
+  postgresorioledb-17: "17.9.0.006-orioledb"
+  postgres17: "17.6.1.153"
+  postgres15: "15.14.1.153"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1


### PR DESCRIPTION
Needed to increment by 1 on release numbers to get release for https://github.com/supabase/postgres/pull/2261
