### PR TITLE
chore: bump postgres_release to cut fresh AMIs (includes #2334)

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -11,9 +11,9 @@ postgres_major:
 # This is the source of truth for Postgres versions used in the Dockerfiles, and
 # is used to derive image tags and base images in the release matrix.
 postgres_release:
-  postgresorioledb-17: "17.9.0.012-orioledb"
-  postgres17: "17.6.1.159"
-  postgres15: "15.14.1.159"
+  postgresorioledb-17: "17.9.0.013-orioledb"
+  postgres17: "17.6.1.160"
+  postgres15: "15.14.1.160"
 # Docker release matrix — base images built first, layered images built on top.
 # tag and base_tag are derived at build time from postgres_release via release_key.
 # tag_suffix is appended to the release version to form the final image tag.


### PR DESCRIPTION
Bumps `postgres_release` (15/17/orioledb-17: `.159 → .160`, orioledb `.012 → .013-orioledb`) to cut fresh AMIs so new projects pick up the `cron.job_run_details` trigger-grant change from #2334.

