### PR TITLE
ci: resolve package install sha from a flake input

### DIFF
--- a/.github/actions/build-ami/action.yml
+++ b/.github/actions/build-ami/action.yml
@@ -14,6 +14,9 @@ inputs:
   git_sha:
     description: 'Git SHA for this build'
     required: true
+  packages_git_sha:
+    description: 'Git SHA to install packages from'
+    required: true
   instance_type:
     description: 'EC2 instance type for the build'
     required: true
@@ -101,7 +104,7 @@ runs:
         nix run .#build-ami -- stage2 ${{ inputs.arch }} \
           -var "ami_name=${{ inputs.ami_name_prefix }}" \
           -var "git-head-version=${{ inputs.git_sha }}" \
-          -var "git_sha=${{ inputs.git_sha }}" \
+          -var "git_sha=${{ inputs.packages_git_sha }}" \
           -var "instance_type=${{ inputs.instance_type }}" \
           -var "packer-execution-id=$PACKER_EXECUTION_ID" \
           -var "postgres_major_version=${{ inputs.postgres_version }}" \

--- a/.github/actions/resolve-git-sha/action.yml
+++ b/.github/actions/resolve-git-sha/action.yml
@@ -1,0 +1,22 @@
+name: Resolve git sha
+description: Resolves the git sha to install packages from, honoring a flake input override
+
+inputs:
+  flake_input:
+    description: 'Flake input name to resolve from flake.lock, if set'
+    required: false
+    default: ''
+
+outputs:
+  sha:
+    description: 'Resolved git sha'
+    value: ${{ steps.resolve.outputs.sha }}
+
+runs:
+  using: composite
+  steps:
+    - id: resolve
+      shell: bash
+      run: |
+        SHA=$(jq -r --arg k "${{ inputs.flake_input }}" 'if $k == "" then empty else (.nodes[$k].locked.rev // empty) end' flake.lock 2>/dev/null || true)
+        echo "sha=${SHA:-${{ github.sha }}}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ami-release-nix.yml
+++ b/.github/workflows/ami-release-nix.yml
@@ -86,6 +86,12 @@ jobs:
           nix-signing-key: ${{ secrets.NIX_SIGN_SECRET_KEY }}
           role-to-assume: ${{ secrets.DEV_AWS_ROLE }}
 
+      - name: Resolve git sha
+        id: resolve-git-sha
+        uses: ./.github/actions/resolve-git-sha
+        with:
+          flake_input: ${{ vars.GIT_SHA_FROM_FLAKE_INPUT }}
+
       - name: Build AMI
         id: build-ami
         uses: ./.github/actions/build-ami
@@ -94,6 +100,7 @@ jobs:
           ami_regions: '["${{ env.AWS_REGION }}"]'
           arch: ${{ matrix.target.arch }}
           git_sha: ${{ github.sha }}
+          packages_git_sha: ${{ steps.resolve-git-sha.outputs.sha }}
           instance_type: ${{ matrix.target.instance_type }}
           postgres_version: ${{ matrix.postgres_version }}
           region: ${{ env.AWS_REGION }}
@@ -122,7 +129,7 @@ jobs:
 
       - name: Create nix flake revision tarball
         run: |
-          GIT_SHA=${{github.sha}}
+          GIT_SHA=${{ steps.resolve-git-sha.outputs.sha }}
 
           mkdir -p "/tmp/pg_upgrade_bin/${POSTGRES_MAJOR_VERSION}"
           echo "$GIT_SHA" >> "/tmp/pg_upgrade_bin/${POSTGRES_MAJOR_VERSION}/nix_flake_version"
@@ -170,7 +177,7 @@ jobs:
 
       - name: Update nix store path catalog
         run: |
-          GIT_SHA="${{ github.sha }}"
+          GIT_SHA="${{ steps.resolve-git-sha.outputs.sha }}"
           SYSTEM=$(nix eval --impure --raw --expr 'builtins.currentSystem')
 
           # Get store path for this build

