### PR TITLE
fix(ami): bump packer build volume from 16GB to 20GB (WIP, doesn't fix root cause)

### DIFF
--- a/amazon-amd64-nix.pkr.hcl
+++ b/amazon-amd64-nix.pkr.hcl
@@ -144,7 +144,7 @@ source "amazon-ebssurrogate" "source" {
   launch_block_device_mappings {
     device_name           = "/dev/${var.build-vol}"
     delete_on_termination = true
-    volume_size           = 16
+    volume_size           = 20
     volume_type           = "gp3"
     omit_from_artifact    = true
   }

--- a/amazon-amd64-nix.pkr.hcl
+++ b/amazon-amd64-nix.pkr.hcl
@@ -124,6 +124,20 @@ source "amazon-ebssurrogate" "source" {
   }
 
   ena_support = true
+
+  # Builder instance's own boot root (from the source Ubuntu AMI, device
+  # /dev/sda1) - separate from the surrogate root (/dev/xvdf) being
+  # assembled below. Ansible/apt provisioning runs directly on this disk
+  # before the chroot into /mnt, and the default Ubuntu AMI root size was
+  # too small, causing "No space left on device" failures during
+  # provisioning (reproduced independent of the surrogate/build-vol sizes).
+  launch_block_device_mappings {
+    device_name           = "/dev/sda1"
+    delete_on_termination = true
+    volume_size           = 16
+    volume_type           = "gp3"
+  }
+
   launch_block_device_mappings {
     device_name           = "/dev/xvdf"
     delete_on_termination = true

--- a/amazon-amd64-nix.pkr.hcl
+++ b/amazon-amd64-nix.pkr.hcl
@@ -124,20 +124,6 @@ source "amazon-ebssurrogate" "source" {
   }
 
   ena_support = true
-
-  # Builder instance's own boot root (from the source Ubuntu AMI, device
-  # /dev/sda1) - separate from the surrogate root (/dev/xvdf) being
-  # assembled below. Ansible/apt provisioning runs directly on this disk
-  # before the chroot into /mnt, and the default Ubuntu AMI root size was
-  # too small, causing "No space left on device" failures during
-  # provisioning (reproduced independent of the surrogate/build-vol sizes).
-  launch_block_device_mappings {
-    device_name           = "/dev/sda1"
-    delete_on_termination = true
-    volume_size           = 16
-    volume_type           = "gp3"
-  }
-
   launch_block_device_mappings {
     device_name           = "/dev/xvdf"
     delete_on_termination = true

--- a/amazon-arm64-nix.pkr.hcl
+++ b/amazon-arm64-nix.pkr.hcl
@@ -144,7 +144,7 @@ source "amazon-ebssurrogate" "source" {
   launch_block_device_mappings {
     device_name           = "/dev/${var.build-vol}"
     delete_on_termination = true
-    volume_size           = 16
+    volume_size           = 20
     volume_type           = "gp3"
     omit_from_artifact    = true
   }

--- a/amazon-arm64-nix.pkr.hcl
+++ b/amazon-arm64-nix.pkr.hcl
@@ -124,6 +124,20 @@ source "amazon-ebssurrogate" "source" {
   }
 
   ena_support = true
+
+  # Builder instance's own boot root (from the source Ubuntu AMI, device
+  # /dev/sda1) - separate from the surrogate root (/dev/xvdf) being
+  # assembled below. Ansible/apt provisioning runs directly on this disk
+  # before the chroot into /mnt, and the default Ubuntu AMI root size was
+  # too small, causing "No space left on device" failures during
+  # provisioning (reproduced independent of the surrogate/build-vol sizes).
+  launch_block_device_mappings {
+    device_name           = "/dev/sda1"
+    delete_on_termination = true
+    volume_size           = 16
+    volume_type           = "gp3"
+  }
+
   launch_block_device_mappings {
     device_name           = "/dev/xvdf"
     delete_on_termination = true

--- a/amazon-arm64-nix.pkr.hcl
+++ b/amazon-arm64-nix.pkr.hcl
@@ -124,20 +124,6 @@ source "amazon-ebssurrogate" "source" {
   }
 
   ena_support = true
-
-  # Builder instance's own boot root (from the source Ubuntu AMI, device
-  # /dev/sda1) - separate from the surrogate root (/dev/xvdf) being
-  # assembled below. Ansible/apt provisioning runs directly on this disk
-  # before the chroot into /mnt, and the default Ubuntu AMI root size was
-  # too small, causing "No space left on device" failures during
-  # provisioning (reproduced independent of the surrogate/build-vol sizes).
-  launch_block_device_mappings {
-    device_name           = "/dev/sda1"
-    delete_on_termination = true
-    volume_size           = 16
-    volume_type           = "gp3"
-  }
-
   launch_block_device_mappings {
     device_name           = "/dev/xvdf"
     delete_on_termination = true


### PR DESCRIPTION
## Summary
- \`test-ami-nix (15, amd64/arm64)\` intermittently fails with \`OSError: [Errno 28] No space left on device\`, reproduced on two unrelated PRs (#2329, #2332).
- **Attempt 1**: bumped \`/dev/xvdc\` (scratch build-vol) 16GB->20GB. Did not fix it - log analysis showed the actual ENOSPC happens inside ansible's own Python logging module flushing \`/tmp/ansible.log\`, which lives on a different disk than xvdc/xvdf/xvdh.
- **Attempt 2** (reverted): added an explicit \`/dev/sda1\` mapping sized to 16GB, theorizing it was the builder instance's own separate boot root. This was **wrong and caused a regression** - on this HVM AMI, \`/dev/sda1\` aliases to the same device as \`ami_root_device\`'s \`/dev/xvda\`, so it grew the *output* AMI's root snapshot to 16GB, breaking test-ami-nix for every Postgres version (including 17/orioledb-17, previously passing) since the test harness launches instances with a hardcoded 8GB root that can no longer satisfy that snapshot.
- Reverted attempt 2. Currently only the harmless-but-ineffective xvdc bump remains.

## Status: root cause still open
Need to identify which actual EBS volume/device \`/tmp\` (on the builder instance, pre-chroot) resolves to, without touching whatever device the final AMI's root snapshot is derived from. Suggest not merging until that's nailed down - happy to hand off details.

## Test plan
- [ ] \`test-ami-nix (15, amd64)\` and \`(15, arm64)\` pass
- [ ] \`test-ami-nix (17, ...)\` and \`(orioledb-17, ...)\` still pass (no regression)