### PR TITLE
testing: version-diff

### DIFF
--- a/nix/packages/postgres.nix
+++ b/nix/packages/postgres.nix
@@ -250,6 +250,13 @@
     in
     {
       packages = binPackages;
-      legacyPackages = basePackages // slimPackages // cliPackages;
+      legacyPackages = basePackages // slimPackages // cliPackages // {
+        # DO NOT MERGE, TESTING: dummy package to exercise the version-diff CI job.
+        version-diff-test-dummy = pkgs.writeTextFile {
+          name = "version-diff-test-dummy-1.0.0";
+          text = "testing drvpath-scoped version-diff workflow\n";
+          destination = "/share/version-diff-test-dummy";
+        };
+      };
     };
 }


### PR DESCRIPTION
DO NOT MERGE, TESTING.

Verifies the drvPath-scoped version-diff job (only realizes/diffs attrs whose drvPath actually changed, instead of the whole `legacyPackages` closure). Adds a trivial dummy package to trigger a real "added" diff.

Base is `ci/nix-version-diff` so the version-diff workflow changes are present without duplicating that diff here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)