### PR TITLE
packer: Use dist-upgrade instead of upgrade

### DIFF
--- a/ebssurrogate/scripts/nix-provision.sh
+++ b/ebssurrogate/scripts/nix-provision.sh
@@ -19,7 +19,7 @@ function cleanup_apt {
 
 function update_and_upgrade_apt {
 	apt-get update --yes
-	apt-get upgrade --yes
+	apt-get dist-upgrade --yes
 }
 
 function install_packages {

--- a/ebssurrogate/scripts/qemu-bootstrap-nix.sh
+++ b/ebssurrogate/scripts/qemu-bootstrap-nix.sh
@@ -50,7 +50,7 @@ function cleanup_apt {
 
 function update_and_upgrade_apt {
 	apt-get update --yes
-	apt-get upgrade --yes
+	apt-get dist-upgrade --yes
 }
 
 function waitfor_boot_finished {

--- a/ebssurrogate/scripts/surrogate-bootstrap-nix.sh
+++ b/ebssurrogate/scripts/surrogate-bootstrap-nix.sh
@@ -48,7 +48,7 @@ function setup_apt {
 
 function update_and_upgrade_apt {
 	apt-get update --yes
-	apt-get upgrade --yes
+	apt-get dist-upgrade --yes
 }
 
 function waitfor_boot_finished {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Maintenance

## What is the current behavior?

All but one of apt upgrading scripts do a plain `upgrade`, `chroot-bootstrap-nix.sh` is the odd script out. This is not ideal because we are being inconsistent and `upgrade` isn't as good as `dist-upgrade`.

## What is the new behavior?

We use `dist-upgrade` instead of `upgrade` and do so any time we do an apt-get --update (ignoring adding new mirror).