### PR TITLE
chore: bump pgctld

### DIFF
--- a/Dockerfile-multigres
+++ b/Dockerfile-multigres
@@ -16,7 +16,7 @@
 
 ARG ALPINE_VERSION=3.23
 ARG GOLANG_VERSION=1.26
-ARG PGCTLD_REV=1e3bad798972600778ee27eb08ab7d34cc8be8e9 # Pinned to the commit that introduced --pg-initdb-sql-dirs (MUL-484)
+ARG PGCTLD_REV=54b4c18f6f5f188ac00ac3cba1369b915a8bb34e
 ARG SUPABASE_IMAGE=supabase-postgres:17
 
 ####################

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -13,9 +13,9 @@ postgres_major:
 # This is the source of truth for Postgres versions used in the Dockerfiles, and
 # is used to derive image tags and base images in the release matrix.
 postgres_release:
-  postgresorioledb-17: "17.9.0.009-orioledb"
-  postgres17: "17.6.1.156"
-  postgres15: "15.14.1.156"
+  postgresorioledb-17: "17.9.0.010-orioledb"
+  postgres17: "17.6.1.157"
+  postgres15: "15.14.1.157"
 
 # Docker release matrix — base images built first, layered images built on top.
 # tag and base_tag are derived at build time from postgres_release via release_key.

--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
     "multigres": {
       "flake": false,
       "locked": {
-        "lastModified": 1779407344,
-        "narHash": "sha256-UQE/2Ru4V1ip5WI+03NqaceTf2KqVV1xEzQWMtqDc6k=",
+        "lastModified": 1784678637,
+        "narHash": "sha256-ayJ46bSgOkXkEJ29WUit+SblYVNaP+ThwoLRBeVjz9A=",
         "owner": "multigres",
         "repo": "multigres",
-        "rev": "96303016e56f172d7bed2450f98cf7466f770b5f",
+        "rev": "54b4c18f6f5f188ac00ac3cba1369b915a8bb34e",
         "type": "github"
       },
       "original": {

--- a/nix/packages/pgctld.nix
+++ b/nix/packages/pgctld.nix
@@ -1,9 +1,10 @@
 {
   lib,
   buildGoModule,
+  go_1_26,
   multigres-src,
 }:
-buildGoModule {
+(buildGoModule.override { go = go_1_26; }) {
   pname = "pgctld";
   version = multigres-src.rev;
   src = multigres-src;
@@ -17,7 +18,7 @@ buildGoModule {
   '';
   # Tests require a running PostgreSQL instance (integration tests); skip in sandbox.
   doCheck = false;
-  vendorHash = "sha256-lObK/Oukh1oEPQENlhny8eNxRhSlTKywO3GCGZ8u5Qw=";
+  vendorHash = "sha256-oRP1ZvRmE8eqYmJIuZSad3/BVicmAFkBJ4qSaiD6F0E=";
 
   meta = {
     description = "PostgreSQL control daemon for Multigres cluster lifecycle management";

--- a/nix/packages/pgctld.nix
+++ b/nix/packages/pgctld.nix
@@ -1,10 +1,9 @@
 {
   lib,
-  buildGoModule,
-  go_1_26,
+  buildGo126Module,
   multigres-src,
 }:
-(buildGoModule.override { go = go_1_26; }) {
+buildGo126Module {
   pname = "pgctld";
   version = multigres-src.rev;
   src = multigres-src;


### PR DESCRIPTION
Bump pgctld to the Multigres version used by the latest multigres-operator version