--- a/.github/workflows/qemu-image-build.yml
+++ b/.github/workflows/qemu-image-build.yml
@@ -67,7 +67,15 @@ jobs:
       - name: Install Nix
         uses: ./.github/actions/nix-install-ephemeral
 
+      - name: Resolve git sha
+        id: resolve-git-sha
+        uses: ./.github/actions/resolve-git-sha
+        with:
+          flake_input: ${{ vars.GIT_SHA_FROM_FLAKE_INPUT }}
+
       - name: Build QEMU artifact
+        env:
+          GIT_SHA: ${{ steps.resolve-git-sha.outputs.sha }}
         run: BUILD_QEMU_IMAGE_HW_VIRT_ONLY=1 nix run .#build-qemu-image "${{ matrix.postgres_version }}" arm64
 
       - name: Grab release version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,9 +61,14 @@ jobs:
           echo "result<<EOF" >> $GITHUB_OUTPUT
           echo "$ARGS" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+      - name: Resolve git sha
+        id: resolve-git-sha
+        uses: ./.github/actions/resolve-git-sha
+        with:
+          flake_input: ${{ vars.GIT_SHA_FROM_FLAKE_INPUT }}
       - name: verify schema.sql is committed
         run: |
-          nix run github:supabase/postgres/${{ github.sha }}#dbmate-tool -- --version ${{ env.PGMAJOR }} --flake-url github:supabase/postgres/${{ github.sha }}
+          nix run github:supabase/postgres/${{ steps.resolve-git-sha.outputs.sha }}#dbmate-tool -- --version ${{ env.PGMAJOR }} --flake-url github:supabase/postgres/${{ steps.resolve-git-sha.outputs.sha }}
           if ! git diff --exit-code --quiet migrations/schema-${{ env.PGMAJOR }}.sql; then
             echo "Detected changes in schema.sql:"
             git diff migrations/schema-${{ env.PGMAJOR }}.sql

--- a/.github/workflows/testinfra-ami-build.yml
+++ b/.github/workflows/testinfra-ami-build.yml
@@ -81,6 +81,12 @@ jobs:
           nix-signing-key: ${{ secrets.NIX_SIGN_SECRET_KEY }}
           role-to-assume: ${{ secrets.DEV_AWS_ROLE }}
 
+      - name: Resolve git sha
+        id: resolve-git-sha
+        uses: ./.github/actions/resolve-git-sha
+        with:
+          flake_input: ${{ vars.GIT_SHA_FROM_FLAKE_INPUT }}
+
       - name: Build AMI
         id: build-ami
         uses: ./.github/actions/build-ami
@@ -89,6 +95,7 @@ jobs:
           ami_regions: '["${{ env.AWS_REGION }}"]'
           arch: ${{ matrix.target.arch }}
           git_sha: ${{ github.sha }}
+          packages_git_sha: ${{ steps.resolve-git-sha.outputs.sha }}
           instance_type: ${{ matrix.target.instance_type }}
           postgres_version: ${{ matrix.postgres_version }}
           region: ${{ env.AWS_REGION }}


### PR DESCRIPTION
Workflows that install nix packages via `github:supabase/postgres/<sha>#pkg` use the run's own commit sha. That breaks when the exact same workflow file runs in a different repo.

Adds a `resolve-git-sha` composite action: if a `GIT_SHA_FROM_FLAKE_INPUT` repo variable names a flake input, resolves that input's pinned rev from `flake.lock`; otherwise falls back to `github.sha` unchanged. Wired into the four workflows that construct these install refs (`ami-release-nix.yml`, `testinfra-ami-build.yml`, `qemu-image-build.yml`, `test.yml`).

`build-ami/action.yml` gets a second input, `packages_git_sha`, kept separate from `git_sha` (AMI identity tag, used for cache lookups, must stay the triggering commit) so the two don't get conflated.

No effect here: the variable is never set in this repo, so every site falls through to `github.sha` exactly as today.