### PR TITLE
ci: Use arm-native-runner for kvm builds on aarch64-linux

### DIFF
--- a/.github/actions/nix-install-ephemeral/action.yml
+++ b/.github/actions/nix-install-ephemeral/action.yml
@@ -1,43 +1,59 @@
-name: 'Install Nix on ephemeral runners'
-description: 'Installs Nix and sets up AWS credentials to push to the Nix binary cache'
+name: Install Nix on ephemeral runners
+description: Installs Nix and sets up AWS credentials to push to the Nix binary cache
 inputs:
   aws-region:
-    description: 'AWS region for the Nix binary cache S3 bucket'
+    description: AWS region for the Nix binary cache S3 bucket
     required: false
-    default: 'us-east-1'
+    default: us-east-1
   force-clean:
     description: Whether to delete pre-existing nix paths
     required: false
-    default: 'false'
-  push-to-cache:
-    description: 'Whether to push build outputs to the Nix binary cache'
+    default: false
+  nix-signing-key:
+    description: Key used to sign uploads to binary cache, required if push-to-cache is true
     required: false
-    default: 'false'
   multi-user:
     description: Whether to install nix in multi-user mode (default true) or single-user mode
     required: false
-    default: 'true'
+    default: true
+  push-to-cache:
+    description: Whether to push build outputs to the Nix binary cache
+    required: false
+    default: false
+  role-to-assume:
+    description: AWS Role to assume when configuring aws credentials, required if push-to-cache is true
+    required: false
 runs:
-  using: 'composite'
+  using: composite
   steps:
-    - name: aws-creds
+    - name: validate push-to-cache required inputs
+      if: inputs.push-to-cache == true
+      shell: bash
+      run: |
+        abort() { echo "$@" >&2; exit 1; }
+        [[ -z "${{ inputs.nix-signing-key}}" ]] && abort "nix-signing-key is required when push-to-cache is true"
+        [[ -z "${{ inputs.role-to-assume}}" ]] && abort "role-to-assume is required when push-to-cache is true"
+
+    - name: configure aws credentials
       uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
-      if: ${{ inputs.push-to-cache == 'true' }}
+      if: inputs.push-to-cache == true
       with:
-        role-to-assume: ${{ env.DEV_AWS_ROLE }}
+        role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.aws-region }}
         output-credentials: true
         role-duration-seconds: 7200
     - name: Force Clean Pre-Existing Nix Paths
-      if: inputs.force-clean == 'true'
+      if: inputs.force-clean == true
       shell: bash
       run: sudo rm -rf /nix /etc/nix "$HOME/.nix-profile" "$HOME/.nix-channels" "$HOME/.config/nix"
+      default: false
     - name: Ensure /etc/nix exists
       shell: bash
       run: sudo mkdir -p /etc/nix
     - name: Setup AWS credentials for Nix
-      if: ${{ inputs.push-to-cache == 'true' }}
+      if: inputs.push-to-cache == true
       shell: bash
+      default: true
       run: |
         sudo -H aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
         sudo -H aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
@@ -54,7 +70,7 @@ runs:
         EOF
         sudo chmod +x /etc/nix/upload-to-cache.sh
       env:
-        NIX_SIGN_SECRET_KEY: ${{ env.NIX_SIGN_SECRET_KEY }}
+        NIX_SIGN_SECRET_KEY: ${{ inputs.nix-signing-key }}
     - name: Install Nix
       shell: bash
       run: |

--- a/.github/actions/nix-install-ephemeral/action.yml
+++ b/.github/actions/nix-install-ephemeral/action.yml
@@ -5,17 +5,9 @@ inputs:
     description: AWS region for the Nix binary cache S3 bucket
     required: false
     default: us-east-1
-  force-clean:
-    description: Whether to delete pre-existing nix paths
-    required: false
-    default: false
   nix-signing-key:
     description: Key used to sign uploads to binary cache, required if push-to-cache is true
     required: false
-  multi-user:
-    description: Whether to install nix in multi-user mode (default true) or single-user mode
-    required: false
-    default: true
   push-to-cache:
     description: Whether to push build outputs to the Nix binary cache
     required: false
