### PR TITLE
fix(ansible): skip zswap params the kernel does not expose

### DIFF
--- a/ansible/tasks/setup-tuned.yml
+++ b/ansible/tasks/setup-tuned.yml
@@ -215,7 +215,9 @@
 
         - name: 'tuned - Configure and enable zswap'  # noqa: name[casing]
           ansible.builtin.shell:
-            cmd: "echo {{ zswap_item['value'] }}  > /sys/module/zswap/parameters/{{ zswap_item['param'] }}"
+            # Kernels >= 6.18 dropped some zswap params (e.g. zpool, since zsmalloc
+            # is the only remaining backend); skip params the kernel doesn't expose.
+            cmd: "[ ! -w /sys/module/zswap/parameters/{{ zswap_item['param'] }} ] || echo {{ zswap_item['value'] }} > /sys/module/zswap/parameters/{{ zswap_item['param'] }}"
           changed_when: true
           loop:
             - param: 'compressor'


### PR DESCRIPTION
## What

One-line guard in `setup-tuned.yml`: only write a zswap sysfs param if the kernel exposes it as writable.

## Why

All AMI builds (Release AMI Nix and PR `run-testinfra / test-ami-nix`, every matrix combo) fail in stage 2 since 2026-07-27:

```
/bin/sh: 1: cannot create /sys/module/zswap/parameters/zpool: Permission denied
```

Stage 1 installs the latest `linux-image-aws` from noble-updates at build time. Between the last green run (Jul 24, [30112106381](https://github.com/supabase/postgres/actions/runs/30112106381), kernel 6.17.0-1019-aws) and Jul 27 ([30278977963](https://github.com/supabase/postgres/actions/runs/30278977963), kernel 7.0.0-1009-aws) noble-updates crossed kernel 6.18, which removed zswap's `zpool` param — zsmalloc is now the only backend. The write fails even as root (not a `become` issue: play-level `become: yes` covers the task, and the other three params write fine).

Skipping `zpool` on new kernels loses nothing (zsmalloc is the default and only backend); on older kernels the param file is writable, so behavior is unchanged.

Fixes [PSQL-1548](https://linear.app/supabase/issue/PSQL-1548/ami-builds-broken-kernel-70-removed-zswap-zpool-param-setup-tunedyml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)