### PR TITLE
fix(ansible): move pgBackRest spool-path off the 10GB root volume

### DIFF
--- a/ansible/files/pgbackrest_config/pgbackrest.conf
+++ b/ansible/files/pgbackrest_config/pgbackrest.conf
@@ -13,6 +13,8 @@ log-level-console = info
 log-level-file = detail
 log-subprocess = y
 resume = n
+# spool-path shares a filesystem with pg_wal so archive-get can hand off WAL segments via rename instead of copy; only reachable once archive-async is enabled. The matching AppArmor grants live in ansible/files/postgresql_config/sbpostgres_apparmor and the audit exclusion in nix/packages/supascan/internal/config/defaults.go -- keep this path in sync across those, plus the directory-creation loop entry in ansible/tasks/setup-pgbackrest.yml (bake-time only; see INDATA-1153 for why that alone doesn't create this directory on any live instance's real /data).
+spool-path = /data/pgbackrest_spool
 start-fast = y
 # Note: the [supabase] stanza (pg1-path, pg1-socket-path, pg1-user) has been
 # removed from this file. supabase-admin-agent owns that stanza and writes it

--- a/ansible/files/pgbackrest_config/pgbackrest.conf
+++ b/ansible/files/pgbackrest_config/pgbackrest.conf
@@ -13,7 +13,7 @@ log-level-console = info
 log-level-file = detail
 log-subprocess = y
 resume = n
-# Explicit vs. the /var/spool/pgbackrest default, which sits on the 10GB AMI root volume that archive-get's replica-catch-up queue (multi-segment WAL) could fill; /data is the dedicated EBS volume.
+# Explicit override of the /var/spool/pgbackrest default. That default sits on the 10GB AMI root volume, which archive-get's replica-catch-up queue could fill; /data is the dedicated EBS volume.
 spool-path = /data/pgbackrest_spool
 start-fast = y
 # Note: the [supabase] stanza (pg1-path, pg1-socket-path, pg1-user) has been

--- a/ansible/files/pgbackrest_config/pgbackrest.conf
+++ b/ansible/files/pgbackrest_config/pgbackrest.conf
@@ -13,6 +13,8 @@ log-level-console = info
 log-level-file = detail
 log-subprocess = y
 resume = n
+# Explicit vs. the /var/spool/pgbackrest default, which sits on the 10GB AMI root volume that archive-get's replica-catch-up queue (multi-segment WAL) could fill; /data is the dedicated EBS volume.
+spool-path = /data/pgbackrest_spool
 start-fast = y
 # Note: the [supabase] stanza (pg1-path, pg1-socket-path, pg1-user) has been
 # removed from this file. supabase-admin-agent owns that stanza and writes it