@@ -42,92 +34,16 @@ runs:
         aws-region: ${{ inputs.aws-region }}
         output-credentials: true
         role-duration-seconds: 7200
-    - name: Force Clean Pre-Existing Nix Paths
-      if: inputs.force-clean == true
-      shell: bash
-      run: sudo rm -rf /nix /etc/nix "$HOME/.nix-profile" "$HOME/.nix-channels" "$HOME/.config/nix"
-      default: false
-    - name: Ensure /etc/nix exists
-      shell: bash
-      run: sudo mkdir -p /etc/nix
-    - name: Setup AWS credentials for Nix
-      if: inputs.push-to-cache == true
-      shell: bash
-      default: true
-      run: |
-        sudo -H aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
-        sudo -H aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
-        sudo -H aws configure set aws_session_token $AWS_SESSION_TOKEN
-        sudo -H aws configure set region ${{ inputs.aws-region }}
-        sudo -E python -c "import os; file = open('/etc/nix/nix-secret-key', 'w'); file.write(os.environ['NIX_SIGN_SECRET_KEY']); file.close()"
-        cat << 'EOF' | sudo tee /etc/nix/upload-to-cache.sh > /dev/null
-        #!/usr/bin/env bash
-        set -euo pipefail
-        set -f
 
-        export IFS=' '
-        /nix/var/nix/profiles/default/bin/nix copy --max-jobs 5 --to 's3://nix-postgres-artifacts?secret-key=/etc/nix/nix-secret-key' $OUT_PATHS
-        EOF
-        sudo chmod +x /etc/nix/upload-to-cache.sh
+    - name: setup nix
+      shell: bash
+      run: cd ${{ github.action_path }} && ./setup-nix.sh
       env:
+        AWS_REGION: ${{ inputs.aws-region }}
+        GITHUB_TOKEN: ${{ github.token }}
         NIX_SIGN_SECRET_KEY: ${{ inputs.nix-signing-key }}
-    - name: Install Nix
-      shell: bash
-      run: |
-        if [[ "${{ inputs.multi-user }}" == true ]]; then
-          daemon=--daemon
-          nixconfdir=/etc/nix
-          path=/nix/var/nix/profiles/default/bin
-          tmpconf=/tmp/nix-extra.conf
+        PUSH_TO_CACHE: ${{ inputs.push-to-cache == true }}
 
-          echo 'access-tokens = github.com=${{ github.token }}' | sudo tee $nixconfdir/github.nix.conf >/dev/null
-          sudo chmod 400 $nixconfdir/github.nix.conf
-        else
-          daemon=--no-daemon
-          nixconfdir=$HOME/.config/nix
-          path=$HOME/.nix-profile/bin
-          tmpconf=$nixconfdir/nix.conf # --nix-extra-conf-files is ignored for single-user installs
-
-          mkdir -p "$(dirname $tmpconf)"
-          echo 'access-tokens = github.com=${{ github.token }}' | tee $nixconfdir/github.nix.conf >/dev/null
-          chmod 400 $nixconfdir/github.nix.conf
-        fi
-
-        cat >$tmpconf <<'NIXCONF'
-        always-allow-substitutes = true
-        extra-experimental-features = flakes nix-command
-        extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
-        extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=
-        max-jobs = 4
-        NIXCONF
-
-
-        if [[ -e /dev/kvm ]]; then
-          echo 'extra-system-features = kvm' >>$tmpconf
-        fi
-
-        if [[ "${{ inputs.push-to-cache }}" == true ]]; then
-          echo 'post-build-hook = /etc/nix/upload-to-cache.sh' >>$tmpconf
-        fi
-
-        echo "!include $nixconfdir/github.nix.conf" >>$tmpconf
-
-        curl -L https://releases.nixos.org/nix/nix-2.34.6/install | sh -s -- $daemon --yes --nix-extra-conf-file $tmpconf
-
-        sudo cat $nixconfdir/nix.conf
-
-        # Add nix to PATH for subsequent steps
-        echo "$path" >> "$GITHUB_PATH"
-    - name: Print Nix version
+    - name: verify nix in path
       shell: bash
       run: nix --version
