### PR TITLE
fix: Allow test CI pipelines to use old Int CA access. For staging only

### DIFF
--- a/testinfra/test_ami_nix.py
+++ b/testinfra/test_ami_nix.py
@@ -316,7 +316,7 @@ write_files:
 runcmd:
     - 'sudo echo \"pgbouncer\" \"postgres\" >> /etc/pgbouncer/userlist.txt'
     - 'cd /tmp && aws s3 cp --region ap-southeast-1 s3://init-scripts-staging/project/init.sh .'
-    - 'bash init.sh "staging"'
+    - 'USE_LEGACY_INT_CA_SECRET=true bash init.sh "staging"'
     - 'touch /var/lib/init-complete'
     - 'rm -rf /tmp/*'
 users:


### PR DESCRIPTION
## What kind of change does this PR introduce?

As part of [INCDNT-558](https://linear.app/supabase/issue/INCDNT-558/monitor-sentry-error-rates-for-network-restriction-enforcement-over) we have changed how we access the Int CA key used for singing the server certs use by postgres. This is not compat with the test pipelines we have in this repo. We are adding a flag to use the old method for these pipelines only. This is only a tactical solution until a proper CA is introduced.