--- a/ansible/files/postgresql_config/sbpostgres_apparmor
+++ b/ansible/files/postgresql_config/sbpostgres_apparmor
@@ -127,7 +127,9 @@ profile sbpostgres flags=(attach_disconnected) {
         /var/lib/postgresql/data/standby.signal rw,
         /var/lib/pgbackrest rw,
         /etc/pgbackrest/conf.d/** rw,
-        /var/spool/pgbackrest/** rw,
+        # bare-dir grant needed alongside ** (same as /data/pgdata/pg_wal/) since ** doesn't cover the directory inode itself; path must match spool-path in ansible/files/pgbackrest_config/pgbackrest.conf, which has the full cross-file sync note
+        /data/pgbackrest_spool/ rw,
+        /data/pgbackrest_spool/** rw,
         /var/log/pgbackrest/** rw,
         /etc/** r,
         /usr/local/** r,
@@ -190,7 +192,9 @@ profile sbpostgres flags=(attach_disconnected) {
         /var/lib/postgresql/data/standby.signal rw,
         /var/lib/pgbackrest rw,
         /etc/pgbackrest/conf.d/** rw,
-        /var/spool/pgbackrest/** rw,
+        # bare-dir grant needed alongside ** (same as /data/pgdata/pg_wal/) since ** doesn't cover the directory inode itself; path must match spool-path in ansible/files/pgbackrest_config/pgbackrest.conf, which has the full cross-file sync note
+        /data/pgbackrest_spool/ rw,
+        /data/pgbackrest_spool/** rw,
         /var/log/pgbackrest/** rw,
         /etc/** r,
         /usr/local/** r,

--- a/ansible/tasks/setup-pgbackrest.yml
+++ b/ansible/tasks/setup-pgbackrest.yml
@@ -47,7 +47,8 @@
     # (running as the pgbackrest user) cannot read conf files created by adminapi.
     - {dir: /etc/pgbackrest/conf.d, mode: '02770'}
     - {dir: /var/lib/pgbackrest}
-    - {dir: /var/spool/pgbackrest}
+    # setgid (02770), same reason as conf.d above (postgres_shell and pgbackrest_shell both write here per sbpostgres_apparmor); must match spool-path in pgbackrest.conf; bake-time only, see INDATA-1153 for why that alone doesn't create this on any live instance's real /data
+    - {dir: /data/pgbackrest_spool, mode: '02770'}
     - {dir: /var/log/pgbackrest}
   loop_control:
     loop_var: backrest_dir

--- a/ansible/tasks/setup-pgbackrest.yml
+++ b/ansible/tasks/setup-pgbackrest.yml
@@ -58,6 +58,7 @@
     # (running as the pgbackrest user) cannot read conf files created by adminapi.
     - {dir: /etc/pgbackrest/conf.d, mode: '02770'}
     - {dir: /var/lib/pgbackrest}
+    # must match spool-path in ansible/files/pgbackrest_config/pgbackrest.conf
     - {dir: /data/pgbackrest_spool}
     - {dir: /var/log/pgbackrest}
   loop_control:

--- a/ansible/tasks/setup-pgbackrest.yml
+++ b/ansible/tasks/setup-pgbackrest.yml
@@ -58,7 +58,7 @@
     # (running as the pgbackrest user) cannot read conf files created by adminapi.
     - {dir: /etc/pgbackrest/conf.d, mode: '02770'}
     - {dir: /var/lib/pgbackrest}
-    - {dir: /var/spool/pgbackrest}
+    - {dir: /data/pgbackrest_spool}
     - {dir: /var/log/pgbackrest}
   loop_control:
     loop_var: backrest_dir

--- a/nix/packages/supascan/internal/config/defaults.go
+++ b/nix/packages/supascan/internal/config/defaults.go
@@ -63,6 +63,9 @@ var DefaultExclusions = Config{
 		// PostgreSQL data directory - contents are dynamic database state
 		"/data/pgdata",
 
+		// pgBackRest spool - transient WAL archive-get/archive-push queue, not durable state
+		"/data/pgbackrest_spool",
+
 		// Deployment/provisioning tools - internal implementation details
 		"/opt/saltstack",
 


### PR DESCRIPTION
## Summary

pgBackRest's `spool-path` was never set explicitly, so it defaulted to `/var/spool/pgbackrest` on the AMI's 10GB root volume instead of `/data` (the dedicated EBS volume PGDATA lives on). This PR sets `spool-path = /data/pgbackrest_spool` in the ansible-managed pgbackrest.conf, and updates the AppArmor profile to allow writes there.

**Correction from an earlier version of this body:** the AMI-bake-time directory-creation task added here does not create this directory on any live instance's real `/data`. This holds for every instance, not just the resize-compute/hibernation-resume/pg-major-upgrade cases originally disclosed under Known gap. `/data` is always a separately-provisioned EBS volume attached at real instance launch. It is never part of the AMI image at any Packer stage. So the config value and the AppArmor grant in this PR are correct and needed groundwork, but on their own they do not make `archive-async` safe to enable anywhere in the fleet. The real fix is a runtime mechanism, tracked at [INDATA-1153](https://linear.app/supabase/issue/INDATA-1153) (reopened, see Known gap below for why).

(bot-generated information collapsed below)

---

<details><summary>Details</summary>

- Sets `spool-path = /data/pgbackrest_spool` in the ansible-managed `[global]` pgbackrest.conf, and updates the directory-creation task to create that path instead of `/var/spool/pgbackrest`.
- Updates the `sbpostgres` AppArmor profile (`postgres_shell` and `pgbackrest_shell` sub-profiles) to grant write access to `/data/pgbackrest_spool` instead of the old `/var/spool/pgbackrest`. The profile runs in enforce mode, so without this change the config change alone would just trade "spool fills the root volume" for "every archive-push/archive-get write gets denied."
- The AppArmor grant is two rules, not a one-for-one path swap: a bare-directory grant (`/data/pgbackrest_spool/ rw,`) plus the recursive `/data/pgbackrest_spool/** rw,` grant. The bare-dir rule has no counterpart in the old `/var/spool/pgbackrest/** rw,` line, since `**` alone doesn't cover the directory inode itself.
- The directory-creation loop entry now also sets setgid (`02770`), matching `/etc/pgbackrest/conf.d`'s own mode in the same loop, for the same reason: both `postgres_shell` and `pgbackrest_shell` write here, so files need the `postgres` group regardless of which sub-profile creates them first.
- This is a `[global]`-scope pgBackRest option, set once at provisioning. No `supabase-admin-agent` changes needed for the config value itself. Split out of #2291 (sudoers grant for `pgbackrest reconcile`) since the two are unrelated concerns: one is a privilege-escalation grant, this one is a storage-location fix, and neither depends on the other.
- `spool-path` is not reachable yet: `archive-async = n` in this same file, and `supabase-admin-agent`'s `repo1_async.conf` still ships `# archive-async = y` commented out. pgBackRest's own config parser only errors on an unmet option dependency when the value comes from the command line, not a config file, so the unused setting is silently accepted rather than rejected. The benefit only materializes once something turns `archive-async` on fleet-wide (INDATA-996), which is gated on the Known gap below closing first.
- Once `archive-async` is on, the spool shares disk headroom with PGDATA instead of the root volume: worst case is `archive-get`'s default 128MiB prefetch queue landing on a data volume that's already tight (a 100MiB `tune2fs -r` reserve is already root-only). Not a new risk this PR introduces on its own, since the setting is inert until `archive-async` ships, but worth bounding `archive-get-queue-max`/`archive-push-queue-max` explicitly wherever that enablement lands, rather than relying on the default.

**Why the config and AppArmor changes are still correct, on their own**
- pgBackRest's own documentation recommends `spool-path` live on the same filesystem as `pg_wal`, so `archive-get` can hand a WAL segment to Postgres with a rename instead of a copy. `/data/pgdata/pg_wal` is on `/data`, so this change satisfies that recommendation directly. That's the primary justification, independent of whether the directory-creation task itself does anything useful (see Known gap).
- **Spool-path data is disposable.** Per pgBackRest docs, `spool-path` contents aren't durable state. `archive-push` rechecks each WAL segment against the repo and `archive-get` rebuilds its queue on loss. No migration needed for spool *contents*, whatever eventually creates the directory.

**Known gap (tracked separately, blocking `archive-async` fleet-wide, not blocking this PR)**
- The directory-creation task in this PR only runs at AMI-bake time, and even then it does not end up on any live instance's real `/data`. Traced through both Packer stages (`amazon-*-nix.pkr.hcl`, `stage2-nix-psql.pkr.hcl`): neither declares an `ami_block_device_mappings` entry for a data volume, and the production data volume is always attached and mounted at `/data` at real instance launch, outside this repo, overlaying whatever the bake wrote underneath. `/data` itself is root:root 0755 at runtime, and the unprivileged `pgbackrest` user can't self-create a directory there (pgBackRest's own `storagePathCreateP` does create missing parents, but the DAC check on root-owned `/data` fails first).
  - Real fix, tracked at [INDATA-1153](https://linear.app/supabase/issue/INDATA-1153): a runtime mechanism that creates and fixes the ownership of `/data/pgbackrest_spool` on the instance itself, at the point pgBackRest is about to need it (`pgbackrest enable`/`setup-replica`/`stanza-upgrade`), not at AMI-bake time. That issue was previously closed as superseded by `supabase-admin-agent#120`'s `EnsureSpoolDir()`. Confirmed during this PR's own review that `EnsureSpoolDir()` is only called from `reconcile`, whose own preflight requires `enable`'s configs to already exist, so it structurally cannot create the directory before `enable` itself needs it. Reopened with the corrected finding.
  - This is a hard, standing prerequisite for INDATA-996 (the fleet-wide `archive-async` enablement gate). Without it, `archive-push`/`archive-get` fail outright on every instance the moment `archive-async` turns on, not just a subset.
- **Second hard prerequisite for INDATA-996, tracked at [INDATA-1180](https://linear.app/supabase/issue/INDATA-1180)** (opened for the profile's pre-existing sub-profile duplication, not by this PR): `supabase/salt` manages its own copy of the `sbpostgres` AppArmor profile (`salt/state/formula/apparmor/files/sbpostgres_apparmor`) and reapplies it on every highstate, fleet-wide, roughly every 10 minutes. That copy still only grants `/var/spool/pgbackrest/** rw,`; it has no `/data/pgbackrest_spool` grant at all, so it overwrites this PR's AppArmor change on every live instance shortly after boot. A companion `supabase/salt` PR needs to add the same two-rule grant before `archive-async` can write to `/data/pgbackrest_spool` anywhere in the fleet.
- Both prerequisites above need to land before INDATA-996 ships fleet-wide, not before this PR merges. The config and AppArmor changes here are correct and harmless while `archive-async` stays off.
- `nix/packages/supascan`'s `ShallowDirs` now excludes `/data/pgbackrest_spool`, matching the existing `/data/pgdata` entry. Both hold transient, high-churn state that would otherwise register as audit-baseline drift on every capture.

**Considered and not done**
- Templating the path (an Ansible variable referenced by all four files that name it, instead of four hardcoded string literals kept in sync by comment cross-reference), rejected. Hardcoded path literals with a cross-reference comment are the established convention in this repo for every other multi-file path dependency (`/data/pgdata`, `/var/lib/pgbackrest`). Templating this one path alone means converting two plain `copy`-sourced files to `.j2` and adding a variable, for a string used three times in Ansible plus once in Go (which can never consume an Ansible variable regardless). Not worth it for this one path when nothing else in the repo does it either.

</details>

---

<details><summary>Testing</summary>

- [x] `ansible-lint ansible/tasks/setup-pgbackrest.yml` passes cleanly
- [x] `ansible-playbook --syntax-check` passes cleanly on the full playbook
- [ ] Manual: confirm `/data/pgbackrest_spool` exists with `pgbackrest:postgres` ownership after provisioning, and `archive-get`/`archive-push` operate against it under the updated AppArmor profile. Expected to fail on a real instance per the Known gap above, until INDATA-1153 ships. Useful only to confirm the AMI-bake-time artifact itself (config value present, AppArmor grant present) is correct.

</details>

---

<details><summary>Misc</summary>

Resolves INDATA-1038

Internal-only entry: [supabase/changelog#225](https://github.com/supabase/changelog/pull/225)

</details>

