### PR TITLE
feat: add guest-to-host time synchronisation

### DIFF
--- a/ansible/files/phc2sys.service.j2
+++ b/ansible/files/phc2sys.service.j2
@@ -1,0 +1,10 @@
+[Unit]
+Description=Sync system clock to KVM PTP clock
+After=dev-ptp0.device
+
+[Service]
+ExecStart=/usr/sbin/phc2sys -s /dev/ptp0 -O 0 -m
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/tasks/setup-kvm-timesync.yml
+++ b/ansible/tasks/setup-kvm-timesync.yml
@@ -1,0 +1,55 @@
+# Replace systemd-timesyncd with phc2sys which uses the KVM-exposed PTP timesource. Don't run NTP syncs within the VM
+# since that drifts more, and requires network access. phc2sys doesn't require any network access.
+- name: phc2sys - install
+  ansible.builtin.apt:
+    pkg:
+      - linuxptp
+
+- name: phc2sys - create service file
+  ansible.builtin.template:
+    src: files/phc2sys.service.j2
+    dest: /etc/systemd/system/phc2sys.service
+
+- name: phc2sys - enable service
+  ansible.builtin.systemd_service:
+    daemon_reload: true
+    enabled: true
+    name: 'phc2sys'
+    state: 'stopped'
+
+- name: phc2sys - remove systemd-timesyncd
+  ansible.builtin.apt:
+    pkg:
+      - systemd-timesyncd
+    purge: true
+    state: absent
+  when:
+    - ansible_distribution == "Ubuntu" and ansible_distribution_version == "24.04"
+
+- name: ptp_kvm.ko - enable
+  ansible.builtin.copy:
+    content: |
+      ptp_kvm
+    dest: /etc/modules-load.d/ptp_kvm.conf
+
+# On Ubuntu 24.04, ptp_kvm.ko is installed with the much larger linux-modules-extra package until after Kernel 6.8.
+# https://bugs.launchpad.net/ubuntu/+source/linux-gcp/+bug/2110241
+#
+# I didn't bisect every version because rebuilding a test image takes ~45 minutes. We can remove when we've fully
+# migrated to Ubuntu 26.04.
+- name: Upgrade running kernel
+  ansible.builtin.apt:
+    pkg:
+      - linux-virtual-7.0
+  when:
+    - ansible_distribution == "Ubuntu" and ansible_distribution_version == "24.04"
+
+- name: Remove old kernel
+  ansible.builtin.apt:
+    pkg:
+      - linux-image-virtual
+    autoremove: true
+    purge: true
+    state: absent
+  when:
+    - ansible_distribution == "Ubuntu" and ansible_distribution_version == "24.04"

--- a/ansible/tasks/setup-system.yml
+++ b/ansible/tasks/setup-system.yml
@@ -91,6 +91,12 @@
   changed_when: false
   failed_when: false
 
+- name: Ensure guest VM time synchronisation
+  ansible.builtin.import_tasks:
+    file: tasks/setup-kvm-timesync.yml
+  when:
+    - qemu
+
 - name: Execute more tasks when stage1
   when: not stage2
   block:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes KUBE-1282.

For v3 qemu images, add guest-to-host time synchronisation.

This ensures that the time between the host and guest does not drift. This uses less resources than the full NTP stack because this uses the Linux PTP_KVM device and does not require network access.

## What is the current behavior?

The default `arch_sys_counter` clock source is used, which loses ~3s of accuracy a day. A pod running for ~1 year is about 15mins off. `systemd-timesyncd` is installed on the node, but several (~200) pods had NTP sync errors.

With such a large drift, all backups will fail.

## What is the new behavior?

We will maintain a constant time sync between guest-and-host even with network disruptions.