### PR TITLE
ci/nix-install-ephemeral: Drop sticky disk config

### DIFF
--- a/.github/workflows/nix-eval.yml
+++ b/.github/workflows/nix-eval.yml
@@ -24,15 +24,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - name: Mount Nix cache disk
-        uses: useblacksmith/stickydisk@a652394bf1bf95399f406e648482b41fbd25c51f # v1
-        with:
-          key: ${{ github.repository }}-nix-cache-eval-${{ runner.os }}
-          path: /nix
-      - name: Remove existing Nix socket
-        run: |
-          sudo rm /nix/var/nix/daemon-socket/socket /nix/receipt.json || true
-          sudo chown root /nix /nix/var /nix/var/nix || true
       - name: Install nix
         uses: ./.github/actions/nix-install-ephemeral
         with:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

We use blacksmith sticky disks in nix-eval workflow and the underlying nix install process chowns /nix. The dir is ever growing and now has enough files that the chown takes an immense amount of time ~9m. We don't even really need the sticky disk since we call nix-eval-jobs with `option eval-cache false` and already have the s3 backed binary cache.

## What is the new behavior?

No sticky disk, no chown for 9m, nix-eval goes from ~11m -> ~3m.

## Additional context

It might make sense to use sticky disk as a faster binary cache, worth looking into.
Fixes [PSQL-1599](https://linear.app/supabase/issue/PSQL-1599)