### PR TITLE
fix(multigres): stop base config data_directory from overriding the pooler data dir

### DIFF
--- a/Dockerfile-multigres
+++ b/Dockerfile-multigres
@@ -97,14 +97,22 @@ COPY docker/pgctld/multigres-migrations/ /docker-entrypoint-initdb.d/migrations/
 # k8s manifests and local provisioner commands work without extra flags
 COPY --chmod=0755 docker/pgctld/pgctld-layered.sh /usr/local/bin/pgctld
 
-# /etc/postgresql/postgresql.conf is not modified here: pgctld renders its own
-# config from postgresql.conf.tmpl and passes it directly to PostgreSQL, so the
-# supabase base config (including wal-g and data_directory settings) is never loaded.
-
-# wal-g is not used in Multigres (pgbackrest handles backups); remove inherited files
-# and delete the now-dangling include line so /etc/postgresql/postgresql.conf stays valid
-# if it is ever loaded directly instead of pgctld's generated config.
-RUN sed -i -e "/^include = '\/etc\/postgresql-custom\/wal-g.conf'/d" /etc/postgresql/postgresql.conf && \
+# The supabase base config /etc/postgresql/postgresql.conf IS loaded in Multigres:
+# the operator's --pg-initdb-extra-conf appends `include = '/etc/postgresql/postgresql.conf'`
+# onto pgctld's generated config. It therefore must not carry settings that assume the
+# base image's `postgres -D /etc/postgresql` layout, so we neutralize two here:
+#
+#   - data_directory = '/var/lib/postgresql/data' would override pgctld's -D/PGDATA and
+#     redirect PostgreSQL off the freshly-initdb'd <pooler-dir>/pg_data to the base image's
+#     empty dir, which fails startup ("data directory ... has invalid permissions") and
+#     leaves the pooler stuck retrying the first backup forever. pgctld pins the data dir
+#     via -D, so comment it out (matching the pre-layered image, which shipped it disabled).
+#   - the wal-g include is dangling (wal-g is unused in Multigres; pgbackrest handles
+#     backups), so delete it and its now-orphaned files.
+RUN sed -i \
+        -e "s|^data_directory = '/var/lib/postgresql/data'|#data_directory = '/var/lib/postgresql/data'|" \
+        -e "/^include = '\/etc\/postgresql-custom\/wal-g.conf'/d" \
+        /etc/postgresql/postgresql.conf && \
     rm -f /etc/postgresql-custom/wal-g.conf /home/postgres/wal_fetch.sh /root/wal_change_ownership.sh
 
 # pgctld uses pooler-dir for pgBackRest config, unix sockets, and state files.


### PR DESCRIPTION
## Problem

The Multigres pooler never bootstraps. pgctld's transient PostgreSQL (started during `InitDataDir`) dies at startup and never becomes ready, so the first-backup bootstrap retries forever (observed 791× over ~8h in one pod) and the pooler socket never appears — surfacing downstream as `MonitorPostgres: failed to create first backup` and `failed to connect to Unix socket /var/lib/pooler/pg_sockets/.s.PGSQL.5432`.

The pgctld logs only show the swallowed `transient PostgreSQL did not become ready after 30 seconds`. The real reason is in `$PGDATA/setup.log`:

```
FATAL:  data directory "/var/lib/postgresql/data" has invalid permissions
DETAIL:  Permissions should be u=rwx (0700) or u=rwx,g=rx (0750).
```

## Cause

pgctld runs `initdb` at `<pooler-dir>/pg_data` and pins the data directory via `-D`/`PGDATA`. But the operator appends `include = '/etc/postgresql/postgresql.conf'` onto pgctld's generated config (via `POSTGRES_INITDB_EXTRA_CONF`). In the layered image that base config has an **active** `data_directory = '/var/lib/postgresql/data'`, and because the `include` is last it wins — redirecting PostgreSQL off the freshly-initdb'd cluster onto the base image's empty, wrong-permission `/var/lib/postgresql/data`, which fails startup.

The pre-layered (non-layered) image shipped `data_directory` commented out, which is why it worked; the layered rewrite left it active. A comment in `Dockerfile-multigres` even asserted the base config "is never loaded" — that assumption is wrong (it *is* loaded, via the operator's include), which is the root of the regression.

## Fix

Comment out `data_directory` in the layered image's copy of `/etc/postgresql/postgresql.conf` (via the same `sed` step that already removes the dangling wal-g `include`), so the base-config `include` becomes harmless regardless of whether it arrives via flag or env var. The stale "never loaded" comment is corrected.

`postgresql.conf.j2` is intentionally left untouched: it is shared by the base supabase image and the VM/ansible deployments, which run `postgres -D /etc/postgresql` and genuinely rely on `data_directory` to locate the data — commenting it there would break them. The fix belongs in the Multigres layer, where pgctld pins the data dir itself.

## Validation

- Reproduced the identical FATAL locally with a layered image + the base-config `include`.
- Confirmed live in the broken staging pod: `postgres -C data_directory` resolves to `/var/lib/postgresql/data` despite `PGDATA` being elsewhere; an empty extra-conf (no include) inits cleanly.
- With this fix applied, init succeeds with the `include` still present and `data_directory` resolves to the correct pooler data dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
