### PR TITLE
[validation only] ci: bump test-portability runners to Ubuntu 26.04

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -89,9 +89,9 @@ jobs:
         include:
           - runner: macos-14
             arch: darwin-arm64
-          - runner: ubuntu-latest
+          - runner: ubuntu-26.04
             arch: linux-x64
-          - runner: ubuntu-24.04-arm
+          - runner: ubuntu-26.04-arm
             arch: linux-arm64
     steps:
       - name: Download artifact


### PR DESCRIPTION
Temporary validation PR targeting #2328's branch to confirm the runner bump actually fixes the \`GLIBC_2.42' not found\` failure with real bumped-nixpkgs artifacts. Will be closed in favor of a develop-based PR once confirmed green, same pattern as #2331 -> #2332 for the cgal fix.