### PR TITLE
chore: pin -test-3 AMIs for supadev #465 smoke (throwaway; do not merge)

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -11,9 +11,9 @@ postgres_major:
 # This is the source of truth for Postgres versions used in the Dockerfiles, and
 # is used to derive image tags and base images in the release matrix.
 postgres_release:
-  postgresorioledb-17: "17.9.0.014-orioledb"
-  postgres17: "17.6.1.161"
-  postgres15: "15.14.1.161"
+  postgresorioledb-17: "17.9.0.014-orioledb-test-3"
+  postgres17: "17.6.1.161-test-3"
+  postgres15: "15.14.1.161-test-3"
 # Docker release matrix — base images built first, layered images built on top.
 # tag and base_tag are derived at build time from postgres_release via release_key.
 # tag_suffix is appended to the release version to form the final image tag.


### PR DESCRIPTION
Throwaway — do NOT merge. Pins postgres_release to the existing `-test-3` AMIs so supadev postgres-smoke can resolve a live PR URL for #465 validation (replaces merged #2342, whose test branch was deleted). Delete the branch when done.