### PR TITLE
fix(multigres): remove dangling wal-g include from postgresql.conf

### DIFF
--- a/Dockerfile-multigres
+++ b/Dockerfile-multigres
@@ -101,11 +101,11 @@ COPY --chmod=0755 docker/pgctld/pgctld-layered.sh /usr/local/bin/pgctld
 # config from postgresql.conf.tmpl and passes it directly to PostgreSQL, so the
 # supabase base config (including wal-g and data_directory settings) is never loaded.
 
-# wal-g is not used in Multigres (pgbackrest handles backups); remove inherited files.
-RUN rm -f \
-    /etc/postgresql-custom/wal-g.conf \
-    /home/postgres/wal_fetch.sh \
-    /root/wal_change_ownership.sh
+# wal-g is not used in Multigres (pgbackrest handles backups); remove inherited files
+# and delete the now-dangling include line so /etc/postgresql/postgresql.conf stays valid
+# if it is ever loaded directly instead of pgctld's generated config.
+RUN sed -i -e "/^include = '\/etc\/postgresql-custom\/wal-g.conf'/d" /etc/postgresql/postgresql.conf && \
+    rm -f /etc/postgresql-custom/wal-g.conf /home/postgres/wal_fetch.sh /root/wal_change_ownership.sh
 
 # pgctld uses pooler-dir for pgBackRest config, unix sockets, and state files.
 RUN mkdir -p /var/lib/pgctld && chown postgres:postgres /var/lib/pgctld

--- a/nix/packages/docker-image-test.nix
+++ b/nix/packages/docker-image-test.nix
@@ -343,6 +343,22 @@ writeShellApplication {
         fi
         log_info "  ✓ /usr/local/bin/pgctld is a wrapper script"
 
+        # 3.5. wal-g must be fully removed: no include line left dangling in the
+        # static /etc/postgresql/postgresql.conf. (Currently, pgctld doesn't load
+        # this file today, but if it's ever loaded directly it should not error out.
+        # See Dockerfile-multigres.) None of the inherited wal-g files should remain.
+        if docker exec "$container" sh -c "grep -q 'wal-g.conf' /etc/postgresql/postgresql.conf"; then
+            log_error "  /etc/postgresql/postgresql.conf still references wal-g.conf"
+            exit 1
+        fi
+        for f in /etc/postgresql-custom/wal-g.conf /home/postgres/wal_fetch.sh /root/wal_change_ownership.sh; do
+            if docker exec "$container" test -e "$f"; then
+                log_error "  $f should have been removed from the multigres image"
+                exit 1
+            fi
+        done
+        log_info "  ✓ wal-g fully removed (no dangling include, no inherited files)"
+
         # 4. pgctld init: initializes PGDATA and runs SQL init scripts (via wrapper's
         #    --pg-initdb-sql-dirs). Uses pooler-dir for socket dir and pgBackRest config.
         local init_out init_rc=0


### PR DESCRIPTION
## Summary
- Dockerfile-multigres removed `/etc/postgresql-custom/wal-g.conf` and the wal-g helper scripts but left the `include = '/etc/postgresql-custom/wal-g.conf'` line in `/etc/postgresql/postgresql.conf` pointing at the now-deleted file. pgctld renders its own config and doesn't load this file today, but it should stay valid if it's ever loaded directly.
- Add a `sed` step to strip the dangling include line alongside the existing file removal.
- Add a docker-image-test check (`verify_pgctld_integration`) confirming wal-g is fully removed from multigres images: no dangling include, and none of the inherited wal-g files remain.

Fixes MUL-1207.

## Test plan
- [x] Traced that `Dockerfile-supabase` uncomments the include line to exactly `include = '/etc/postgresql-custom/wal-g.conf'` with no trailing content, confirming the `sed` pattern matches.
- [x] `bash -n` and `shellcheck` pass on the new test snippet.
- [ ] CI: `docker-image-test` workflow build + test for `multigres-17`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)