### PR TITLE
feat(ansible): delegate extension version handling to site-extensions-update

### DIFF
--- a/ansible/files/postgres_prestart.sh.j2
+++ b/ansible/files/postgres_prestart.sh.j2
@@ -40,9 +40,9 @@ handle_extension_versions() {
     fi
 
     if site-extensions-update "$extensions_file"; then
-        log "extensions: profile updated"
+        log "extensions: env updated"
     else
-        log "extensions: update failed, continuing with existing profile"
+        log "extensions: update failed, continuing with existing env"
     fi
 }
 

--- a/ansible/files/postgres_prestart.sh.j2
+++ b/ansible/files/postgres_prestart.sh.j2
@@ -32,78 +32,18 @@ update_orioledb_buffers() {
    fi
 }
 
-check_extensions_file() {
+handle_extension_versions() {
     local extensions_file="/etc/adminapi/pg-extensions.json"
-    if [ ! -f "$extensions_file" ]; then
-        log "extensions: No extensions file found, skipping extensions versions check"
-        return 0 #if file not found, skip
-    fi
     if [ ! -r "$extensions_file" ]; then
-        log "extensions: Cannot read extensions file"
-        return 1 #a true error, we should be able to read file
-    fi
-    return 0
-}
-
-switch_extension_version() {
-    local extension_name="$1"
-    local version="$2"
-    
-    # Use BIN_PATH environment variable or default to /var/lib/postgresql/.nix-profile
-    : ${BIN_PATH:="/var/lib/postgresql/.nix-profile"}
-    
-    local switch_script="$BIN_PATH/bin/switch_${extension_name}_version"
-
-    if [ ! -x "$switch_script" ]; then
-        log "$extension_name: No version switch script available at $switch_script, skipping"
+        log "extensions: no manifest at $extensions_file, skipping"
         return 0
     fi
 
-    log "$extension_name: Switching to version $version"
-    # Run directly as root since we're already running as root
-    "$switch_script" "$version"
-    local exit_code=$?
-    if [ $exit_code -eq 0 ]; then
-        log "$extension_name: Version switch completed successfully"
+    if site-extensions-update "$extensions_file"; then
+        log "extensions: profile updated"
     else
-        log "$extension_name: Version switch failed with exit code $exit_code"
+        log "extensions: update failed, continuing with existing profile"
     fi
-    return $exit_code
-}
-
-handle_extension_versions() {
-    if ! check_extensions_file; then
-        return
-    fi
-
-    local extensions_file="/etc/adminapi/pg-extensions.json"
-    
-    # Get all extension names from the JSON file
-    local extensions
-    extensions=$(jq -r 'keys[]' "$extensions_file" 2>/dev/null)
-    
-    if [ -z "$extensions" ]; then
-        log "extensions: No extensions found in configuration"
-        return
-    fi
-    
-    # Iterate through each extension
-    while IFS= read -r extension_name; do
-        # Get the version for this extension
-        local version
-        version=$(jq -r --arg ext "$extension_name" '.[$ext] // empty' "$extensions_file")
-        
-        if [ -z "$version" ]; then
-            log "$extension_name: No version specified, skipping"
-            continue
-        fi
-                
-        log "$extension_name: Found version $version in extensions file"
-        
-        # Don't fail if version switch fails - just log and continue
-        switch_extension_version "$extension_name" "$version" || log "$extension_name: Version switch failed but continuing"
-        
-    done <<< "$extensions"
 }
 
 main() {

--- a/ansible/files/postgres_prestart.sh.j2
+++ b/ansible/files/postgres_prestart.sh.j2
@@ -40,9 +40,9 @@ handle_extension_versions() {
     fi
 
     if site-extensions-update "$extensions_file"; then
-        log "extensions: env updated"
+        log "extensions: profile updated"
     else
-        log "extensions: update failed, continuing with existing env"
+        log "extensions: update failed, profile unchanged"
     fi
 }
 

--- a/ansible/files/postgres_prestart.sh.j2
+++ b/ansible/files/postgres_prestart.sh.j2
@@ -13,7 +13,7 @@ handle_extension_versions() {
         return 0
     fi
 
-    if site-extensions-update "$extensions_file"; then
+    if update-site-extensions "$extensions_file"; then
         log "extensions: profile updated"
     else
         log "extensions: update failed, profile unchanged"

--- a/ansible/files/postgres_prestart.sh.j2
+++ b/ansible/files/postgres_prestart.sh.j2
@@ -14,9 +14,9 @@ handle_extension_versions() {
     fi
 
     if site-extensions-update "$extensions_file"; then
-        log "extensions: profile updated"
+        log "extensions: env updated"
     else
-        log "extensions: update failed, continuing with existing profile"
+        log "extensions: update failed, continuing with existing env"
     fi
 }
 

--- a/ansible/files/postgres_prestart.sh.j2
+++ b/ansible/files/postgres_prestart.sh.j2
@@ -14,9 +14,9 @@ handle_extension_versions() {
     fi
 
     if site-extensions-update "$extensions_file"; then
-        log "extensions: env updated"
+        log "extensions: profile updated"
     else
-        log "extensions: update failed, continuing with existing env"
+        log "extensions: update failed, profile unchanged"
     fi
 }
 

--- a/ansible/files/postgres_prestart.sh.j2
+++ b/ansible/files/postgres_prestart.sh.j2
@@ -6,78 +6,18 @@ log() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"
 }
 
-check_extensions_file() {
+handle_extension_versions() {
     local extensions_file="/etc/adminapi/pg-extensions.json"
-    if [ ! -f "$extensions_file" ]; then
-        log "extensions: No extensions file found, skipping extensions versions check"
-        return 0 #if file not found, skip
-    fi
     if [ ! -r "$extensions_file" ]; then
-        log "extensions: Cannot read extensions file"
-        return 1 #a true error, we should be able to read file
-    fi
-    return 0
-}
-
-switch_extension_version() {
-    local extension_name="$1"
-    local version="$2"
-    
-    # Use BIN_PATH environment variable or default to /var/lib/postgresql/.nix-profile
-    : ${BIN_PATH:="/var/lib/postgresql/.nix-profile"}
-    
-    local switch_script="$BIN_PATH/bin/switch_${extension_name}_version"
-
-    if [ ! -x "$switch_script" ]; then
-        log "$extension_name: No version switch script available at $switch_script, skipping"
+        log "extensions: no manifest at $extensions_file, skipping"
         return 0
     fi
 
-    log "$extension_name: Switching to version $version"
-    # Run directly as root since we're already running as root
-    "$switch_script" "$version"
-    local exit_code=$?
-    if [ $exit_code -eq 0 ]; then
-        log "$extension_name: Version switch completed successfully"
+    if site-extensions-update "$extensions_file"; then
+        log "extensions: profile updated"
     else
-        log "$extension_name: Version switch failed with exit code $exit_code"
+        log "extensions: update failed, continuing with existing profile"
     fi
-    return $exit_code
-}
-
-handle_extension_versions() {
-    if ! check_extensions_file; then
-        return
-    fi
-
-    local extensions_file="/etc/adminapi/pg-extensions.json"
-    
-    # Get all extension names from the JSON file
-    local extensions
-    extensions=$(jq -r 'keys[]' "$extensions_file" 2>/dev/null)
-    
-    if [ -z "$extensions" ]; then
-        log "extensions: No extensions found in configuration"
-        return
-    fi
-    
-    # Iterate through each extension
-    while IFS= read -r extension_name; do
-        # Get the version for this extension
-        local version
-        version=$(jq -r --arg ext "$extension_name" '.[$ext] // empty' "$extensions_file")
-        
-        if [ -z "$version" ]; then
-            log "$extension_name: No version specified, skipping"
-            continue
-        fi
-                
-        log "$extension_name: Found version $version in extensions file"
-        
-        # Don't fail if version switch fails - just log and continue
-        switch_extension_version "$extension_name" "$version" || log "$extension_name: Version switch failed but continuing"
-        
-    done <<< "$extensions"
 }
 
 main() {

--- a/ansible/files/postgresql_config/postgresql.service
+++ b/ansible/files/postgresql_config/postgresql.service
@@ -10,7 +10,7 @@ After=database-optimizations.service
 Type=notify
 User=postgres
 ExecStart=/usr/lib/postgresql/bin/postgres -D /etc/postgresql
-ExecStartPre=+/usr/local/bin/postgres_prestart.sh
+ExecStartPre=-+/usr/local/bin/postgres_prestart.sh
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=mixed
 KillSignal=SIGINT
@@ -22,7 +22,7 @@ OOMScoreAdjust=-1000
 EnvironmentFile=-/etc/environment.d/postgresql.env
 LimitNOFILE=16384
 {% if supabase_internal is defined %}
-ReadOnlyPaths=/etc
+ReadOnlyPaths=/etc /usr/local
 InaccessiblePaths=/root -/var/lib/supabase -/var/lib/supabase-admin-agent -/var/cache/supabase-admin-agent -/opt/saltstack -/etc/salt
 AppArmorProfile=-sbpostgres
 {% endif %}


### PR DESCRIPTION
DO NOT MERGE - WIP. Depends on #2317 and #2283.

Part of [PSQL-1530](https://linear.app/supabase/issue/PSQL-1530/use-profiles-for-multi-version-extensions).

`postgres_prestart.sh`'s `handle_extension_versions()` now delegates to `site-extensions-update` instead of looping `switch_<ext>_version` per extension.

Also fixes drift in `postgresql.service`: it had fallen out of sync with salt's live copy of the unit (`ExecStartPre` missing the `-` ignore-failure prefix, `ReadOnlyPaths` missing `/usr/local`). Both now match what's actually deployed on the fleet.

Also blocked on: Postgres's `dynamic_library_path`/`extension_control_path` needs the `site-extensions` profile path added (drafted in the PSQL-1530 issue's migration plan, not yet implemented).