### PR TITLE
chore: remove nixConfig from flake.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The project uses Nix as its build system, which provides:
 
 ## Common Tasks
 
-To skip hours of building and download instead, configure the Supabase Postgres Nix binary cache: [nix/docs/binary-cache.md](nix/docs/binary-cache.md).
+To skip hours of building and download packages instead, start using the Supabase Postgres Nix binary cache: [nix/docs/binary-cache.md](nix/docs/binary-cache.md).
 
 ### Building Locally
 
@@ -189,7 +189,7 @@ This is the same PostgreSQL build that powers [Supabase](https://supabase.io), b
 - ✅ Ubuntu 24.04 (Noble Numbat).
 - ✅ [wal_level](https://www.postgresql.org/docs/current/runtime-config-wal.html) = logical and [max_replication_slots](https://www.postgresql.org/docs/current/runtime-config-replication.html) = 5. Ready for replication.
 - ✅ [Large Systems Extensions](https://github.com/aws/aws-graviton-getting-started#building-for-graviton-and-graviton2). Enabled for ARM images.
-## Extensions 
+## Extensions
 
 ### PostgreSQL 15 Extensions
 | Extension | Version | Description |

--- a/flake.nix
+++ b/flake.nix
@@ -1,10 +1,9 @@
 {
-  description = "Prototype tooling for deploying PostgreSQL";
-  nixConfig = {
-    # Skip rebuilding all the packages, download instead.
-    # See nix/docs/binary-cache.nix to set it up.
-    extra-substituters = [ "https://nix-postgres-artifacts.s3.amazonaws.com" ];
-  };
+  description = "Tools for deploying PostgreSQL and extensions";
+
+  # Skip rebuilding all the packages, download instead.
+  # See nix/docs/binary-cache.nix to set it up.
+
   inputs = {
     devshell.url = "github:numtide/devshell";
     devshell.inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
## Why
`nixConfig.extra-substituters` only applies to trusted users, so everyone else sees:

> warning: ignoring untrusted substituter '...', you are not a trusted user

That warning invites people to add themselves to `trusted-users`, which is actually a local privilege-escalation vector ([Nix manual](https://nix.dev/manual/nix/stable/command-ref/conf-file#conf-trusted-users), see also SEC-894), not a config gap to fix.

## What
Remove `nixConfig` from `flake.nix`. (Configure substituters via `nix.conf`/nix-darwin instead.)