### PR TITLE
chore: bump supautils to 3.4.0

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -10,9 +10,9 @@ postgres_major:
 
 # Full version strings for each major version
 postgres_release:
-  postgresorioledb-17: "17.9.0.007-orioledb"
-  postgres17: "17.6.1.154"
-  postgres15: "15.14.1.154"
+  postgresorioledb-17: "17.9.0.008-orioledb"
+  postgres17: "17.6.1.155"
+  postgres15: "15.14.1.155"
 
 # Non Postgres Extensions
 pgbouncer_release: 1.25.1

--- a/nix/ext/supautils.nix
+++ b/nix/ext/supautils.nix
@@ -8,7 +8,7 @@
 stdenv.mkDerivation rec {
   pname = "supautils";
   name = pname;
-  version = "3.3.0";
+  version = "3.4.0";
 
   buildInputs = [ postgresql ];
 
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     owner = "supabase";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-yGKl5vUrfvFf4eQaEbTOURMbQdRPFhdmKXgz1WKZwCU=";
+    hash = "sha256-O2zVVVf2OFTCc4BYHuGJ67odU0TwMnTJQuz9uk+a4/0=";
   };
 
   installPhase = ''

--- a/nix/ext/supautils.nix
+++ b/nix/ext/supautils.nix
@@ -8,7 +8,7 @@
 stdenv.mkDerivation rec {
   pname = "supautils";
   name = pname;
-  version = "3.2.3";
+  version = "3.3.0";
 
   buildInputs = [ postgresql ];
 
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     owner = "supabase";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-KpI7F9Hv0PlqGfLAoj0WnIfdttqeXYxzMmk1xqhfw7w=";
+    hash = "sha256-yGKl5vUrfvFf4eQaEbTOURMbQdRPFhdmKXgz1WKZwCU=";
   };
 
   installPhase = ''


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump supautils to [v3.4.0](https://github.com/supabase/supautils/releases/tag/v3.4.0)

## What is the new behavior?

https://github.com/supabase/supautils/releases/tag/v3.4.0

* Limit ext version by @samrose in https://github.com/supabase/supautils/pull/187
* feat: permit `COMMENT ON POLICY` in `supautils.policy_grants` by @leandrocp in https://github.com/supabase/supautils/pull/208
* chore: bump MODVERSION to 3.3.0 by @soedirgo in https://github.com/supabase/supautils/pull/210
* fix: only elevate to superuser for extensions with control file on disk by @imor in https://github.com/supabase/supautils/pull/206

## Additional context

1. Contains an important fix to unblock Realtime projects failing to branch with `"must be owner of relation messages" on documented realtime.messages RLS policy`

2. Not added `supautils.restrict_extension_versions` because it defaults to `off` (no behavior changes).