### PR TITLE
gha/nix-install-ephemeral: Actually copy to s3, not just echo it

### DIFF
--- a/.github/actions/nix-install-ephemeral/setup-nix.sh
+++ b/.github/actions/nix-install-ephemeral/setup-nix.sh
@@ -12,7 +12,7 @@ if systemctl whoami &>/dev/null || [[ $(uname) == Darwin ]]; then
 	tmpdir=$(mktemp -d)
 	trap 'cd; rm -rf $tmpdir' EXIT
 
-	function maybesudo { sudo -E env "$@"; }
+	function maybesudo { sudo -EH env "$@"; }
 else
 	# systemd is *not* running so we must install in single-user mode
 	daemon=--no-daemon

--- a/.github/actions/nix-install-ephemeral/setup-push.sh
+++ b/.github/actions/nix-install-ephemeral/setup-push.sh
@@ -28,7 +28,7 @@ cat >"$NIXCONFDIR/upload-to-cache.sh" <<-EOF
 	fi
 
 	export IFS=' '
-	echo $NIXBINDIR/nix copy --max-jobs 5 --to 's3://nix-postgres-artifacts?secret-key=$NIXCONFDIR/nix-secret-key' \$OUT_PATHS
+	$NIXBINDIR/nix copy --max-jobs 5 --to 's3://nix-postgres-artifacts?secret-key=$NIXCONFDIR/nix-secret-key' \$OUT_PATHS
 EOF
 chmod 755 "$NIXCONFDIR/upload-to-cache.sh"
 


### PR DESCRIPTION
I kept seeing that the site-env-* and other tests kept running in CI and I thought I fixed it recently but turns out I left a debug echo in place and was writing the aws config/creds to the wrong file... :(