### PR TITLE
feat: Add `ORIOLEDB_ENABLED` into `/etc/environment.d/postgresql.env`

### DIFF
--- a/ansible/files/database-optimizations.service
+++ b/ansible/files/database-optimizations.service
@@ -3,6 +3,7 @@ Description=Postgresql optimizations
 
 [Service]
 Type=oneshot
+EnvironmentFile=/etc/environment.d/postgresql.env
 # we do not want failures from these commands to cause downstream service startup to fail
 ExecStart=-/opt/supabase-admin-api optimize db --destination-config-file-path /etc/postgresql-custom/generated-optimizations.conf
 ExecStart=-/opt/supabase-admin-api optimize pgbouncer --destination-config-file-path /etc/pgbouncer-custom/generated-optimizations.ini

--- a/ansible/tasks/stage2-setup-postgres.yml
+++ b/ansible/tasks/stage2-setup-postgres.yml
@@ -53,6 +53,11 @@
             line: 'ORIOLEDB_ENABLED=true'
             path: '/etc/environment'
 
+        - name: Add ORIOLEDB_ENABLED environment variable to postgresql.env
+          ansible.builtin.lineinfile:
+            line: 'ORIOLEDB_ENABLED=true'
+            path: '/etc/environment.d/postgresql.env'
+
 - name: Execute things when stage2
   when: stage2
   become: true

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -11,9 +11,9 @@ postgres_major:
 # This is the source of truth for Postgres versions used in the Dockerfiles, and
 # is used to derive image tags and base images in the release matrix.
 postgres_release:
-  postgresorioledb-17: "17.9.0.014-orioledb"
-  postgres17: "17.6.1.161"
-  postgres15: "15.14.1.161"
+  postgresorioledb-17: "17.9.0.015-orioledb"
+  postgres17: "17.6.1.162"
+  postgres15: "15.14.1.162"
 # Docker release matrix — base images built first, layered images built on top.
 # tag and base_tag are derived at build time from postgres_release via release_key.
 # tag_suffix is appended to the release version to form the final image tag.


### PR DESCRIPTION
## What kind of change does this PR introduce?

`database-optimizations.service` ignores `ORIOLEDB_ENABLED` variable, which is defined in `/etc/environment`. This PR adds it into `/etc/environment.d/postgresql.env` similar to other variables and explicitly use it in the `database-optimizations.service` similar to `postgresql.service`. We keep `/etc/environment` unchanged for backward compatibility.

## What is the current behavior?

`database-optimizations.service` ignores `ORIOLEDB_ENABLED` variable

## What is the new behavior?

`database-optimizations.service` respects `ORIOLEDB_ENABLED` variable defined in `/etc/environment.d/postgresql.env`

## Additional context

https://linear.app/supabase/issue/PSQL-1621