### PR TITLE
ci: bump test-portability runners to Ubuntu 26.04

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -89,9 +89,9 @@ jobs:
         include:
           - runner: macos-14
             arch: darwin-arm64
-          - runner: ubuntu-latest
+          - runner: ubuntu-26.04
             arch: linux-x64
-          - runner: ubuntu-24.04-arm
+          - runner: ubuntu-26.04-arm
             arch: linux-arm64
     steps:
       - name: Download artifact


### PR DESCRIPTION
## Summary
- #2328's nixpkgs bump moves the `nixpkgs_2` lock node (what `root.inputs.nixpkgs` actually resolves to) to a pin whose `pkgs.glibc` is 2.42, up from 2.40. The portable CLI bundle ([nix/packages/postgres-portable.nix](nix/packages/postgres-portable.nix)) deliberately excludes glibc/ld-linux/etc. from the bundle and relies on the host's own glibc at runtime — so this broke `linux-arm64 without Nix` / `linux-x64 without Nix` with `GLIBC_2.42' not found`.
- Considered vendoring glibc into the bundle instead, but rejected it: nixpkgs' glibc bakes in nix-store paths for NSS modules and gconv/locale data that the existing portability checks (dynamic-section-only `readelf -d`) wouldn't catch — trading one loud failure for a class of silent ones.
- The correct fix is restoring the invariant the bundle already assumes: host glibc ≥ nixpkgs' glibc. Ubuntu 26.04 LTS ships glibc 2.43 and GitHub Actions now has `ubuntu-26.04`/`ubuntu-26.04-arm` runner labels.
- Only bumped the `test-portability` job's matrix (the one that runs bundled binaries against host glibc) — `build-native` builds everything inside Nix's own sandbox, so host glibc doesn't matter there.

## Test plan
- [x] Validated against #2328's actual bumped nixpkgs via a temporary PR (#2333, now closed): `linux-arm64 without Nix` and `linux-x64 without Nix` both passed on `ubuntu-26.04`/`ubuntu-26.04-arm`