### PR TITLE
ci: Fix CLI release workflow trigger race

### DIFF
--- a/.github/workflows/ami-release-nix.yml
+++ b/.github/workflows/ami-release-nix.yml
@@ -204,7 +204,7 @@ jobs:
           tag_name: ${{ env.RELEASE_TAG }}
           target_commitish: ${{ github.sha }}
 
-      - name: Create CLI tag for PG 17
+      - name: Create CLI tag for PG 17 & Trigger Release
         if: matrix.postgres_version == '17' && matrix.target.arch == 'arm64' && github.event_name != 'workflow_dispatch'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -214,12 +214,7 @@ jobs:
           git tag "${CLI_TAG}" "${{ github.sha }}"
           git push origin "${CLI_TAG}"
 
-      - name: Trigger CLI release workflow for PG 17
-        if: matrix.postgres_version == '17' && github.event_name != 'workflow_dispatch'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          CLI_TAG="v${POSTGRES_SUPABASE_VERSION}-cli"
+          echo "Triggering Release Workflow: ${CLI_TAG}"
           gh workflow run cli-release.yml \
             --ref "${CLI_TAG}" \
             -f version="${CLI_TAG}"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Sometimes the cli release workflow trigger fails when running amd64 builds. For example https://github.com/supabase/postgres/actions/runs/30005331013/job/89199985385 fails with the following message:

> could not create workflow dispatch event: HTTP 422: No ref found for: v17.6.1.154-cli (https://api.github.com/repos/supabase/postgres/actions/workflows/229793425/dispatches)

And it looks like that is a race where amd64 got to this stage before arm64 was able to create the tag.

## What is the new behavior?

I've combined both tag and trigger release workflow into one step since they are pretty tightly coupled and also meant to be done just once.