### PR TITLE
fix(ansible): drop no-op zpool item and filter

### DIFF
--- a/ansible/tasks/setup-tuned.yml
+++ b/ansible/tasks/setup-tuned.yml
@@ -215,17 +215,13 @@
 
         - name: 'tuned - Configure and enable zswap'  # noqa: name[casing]
           ansible.builtin.shell:
-            # Kernels >= 6.18 dropped some zswap params (e.g. zpool, since zsmalloc
-            # is the only remaining backend); skip params the kernel doesn't expose.
-            cmd: "[ ! -w /sys/module/zswap/parameters/{{ zswap_item['param'] }} ] || echo {{ zswap_item['value'] }} > /sys/module/zswap/parameters/{{ zswap_item['param'] }}"
+            cmd: "echo {{ zswap_item['value'] }}  > /sys/module/zswap/parameters/{{ zswap_item['param'] }}"
           changed_when: true
           loop:
             - param: 'compressor'
               value: 'zstd'
             - param: 'max_pool_percent'
               value: '10'
-            - param: 'zpool'
-              value: 'zsmalloc'
             - param: 'enabled'
               value: 'Y'
           loop_control:


### PR DESCRIPTION
## What

Drop the `zpool: zsmalloc` loop item entirely — no guard needed.

## Why

@brainrake  raised in https://github.com/supabase/postgres/pull/2321#issuecomment-5104368893 if the default already matches the value we set, we should remove the param rather than conditionally skip it.

Confirmed: zsmalloc has been zswap's default allocator since kernel 6.3 ([patch](https://patchew.org/linux/20230908235115.2943486-1-nphamcs@gmail.com/), Sept 2023). Ubuntu noble has always shipped >= 6.8, so `echo zsmalloc > .../parameters/zpool` was a no-op.

Related: PSQL-1548