### PR TITLE
feat: Do not hardcode `orioledb.main_buffers` in `postgresql.conf`

### DIFF
--- a/ansible/files/postgres_prestart.sh.j2
+++ b/ansible/files/postgres_prestart.sh.j2
@@ -6,32 +6,6 @@ log() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"
 }
 
-check_orioledb_enabled() {
-   local pg_conf="/etc/postgresql/postgresql.conf"
-   if [ ! -f "$pg_conf" ]; then
-       return 0
-    fi
-   grep "^shared_preload_libraries" "$pg_conf" | grep -c "orioledb" || return 0
-}
-
-get_shared_buffers() {
-    local opt_conf="/etc/postgresql-custom/generated-optimizations.conf"
-    if [ ! -f "$opt_conf" ]; then
-        return 0
-    fi
-    grep "^shared_buffers = " "$opt_conf" | cut -d "=" -f2 | tr -d ' ' || return 0
-}
-
-update_orioledb_buffers() {
-   local pg_conf="/etc/postgresql/postgresql.conf"
-   local value="$1"
-   if grep -q "^orioledb.main_buffers = " "$pg_conf"; then
-       sed -i "s/^orioledb.main_buffers = .*/orioledb.main_buffers = $value/" "$pg_conf"
-   else
-       echo "orioledb.main_buffers = $value" >> "$pg_conf"
-   fi
-}
-
 check_extensions_file() {
     local extensions_file="/etc/adminapi/pg-extensions.json"
     if [ ! -f "$extensions_file" ]; then
@@ -111,16 +85,6 @@ main() {
    
    # 1. Handle all extension versions from config file
    handle_extension_versions
-
-   # 2. orioledb handling 
-   local has_orioledb=$(check_orioledb_enabled)
-   if [ "$has_orioledb" -lt 1 ]; then
-       return 0
-   fi
-   local shared_buffers_value=$(get_shared_buffers)
-   if [ ! -z "$shared_buffers_value" ]; then
-       update_orioledb_buffers "$shared_buffers_value"
-   fi
 
    log "Prestart script completed"
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

`supabase-admin-api` now stores orioledb config into `generated-optimizations.conf` config file and therefore we should avoid hardcoding `orioledb.main_buffers` into `postgresql.conf`

https://linear.app/supabase/issue/ORI-219/apply-orioledb-guc-settings-based-on-instance-size

## What is the current behavior?

Now `ansible/files/postgres_prestart.sh.j2` hardcodes `orioledb.main_buffers` into `postgresql.conf`

## What is the new behavior?

`supabase-admin-api` will save optimized config for orioledb into `generated-optimizations.conf`.

## Additional context

https://linear.app/supabase/issue/ORI-219/apply-orioledb-guc-settings-based-on-instance-size