### PR TITLE
ci: Add final job that depends on the important jobs

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -248,3 +248,21 @@ jobs:
     secrets:
       DEV_AWS_ROLE: ${{ secrets.DEV_AWS_ROLE }}
       NIX_SIGN_SECRET_KEY: ${{ secrets.NIX_SIGN_SECRET_KEY }}
+
+  nix-ci-check:
+    name: Nix CI ✅
+    if: always()
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    needs:
+      - docker-image-test
+      - nix-build-checks-aarch64-darwin
+      - nix-build-checks-aarch64-linux
+      - nix-build-checks-x86_64-linux
+      - run-testinfra
+      - run-tests
+    steps:
+      - name: Check dependent job results
+        if: contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped')
+        run: |
+          jq -rn --argjson needs '${{ toJSON(needs) }}' '$needs|to_entries[]|select(.value.result!="success")|"::error::"+.key+": "+.value.result'
+          exit 1


### PR DESCRIPTION
## What kind of change does this PR introduce?

CI Feature

## What is the current behavior?

There is no single Nix CI passed signal which means our GH branch protection settings are for sub-jobs and don't even block on arguably the most important jobs for this repo (for now at least) such as the testinfra-ami-build, lints, builds and checks.

## What is the new behavior?

One final job that depends on builds, checks, testinfra-ami-build, lints. Will be used for branch protection required check.