### PR TITLE
[validation only] Go pin removal on top of AMI volume bump

### DIFF
--- a/nix/packages/gatekeeper.nix
+++ b/nix/packages/gatekeeper.nix
@@ -1,10 +1,10 @@
 { pkgs, ... }:
 let
 
-  go124 = pkgs.go_1_24;
-  buildGoModule124 = pkgs.buildGoModule.override { go = go124; };
+  go125 = pkgs.go_1_25;
+  buildGoModule125 = pkgs.buildGoModule.override { go = go125; };
 
-  upstream-gatekeeper = buildGoModule124 {
+  upstream-gatekeeper = buildGoModule125 {
     pname = "jit-db-gatekeeper";
     version = "1.0.5";
     src = pkgs.fetchFromGitHub {

--- a/nix/packages/gatekeeper.nix
+++ b/nix/packages/gatekeeper.nix
@@ -1,10 +1,6 @@
 { pkgs, ... }:
 let
-
-  go125 = pkgs.go_1_25;
-  buildGoModule125 = pkgs.buildGoModule.override { go = go125; };
-
-  upstream-gatekeeper = buildGoModule125 {
+  upstream-gatekeeper = pkgs.buildGoModule {
     pname = "jit-db-gatekeeper";
     version = "1.0.5";
     src = pkgs.fetchFromGitHub {

--- a/nix/packages/supascan.nix
+++ b/nix/packages/supascan.nix
@@ -1,9 +1,5 @@
 { pkgs, lib, ... }:
 let
-  # Use Go 1.25 for the scanner which requires Go >= 1.23.2
-  go125 = pkgs.go_1_25;
-  buildGoModule125 = pkgs.buildGoModule.override { go = go125; };
-
   # Package GOSS - server validation spec runner
   goss = pkgs.buildGoModule rec {
     pname = "goss";
@@ -28,7 +24,7 @@ let
   };
 
   # Main supascan CLI - consolidated tool for baseline generation and validation
-  supascan = buildGoModule125 {
+  supascan = pkgs.buildGoModule {
     pname = "supascan";
     version = "1.0.0";
 

--- a/nix/packages/supascan.nix
+++ b/nix/packages/supascan.nix
@@ -1,8 +1,8 @@
 { pkgs, lib, ... }:
 let
-  # Use Go 1.24 for the scanner which requires Go >= 1.23.2
-  go124 = pkgs.go_1_24;
-  buildGoModule124 = pkgs.buildGoModule.override { go = go124; };
+  # Use Go 1.25 for the scanner which requires Go >= 1.23.2
+  go125 = pkgs.go_1_25;
+  buildGoModule125 = pkgs.buildGoModule.override { go = go125; };
 
   # Package GOSS - server validation spec runner
   goss = pkgs.buildGoModule rec {
@@ -28,7 +28,7 @@ let
   };
 
   # Main supascan CLI - consolidated tool for baseline generation and validation
-  supascan = buildGoModule124 {
+  supascan = buildGoModule125 {
     pname = "supascan";
     version = "1.0.0";
 


### PR DESCRIPTION
Temporary validation PR: #2329's Go pin removal rebased onto #2339's 20GB build volume bump, to confirm test-ami-nix (15, amd64/arm64) passes with the larger volume. Will close once confirmed.