### PR TITLE
ci: Fix nix-build PUSH_TO_CACHE

### DIFF
--- a/.github/actions/nix-install-ephemeral/action.yml
+++ b/.github/actions/nix-install-ephemeral/action.yml
@@ -19,7 +19,7 @@ runs:
   using: composite
   steps:
     - name: validate push-to-cache required inputs
-      if: inputs.push-to-cache == true
+      if: inputs.push-to-cache == 'true'
       shell: bash
       run: |
         abort() { echo "$@" >&2; exit 1; }
@@ -31,7 +31,7 @@ runs:
 
     - name: configure aws credentials
       uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
-      if: inputs.push-to-cache == true
+      if: inputs.push-to-cache == 'true'
       with:
         role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.aws-region }}
@@ -45,7 +45,7 @@ runs:
         AWS_REGION: ${{ inputs.aws-region }}
         GITHUB_TOKEN: ${{ github.token }}
         NIX_SIGN_SECRET_KEY: ${{ inputs.nix-signing-key }}
-        PUSH_TO_CACHE: ${{ inputs.push-to-cache == true }}
+        PUSH_TO_CACHE: ${{ inputs.push-to-cache == 'true' }}
 
     - name: verify nix in path
       shell: bash

--- a/.github/actions/nix-install-ephemeral/action.yml
+++ b/.github/actions/nix-install-ephemeral/action.yml
@@ -23,8 +23,11 @@ runs:
       shell: bash
       run: |
         abort() { echo "$@" >&2; exit 1; }
-        [[ -z "${{ inputs.nix-signing-key}}" ]] && abort "nix-signing-key is required when push-to-cache is true"
-        [[ -z "${{ inputs.role-to-assume}}" ]] && abort "role-to-assume is required when push-to-cache is true"
+        [[ -n ${NIX_SIGNING_KEY:+ok} ]] || abort "nix-signing-key is required when push-to-cache is true"
+        [[ -n ${ROLE_TO_ASSUME:+ok} ]] || abort "role-to-assume is required when push-to-cache is true"
+      env:
+        NIX_SIGNING_KEY: ${{ inputs.nix-signing-key }}
+        ROLE_TO_ASSUME: ${{ inputs.role-to-assume }}
 
     - name: configure aws credentials
       uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1

--- a/.github/actions/nix-install-ephemeral/setup-push.sh
+++ b/.github/actions/nix-install-ephemeral/setup-push.sh
@@ -30,6 +30,6 @@ cat >"$NIXCONFDIR/upload-to-cache.sh" <<-EOF
 	export IFS=' '
 	echo $NIXBINDIR/nix copy --max-jobs 5 --to 's3://nix-postgres-artifacts?secret-key=$NIXCONFDIR/nix-secret-key' \$OUT_PATHS
 EOF
-chmod o+x "$NIXCONFDIR/upload-to-cache.sh"
+chmod 755 "$NIXCONFDIR/upload-to-cache.sh"
 
 echo "post-build-hook = $NIXCONFDIR/upload-to-cache.sh"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Looks like builds aren't being pushed to remote binary cache

## What is the new behavior?

Builds get pushed to remote binary cache when `push-to-cache` is true

## Additional context

Likely broken from https://github.com/supabase/postgres/pull/2319