### PR TITLE
feat: derive AMI/postgres release version from git short SHA

### DIFF
--- a/.github/actions/build-ami/action.yml
+++ b/.github/actions/build-ami/action.yml
@@ -58,10 +58,12 @@ runs:
       shell: bash
       run: |
         PG_VERSION=$(nix run nixpkgs#yq-go -- -r '.postgres_release["postgres${{ inputs.postgres_version }}"]' ansible/vars.yml)
-        echo 'postgres-version = "'$PG_VERSION'"' > common-nix.vars.pkr.hcl
+        SHORT_SHA=$(git rev-parse --short=7 "${{ inputs.git_sha }}")
+        FULL_VERSION="${PG_VERSION}.${SHORT_SHA}"
+        echo 'postgres-version = "'"$FULL_VERSION"'"' > common-nix.vars.pkr.hcl
         echo "" >> common-nix.vars.pkr.hcl
         git add -f common-nix.vars.pkr.hcl
-        echo "version=$PG_VERSION" >> $GITHUB_OUTPUT
+        echo "version=$FULL_VERSION" >> $GITHUB_OUTPUT
 
     - name: Build AMI stage 1
       shell: bash

--- a/.github/workflows/publish-nix-pgupgrade-bin-flake-version.yml
+++ b/.github/workflows/publish-nix-pgupgrade-bin-flake-version.yml
@@ -57,11 +57,10 @@ jobs:
           POSTGRES_VERSION: ${{ inputs.postgresVersion }}
         run: |
           set -eo pipefail
-          if [[ -n "$POSTGRES_VERSION" ]]; then
-            VERSION=$(git show "$POSTGRES_VERSION:ansible/vars.yml" | nix run nixpkgs#yq-go -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]')
-          else
-            VERSION=$(nix run nixpkgs#yq-go -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]' ansible/vars.yml)
-          fi
+          REF="${POSTGRES_VERSION:-HEAD}"
+          PG_VERSION=$(git show "$REF:ansible/vars.yml" | nix run nixpkgs#yq-go -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]')
+          SHORT_SHA=$(git rev-parse --short=7 "$REF")
+          VERSION="${PG_VERSION}.${SHORT_SHA}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "major_version=$(echo $VERSION | cut -d'.' -f1)" >> "$GITHUB_OUTPUT"
 
@@ -114,11 +113,10 @@ jobs:
           POSTGRES_VERSION: ${{ inputs.postgresVersion }}
         run: |
           set -eo pipefail
-          if [[ -n "$POSTGRES_VERSION" ]]; then
-            VERSION=$(git show "$POSTGRES_VERSION:ansible/vars.yml" | nix run nixpkgs#yq-go -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]')
-          else
-            VERSION=$(nix run nixpkgs#yq-go -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]' ansible/vars.yml)
-          fi
+          REF="${POSTGRES_VERSION:-HEAD}"
+          PG_VERSION=$(git show "$REF:ansible/vars.yml" | nix run nixpkgs#yq-go -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]')
+          SHORT_SHA=$(git rev-parse --short=7 "$REF")
+          VERSION="${PG_VERSION}.${SHORT_SHA}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "major_version=$(echo $VERSION | cut -d'.' -f1)" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/publish-nix-pgupgrade-scripts.yml
+++ b/.github/workflows/publish-nix-pgupgrade-scripts.yml
@@ -62,12 +62,10 @@ jobs:
           POSTGRES_VERSION: ${{ inputs.postgresVersion }}
         run: |
           set -eo pipefail
-          if [[ -n "$POSTGRES_VERSION" ]]; then
-            VERSION=$(git show "$POSTGRES_VERSION:ansible/vars.yml" | nix run nixpkgs#yq-go -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]')
-          else
-            VERSION=$(nix run nixpkgs#yq-go -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]' ansible/vars.yml)
-          fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          REF="${POSTGRES_VERSION:-HEAD}"
+          PG_VERSION=$(git show "$REF:ansible/vars.yml" | nix run nixpkgs#yq-go -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]')
+          SHORT_SHA=$(git rev-parse --short=7 "$REF")
+          echo "version=${PG_VERSION}.${SHORT_SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Create a tarball containing pg_upgrade scripts
         run: |
@@ -117,12 +115,10 @@ jobs:
           POSTGRES_VERSION: ${{ inputs.postgresVersion }}
         run: |
           set -eo pipefail
-          if [[ -n "$POSTGRES_VERSION" ]]; then
-            VERSION=$(git show "$POSTGRES_VERSION:ansible/vars.yml" | nix run nixpkgs#yq-go -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]')
-          else
-            VERSION=$(nix run nixpkgs#yq-go -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]' ansible/vars.yml)
-          fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          REF="${POSTGRES_VERSION:-HEAD}"
+          PG_VERSION=$(git show "$REF:ansible/vars.yml" | nix run nixpkgs#yq-go -- -r '.postgres_release["postgres'${{ matrix.postgres_version }}'"]')
+          SHORT_SHA=$(git rev-parse --short=7 "$REF")
+          echo "version=${PG_VERSION}.${SHORT_SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Create a tarball containing pg_upgrade scripts
         run: |

--- a/.github/workflows/qemu-image-build.yml
+++ b/.github/workflows/qemu-image-build.yml
@@ -45,15 +45,6 @@ jobs:
       - name: Checkout Repo
         uses: supabase/postgres/.github/actions/shared-checkout@HEAD
 
-      - name: Run checks if triggered manually
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: |
-          SUFFIX=$(yq ".postgres_release[\"postgres${{ matrix.postgres_version }}\"]" ansible/vars.yml | sed -E 's/[0-9\.]+(.*)$/\1/')
-          if [[ -z $SUFFIX ]] ; then
-            echo "Version must include non-numeric characters if built manually."
-            exit 1
-          fi
-
       - name: enable KVM support
         run: |
           sudo chown runner /dev/kvm
@@ -69,7 +60,8 @@ jobs:
           curl -L https://github.com/mikefarah/yq/releases/download/v4.45.1/yq_linux_arm64 -o yq && chmod +x yq
           PG_VERSION=$(./yq '.postgres_release["postgres'${{ matrix.postgres_version }}'"]' ansible/vars.yml)
           PG_VERSION=$(echo "$PG_VERSION" | tr -d '"')  # Remove any surrounding quotes
-          echo 'postgres-version = "'$PG_VERSION'"' > common-nix.vars.pkr.hcl
+          SHORT_SHA=$(git rev-parse --short=7 HEAD)
+          echo 'postgres-version = "'"${PG_VERSION}.${SHORT_SHA}"'"' > common-nix.vars.pkr.hcl
           echo 'postgres_major_version = "'$POSTGRES_MAJOR_VERSION'"' >> common-nix.vars.pkr.hcl
           # Ensure there's a newline at the end of the file
           echo "" >> common-nix.vars.pkr.hcl

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.9.0.005-orioledb"
-  postgres17: "17.6.1.152"
-  postgres15: "15.14.1.152"
+  postgresorioledb-17: "17.9.0-orioledb"
+  postgres17: "17.6.1"
+  postgres15: "15.14.1"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1


### PR DESCRIPTION
Replaces the manually-bumped counter in `postgres_release` (ansible/vars.yml) with an automatically derived git short SHA.

PSQL-1430