-    - name: Setup KVM permissions
-      shell: bash
-      run: |
-        if [ -e /dev/kvm ]; then
-          sudo chown runner /dev/kvm
-          sudo chmod 666 /dev/kvm
-          echo "KVM configured: $(ls -l /dev/kvm)"
-        else
-          echo "KVM device not available"
-        fi

--- a/.github/actions/nix-install-ephemeral/setup-github-access.sh
+++ b/.github/actions/nix-install-ephemeral/setup-github-access.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+umask 0277
+echo "access-tokens = github.com=${GITHUB_TOKEN:?}" >"$NIXCONFDIR/github.nix.conf"
+echo "!include $NIXCONFDIR/github.nix.conf"

--- a/.github/actions/nix-install-ephemeral/setup-nix.sh
+++ b/.github/actions/nix-install-ephemeral/setup-nix.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if systemctl whoami &>/dev/null || [[ $(uname) == Darwin ]]; then
+	# systemd is running so we can install in multi-user mode
+	# or running on macos
+	daemon=--daemon
+	nixconfdir=/etc/nix
+	path=/nix/var/nix/profiles/default/bin
+
+	tmpdir=$(mktemp -d)
+	trap 'cd; rm -rf $tmpdir' EXIT
+
+	function maybesudo { sudo -E env "$@"; }
+else
+	# systemd is *not* running so we must install in single-user mode
+	daemon=--no-daemon
+	nixconfdir=$HOME/.config/nix
+	path=$HOME/.nix-profile/bin
+
+	tmpdir=$nixconfdir
+
+	function maybesudo { env "$@"; }
+fi
+
+maybesudo mkdir -p "$nixconfdir"
+cat >"$tmpdir/nix.conf" <<-EOF
+	always-allow-substitutes = true
+	extra-experimental-features = flakes nix-command
+	extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
+	extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI=
+	max-jobs = 5
+EOF
+
+if [[ -e /dev/kvm ]]; then
+	sudo chown runner /dev/kvm
+	sudo chmod 666 /dev/kvm
+	echo 'extra-system-features = kvm' >>"$tmpdir/nix.conf"
+fi
+
+if [[ ${PUSH_TO_CACHE:?} == true ]]; then
+	set -x
+	maybesudo NIXCONFDIR="$nixconfdir" NIXBINDIR="$path" ./setup-push.sh >>"$tmpdir/nix.conf"
+fi
+
+maybesudo NIXCONFDIR="$nixconfdir" ./setup-github-access.sh >>"$tmpdir/nix.conf"
+
+curl -L https://releases.nixos.org/nix/nix-2.34.6/install | sh -s -- $daemon --yes --nix-extra-conf-file "$tmpdir/nix.conf"
+cat "$nixconfdir/nix.conf"
+
+# Add nix to PATH for subsequent steps
+echo "$path" >>"${GITHUB_PATH:?}"

--- a/.github/actions/nix-install-ephemeral/setup-push.sh
+++ b/.github/actions/nix-install-ephemeral/setup-push.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+mkdir -p ~/.aws
+umask 0277
+cat >~/.aws/config <<-EOF
+	[default]
+	region = ${AWS_REGION:?}
+EOF
+cat >~/.aws/credentials <<-EOF
+	[default]
+	aws_access_key_id = ${AWS_ACCESS_KEY_ID:?}
+	aws_secret_access_key = ${AWS_SECRET_ACCESS_KEY:?}
+	aws_session_token = ${AWS_SESSION_TOKEN:?}
+EOF
+
+printenv NIX_SIGN_SECRET_KEY >"${NIXCONFDIR:?}/nix-secret-key"
+
+cat >"$NIXCONFDIR/upload-to-cache.sh" <<-EOF
+	#!/usr/bin/env bash
+	set -euo pipefail
+	set -f
+
+	if [[ ! -e  ${NIXBINDIR:?}/nix ]]; then
+		# called during nix install, but nix isn't available yet
+		exit
+	fi
+
+	export IFS=' '
+	echo $NIXBINDIR/nix copy --max-jobs 5 --to 's3://nix-postgres-artifacts?secret-key=$NIXCONFDIR/nix-secret-key' \$OUT_PATHS
+EOF
+chmod o+x "$NIXCONFDIR/upload-to-cache.sh"
+
+echo "post-build-hook = $NIXCONFDIR/upload-to-cache.sh"

