### PR TITLE
fix(nix): pin cgal to 6.0.2 to unbreak sfcgal/postgis

### DIFF
--- a/nix/overlays/default.nix
+++ b/nix/overlays/default.nix
@@ -1,6 +1,6 @@
 { self, ... }:
 {
-  flake.overlays.default = final: _prev: {
+  flake.overlays.default = final: prev: {
     # NOTE: add any needed overlays here. in theory we could
     # pull them from the overlays/ directory automatically, but we don't
     # want to have an arbitrary order, since it might matter. being
@@ -16,6 +16,15 @@
       ;
 
     xmrig = throw "The xmrig package has been explicitly disabled in this flake.";
+
+    # Hold cgal back to 6.0.2 until nixpkgs bumps sfcgal past 2.2.0 (incompatible with CGAL 6.1+).
+    cgal = prev.cgal.overrideAttrs (_: {
+      version = "6.0.2";
+      src = final.fetchurl {
+        url = "https://github.com/CGAL/cgal/releases/download/v6.0.2/CGAL-6.0.2.tar.xz";
+        sha256 = "sha256-8wxb58JaKj6iS8y6q1z2P6/aY8AnnzTX5/izISgh/tY=";
+      };
+    });
 
     cargo-pgrx = final.callPackage ../cargo-pgrx/default.nix {
       inherit (final) lib;


### PR DESCRIPTION
## Summary
- #2328's nixpkgs bump (25.11pre -> 26.05pre) brings CGAL 6.1, which removes `CGAL::Polygon_mesh_processing::surface_intersection`. nixpkgs' `sfcgal` is still pinned to 2.2.0, which uses that symbol, so `sfcgal` fails to build and cascades into `postgis`.
- Upstream SFCGAL 2.3.0 adds CGAL 6.1/6.2 support, but nixpkgs hasn't bumped `sfcgal` to it yet.
- This adds an overlay pinning `cgal` back to 6.0.2 (last version sfcgal 2.2.0 builds against) until nixpkgs bumps `sfcgal`.
- Based on #2328 since the break only manifests once nixpkgs is actually bumped.

## Test plan
- [x] `pkgs.cgal.version` resolves to `6.0.2` through the flake's actual `overlays.default`
- [x] `pkgs.sfcgal` builds successfully through the same overlay path on the bumped nixpkgs