### PR TITLE
fix(nix): pin cgal to 6.0.2 to unbreak sfcgal/postgis

### DIFF
--- a/nix/overlays/default.nix
+++ b/nix/overlays/default.nix
@@ -1,6 +1,6 @@
 { self, ... }:
 {
-  flake.overlays.default = final: _prev: {
+  flake.overlays.default = final: prev: {
     # NOTE: add any needed overlays here. in theory we could
     # pull them from the overlays/ directory automatically, but we don't
     # want to have an arbitrary order, since it might matter. being
@@ -16,6 +16,15 @@
       ;
 
     xmrig = throw "The xmrig package has been explicitly disabled in this flake.";
+
+    # Hold cgal back to 6.0.2 until nixpkgs bumps sfcgal past 2.2.0 (incompatible with CGAL 6.1+).
+    cgal = prev.cgal.overrideAttrs (_: {
+      version = "6.0.2";
+      src = final.fetchurl {
+        url = "https://github.com/CGAL/cgal/releases/download/v6.0.2/CGAL-6.0.2.tar.xz";
+        sha256 = "sha256-8wxb58JaKj6iS8y6q1z2P6/aY8AnnzTX5/izISgh/tY=";
+      };
+    });
 
     cargo-pgrx = final.callPackage ../cargo-pgrx/default.nix {
       inherit (final) lib;


### PR DESCRIPTION
## Summary
- #2328's nixpkgs bump (25.11pre -> 26.05pre) brings CGAL 6.1, which removes `CGAL::Polygon_mesh_processing::surface_intersection`. nixpkgs' `sfcgal` is still pinned to 2.2.0, which uses that symbol, so `sfcgal` fails to build and cascades into `postgis`.
- Upstream SFCGAL 2.3.0 adds CGAL 6.1/6.2 support, but nixpkgs hasn't bumped `sfcgal` to it yet.
- This adds an overlay pinning `cgal` back to 6.0.2 (last version sfcgal 2.2.0 builds against) until nixpkgs bumps `sfcgal`.
- Based on develop rather than #2328: on develop's current nixpkgs, `cgal` already resolves to 6.0.2, so this override produces the exact same `.drv` as unpatched nixpkgs there (verified) — a true no-op today, and it just keeps working once #2328's nixpkgs bump lands.

## Test plan
- [x] On develop's nixpkgs: overridden `cgal` derivation produces an identical `.drv` path to unpatched nixpkgs (no-op)
- [x] On #2328's bumped nixpkgs: `pkgs.cgal.version` resolves to `6.0.2` through the flake's actual `overlays.default`, and `pkgs.sfcgal` builds successfully through that same overlay path