--- a/.github/workflows/ami-release-nix.yml
+++ b/.github/workflows/ami-release-nix.yml
@@ -81,11 +81,10 @@ jobs:
       - name: Install nix
         uses: ./.github/actions/nix-install-ephemeral
         with:
-          push-to-cache: 'true'
+          push-to-cache: true
           aws-region: ${{ env.AWS_REGION }}
-        env:
-          DEV_AWS_ROLE: ${{ secrets.DEV_AWS_ROLE }}
-          NIX_SIGN_SECRET_KEY: ${{ secrets.NIX_SIGN_SECRET_KEY }}
+          nix-signing-key: ${{ secrets.NIX_SIGN_SECRET_KEY }}
+          role-to-assume: ${{ secrets.DEV_AWS_ROLE }}
 
       - name: Build AMI
         id: build-ami

--- a/.github/workflows/cli-smoke-test.yml
+++ b/.github/workflows/cli-smoke-test.yml
@@ -27,11 +27,6 @@ jobs:
 
       - name: Install nix
         uses: ./.github/actions/nix-install-ephemeral
-        with:
-          push-to-cache: 'false'
-        env:
-          DEV_AWS_ROLE: ${{ secrets.DEV_AWS_ROLE }}
-          NIX_SIGN_SECRET_KEY: ${{ secrets.NIX_SIGN_SECRET_KEY }}
 
       - name: Check Docker image changes
         id: check
@@ -56,11 +51,6 @@ jobs:
 
       - name: Install nix
         uses: ./.github/actions/nix-install-ephemeral
-        with:
-          push-to-cache: 'false'
-        env:
-          DEV_AWS_ROLE: ${{ secrets.DEV_AWS_ROLE }}
-          NIX_SIGN_SECRET_KEY: ${{ secrets.NIX_SIGN_SECRET_KEY }}
 
       - name: Create Docker context
         run: docker context create builders

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -38,11 +38,6 @@ jobs:
 
       - name: Install nix
         uses: ./.github/actions/nix-install-ephemeral
-        with:
-          push-to-cache: 'false'
-        env:
-          DEV_AWS_ROLE: ${{ secrets.DEV_AWS_ROLE }}
-          NIX_SIGN_SECRET_KEY: ${{ secrets.NIX_SIGN_SECRET_KEY }}
 
       - name: Check Docker image changes
         id: check
@@ -85,11 +80,6 @@ jobs:
 
       - name: Install nix
         uses: ./.github/actions/nix-install-ephemeral
-        with:
-          push-to-cache: 'false'
-        env:
-          DEV_AWS_ROLE: ${{ secrets.DEV_AWS_ROLE }}
-          NIX_SIGN_SECRET_KEY: ${{ secrets.NIX_SIGN_SECRET_KEY }}
 
       - name: Create Docker context
         run: docker context create builders

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -44,10 +44,9 @@ jobs:
         if: ${{ matrix.attr != '' }}
         uses: ./.github/actions/nix-install-ephemeral
         with:
-          push-to-cache: 'true'
-        env:
-          DEV_AWS_ROLE: ${{ secrets.DEV_AWS_ROLE }}
-          NIX_SIGN_SECRET_KEY: ${{ secrets.NIX_SIGN_SECRET_KEY }}
+          push-to-cache: true
+          nix-signing-key: ${{ secrets.NIX_SIGN_SECRET_KEY }}
+          role-to-assume: ${{ secrets.DEV_AWS_ROLE }}
       - name: nix build
         if: ${{ matrix.attr != '' }}
         uses: ./.github/actions/nix-build-retry
@@ -75,10 +74,9 @@ jobs:
         if: ${{ matrix.attr != '' }}
         uses: ./.github/actions/nix-install-ephemeral
         with:
