### PR TITLE
ci: Fix dockerhub-release-matrix matrix generation

### DIFF
--- a/.github/workflows/dockerhub-release-matrix.yml
+++ b/.github/workflows/dockerhub-release-matrix.yml
@@ -38,9 +38,9 @@ jobs:
                 $e | insert tag $"($ver)($e.tag_suffix)" | insert base_tag $ver
               })
           let combined = ($base | append $layered)
-          $"base_matrix=({include: $base} | to json -r)" | save --append $env.GITHUB_OUTPUT
-          $"layered_matrix=({include: $layered} | to json -r)" | save --append $env.GITHUB_OUTPUT
-          $"matrix_config=({include: $combined} | to json -r)" | save --append $env.GITHUB_OUTPUT
+          $"base_matrix=({include: $base} | to json -r)(char eol)" | save --append $env.GITHUB_OUTPUT
+          $"layered_matrix=({include: $layered} | to json -r)(char eol)" | save --append $env.GITHUB_OUTPUT
+          $"matrix_config=({include: $combined} | to json -r)(char eol)" | save --append $env.GITHUB_OUTPUT
           '
   build:
     needs: prepare


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Dockerhub release workflow is failing due to the matrix strategy json being messed up. GITHUB_OUTPUT should be newline deliminated k=v pairs but we are currently writing w/o a newline so it sees one long non-json line.

## What is the new behavior?

The fix is by having newlines separate each output definition.

## Additional context

See failed run: https://github.com/supabase/postgres/actions/runs/30275880815