### PR TITLE
chore: throwaway test AMI for supadev #465 smoke validation (do not merge)

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -11,9 +11,9 @@ postgres_major:
 # This is the source of truth for Postgres versions used in the Dockerfiles, and
 # is used to derive image tags and base images in the release matrix.
 postgres_release:
-  postgresorioledb-17: "17.9.0.013-orioledb"
-  postgres17: "17.6.1.160"
-  postgres15: "15.14.1.160"
+  postgresorioledb-17: "17.9.0.013-orioledb-mmlb-for-tests"
+  postgres17: "17.6.1.160-mmlb-for-tests"
+  postgres15: "15.14.1.160-mmlb-for-tests"
 # Docker release matrix — base images built first, layered images built on top.
 # tag and base_tag are derived at build time from postgres_release via release_key.
 # tag_suffix is appended to the release version to form the final image tag.


### PR DESCRIPTION
**Throwaway — DO NOT MERGE** (will be closed once validation is done).

Opened only to provide a PR URL for the supadev postgres-smoke suite, so the three scripts that require a PR-built AMI (`engines-with-smoke`, `upgrade`, `upgrade-with-smoke`) can run against the fresh test AMIs on this branch — finishing validation of supabase/supadev#465 (RELENG-176, deterministic x86/arm64 instance-type pin).

Test AMIs from build run https://github.com/supabase/postgres/actions/runs/31506637395 — versions `17.6.1.160-mmlb-for-tests`, `15.14.1.160-mmlb-for-tests`, `17.9.0.013-orioledb-mmlb-for-tests`.

The only change on this branch is the pg-version bump to cut a test AMI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