-          push-to-cache: 'true'
-        env:
-          DEV_AWS_ROLE: ${{ secrets.DEV_AWS_ROLE }}
-          NIX_SIGN_SECRET_KEY: ${{ secrets.NIX_SIGN_SECRET_KEY }}
+          push-to-cache: true
+          nix-signing-key: ${{ secrets.NIX_SIGN_SECRET_KEY }}
+          role-to-assume: ${{ secrets.DEV_AWS_ROLE }}
       - name: nix build
         if: ${{ matrix.attr != '' }}
         uses: ./.github/actions/nix-build-retry
@@ -104,10 +102,9 @@ jobs:
         if: ${{ matrix.attr != '' && matrix.runs_on.group != 'self-hosted-runners-nix' }}
         uses: ./.github/actions/nix-install-ephemeral
         with:
-          push-to-cache: 'true'
-        env:
-          DEV_AWS_ROLE: ${{ secrets.DEV_AWS_ROLE }}
-          NIX_SIGN_SECRET_KEY: ${{ secrets.NIX_SIGN_SECRET_KEY }}
+          push-to-cache: true
+          nix-signing-key: ${{ secrets.NIX_SIGN_SECRET_KEY }}
+          role-to-assume: ${{ secrets.DEV_AWS_ROLE }}
       - name: Install nix (self-hosted)
         if: ${{ matrix.attr != '' && matrix.runs_on.group == 'self-hosted-runners-nix' }}
         uses: ./.github/actions/nix-install-self-hosted
@@ -138,10 +135,9 @@ jobs:
         if: ${{ matrix.attr != '' }}
         uses: ./.github/actions/nix-install-ephemeral
         with:
-          push-to-cache: 'true'
-        env:
-          DEV_AWS_ROLE: ${{ secrets.DEV_AWS_ROLE }}
-          NIX_SIGN_SECRET_KEY: ${{ secrets.NIX_SIGN_SECRET_KEY }}
+          push-to-cache: true
+          nix-signing-key: ${{ secrets.NIX_SIGN_SECRET_KEY }}
+          role-to-assume: ${{ secrets.DEV_AWS_ROLE }}
       - name: nix build
         if: ${{ matrix.attr != '' }}
         uses: ./.github/actions/nix-build-retry
@@ -167,10 +163,9 @@ jobs:
         if: ${{ matrix.attr != '' }}
         uses: ./.github/actions/nix-install-ephemeral
         with:
-          push-to-cache: 'true'
-        env:
-          DEV_AWS_ROLE: ${{ secrets.DEV_AWS_ROLE }}
-          NIX_SIGN_SECRET_KEY: ${{ secrets.NIX_SIGN_SECRET_KEY }}
+          push-to-cache: true
+          nix-signing-key: ${{ secrets.NIX_SIGN_SECRET_KEY }}
+          role-to-assume: ${{ secrets.DEV_AWS_ROLE }}
       - name: nix build
         if: ${{ matrix.attr != '' }}
         uses: ./.github/actions/nix-build-retry
@@ -198,10 +193,9 @@ jobs:
         if: ${{ matrix.attr != '' }}
         uses: ./.github/actions/nix-install-ephemeral
         with:
-          push-to-cache: 'true'
-        env:
-          DEV_AWS_ROLE: ${{ secrets.DEV_AWS_ROLE }}
-          NIX_SIGN_SECRET_KEY: ${{ secrets.NIX_SIGN_SECRET_KEY }}
+          push-to-cache: true
+          nix-signing-key: ${{ secrets.NIX_SIGN_SECRET_KEY }}
+          role-to-assume: ${{ secrets.DEV_AWS_ROLE }}
       - name: nix build
         if: ${{ matrix.attr != '' }}
         uses: ./.github/actions/nix-build-retry

--- a/.github/workflows/nix-dependency-analysis.yml
+++ b/.github/workflows/nix-dependency-analysis.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           push-to-cache: "false"
         env:
-          DEV_AWS_ROLE: ${{ secrets.DEV_AWS_ROLE }}
+          role-to-assume: ${{ secrets.DEV_AWS_ROLE }}
           NIX_SIGN_SECRET_KEY: ${{ secrets.NIX_SIGN_SECRET_KEY }}
 
       - name: Run dependency analysis
@@ -89,7 +89,7 @@ jobs:
         with:
           push-to-cache: "false"
         env:
-          DEV_AWS_ROLE: ${{ secrets.DEV_AWS_ROLE }}
+          role-to-assume: ${{ secrets.DEV_AWS_ROLE }}
           NIX_SIGN_SECRET_KEY: ${{ secrets.NIX_SIGN_SECRET_KEY }}
 
       - name: Run extension analysis

--- a/.github/workflows/nix-eval.yml
+++ b/.github/workflows/nix-eval.yml
@@ -36,10 +36,9 @@ jobs:
       - name: Install nix
         uses: ./.github/actions/nix-install-ephemeral
         with:
-          push-to-cache: 'true'
-        env:
-          DEV_AWS_ROLE: ${{ secrets.DEV_AWS_ROLE }}
-          NIX_SIGN_SECRET_KEY: ${{ secrets.NIX_SIGN_SECRET_KEY }}
+          push-to-cache: true
+          nix-signing-key: ${{ secrets.NIX_SIGN_SECRET_KEY }}
+          role-to-assume: ${{ secrets.DEV_AWS_ROLE }}
       - id: set-matrix
         name: Generate Nix Matrix
         run: |

--- a/.github/workflows/qemu-image-build.yml
+++ b/.github/workflows/qemu-image-build.yml
@@ -66,9 +66,6 @@ jobs:
 
       - name: Install Nix
         uses: ./.github/actions/nix-install-ephemeral
-        with:
-          force-clean: "true"
-          multi-user: "false"
 
       - name: Build QEMU artifact
         run: BUILD_QEMU_IMAGE_HW_VIRT_ONLY=1 nix run .#build-qemu-image "${{ matrix.postgres_version }}" arm64

--- a/.github/workflows/testinfra-ami-build.yml
+++ b/.github/workflows/testinfra-ami-build.yml
@@ -76,11 +76,10 @@ jobs:
       - name: Install nix
         uses: ./.github/actions/nix-install-ephemeral
         with:
-          push-to-cache: 'true'
+          push-to-cache: true
           aws-region: ${{ env.AWS_REGION }}
-        env:
-          DEV_AWS_ROLE: ${{ secrets.DEV_AWS_ROLE }}
-          NIX_SIGN_SECRET_KEY: ${{ secrets.NIX_SIGN_SECRET_KEY }}
+          nix-signing-key: ${{ secrets.NIX_SIGN_SECRET_KEY }}
+          role-to-assume: ${{ secrets.DEV_AWS_ROLE }}
 
       - name: Build AMI
         id: build-ami

--- a/nix/packages/github-matrix/github_matrix.py
+++ b/nix/packages/github-matrix/github_matrix.py
@@ -258,7 +258,7 @@ def get_runner_for_package(pkg: NixEvalJobsOutput) -> RunsOnConfig | None:
         case (True, _, "darwin", "aarch64"):
             return {"group": "self-hosted-runners-nix", "labels": ["aarch64-darwin"]}
         case (True, _, "linux", "aarch64"):
-            specs = Specs(16, "ubuntu-2404-arm")
+            return {"labels": ["arm-native-runner"]}
         case (True, _, "linux", "x86_64"):
             specs = Specs(16, "ubuntu-2404")
 

--- a/nix/packages/github-matrix/tests/test_github_matrix.py
+++ b/nix/packages/github-matrix/tests/test_github_matrix.py
@@ -132,7 +132,7 @@ class TestGetRunnerForPackage:
             (
                 "aarch64-linux",
                 "kvm",
-                {"labels": ["blacksmith-16vcpu-ubuntu-2404-arm"]},
+                {"labels": ["arm-native-runner"]},
             ),
             (
                 "aarch64-linux",

--- a/nix/tools/default.nix
+++ b/nix/tools/default.nix
@@ -1,4 +1,4 @@
-{ self, inputs, ... }:
+{ ... }:
 {
   perSystem =
     { pkgs, ... }:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

NixOS tests require VMs and are being scheduled on blacksmith for linux builds, but that only works for x86_64-linux hosts, aarch64 fails.

## What is the new behavior?

Use arm-native-runners which are currently used for qemu builds and are aarch64 only.

## Additional context

In response to https://github.com/supabase/postgres/actions/runs/30160241092/job/89694722493?pr=2315

Fixes PSQL-1547