### PR TITLE
fix: use log helper for human-targetted output

### DIFF
--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/common.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/common.sh
@@ -20,6 +20,18 @@ function run_sql {
 	psql -h localhost -U supabase_admin -d postgres "$@"
 }
 
+# Wrap a db name in dbname='...' (escaping \ and ') so characters special to -d
+# parsing (=, spaces, quotes) stay part of a literal name, not a conninfo fragment.
+# psql parses a -d value containing '=' as a full conninfo string, so a customer
+# database named e.g. `host=example.com dbname=postgres` would otherwise redirect
+# this root-launched connection off-box. Same helper as refresh_collation.sh.
+function conninfo_for_db {
+	local d="$1"
+	d="${d//\\/\\\\}"
+	d="${d//\'/\\\'}"
+	printf "dbname='%s'" "$d"
+}
+
 function ship_logs {
 	LOG_FILE=$1
 

--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/common.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/common.sh
@@ -24,17 +24,17 @@ function ship_logs {
 	LOG_FILE=$1
 
 	if [ -z "$REPORTING_ANON_KEY" ]; then
-		echo "No reporting key found. Skipping log upload."
+		log "No reporting key found. Skipping log upload."
 		return 0
 	fi
 
 	if [ ! -f "$LOG_FILE" ]; then
-		echo "No log file found. Skipping log upload."
+		log "No log file found. Skipping log upload."
 		return 0
 	fi
 
 	if [ ! -s "$LOG_FILE" ]; then
-		echo "Log file is empty. Skipping log upload."
+		log "Log file is empty. Skipping log upload."
 		return 0
 	fi
 
@@ -59,12 +59,12 @@ function check_free_space {
 	available_kb=$(df -Pk / | awk 'NR==2 {print $4}')
 
 	if ! [[ $available_kb =~ ^[0-9]+$ ]]; then
-		echo "ERROR: could not determine free space on /; aborting upgrade."
+		log "ERROR: could not determine free space on /; aborting upgrade."
 		return 1
 	fi
 
 	if ((available_kb < required_kb)); then
-		echo "ERROR: only ${available_kb}KB free on / but ${required_kb}KB required; aborting upgrade."
+		log "ERROR: only ${available_kb}KB free on / but ${required_kb}KB required; aborting upgrade."
 		return 1
 	fi
 }
@@ -79,10 +79,10 @@ function retry {
 		wait=$((2 ** (count + 1)))
 		count=$((count + 1))
 		if [ $count -lt "$retries" ]; then
-			echo "Command $* exited with code $exit, retrying..."
+			log "Command $* exited with code $exit, retrying..."
 			sleep $wait
 		else
-			echo "Command $* exited with code $exit, no more retries left."
+			log "Command $* exited with code $exit, no more retries left."
 			return $exit
 		fi
 	done

--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/complete.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/complete.sh
@@ -19,20 +19,20 @@ function wait_for_data_device {
 	local fstab_src dev=""
 	fstab_src=$(awk '$2 == "/data" {print $1}' /etc/fstab)
 	if [ -z "$fstab_src" ]; then
-		echo "No /data entry in /etc/fstab"
+		log "No /data entry in /etc/fstab"
 		return 1
 	fi
 
-	echo "Waiting for /data device ($fstab_src) to appear"
+	log "Waiting for /data device ($fstab_src) to appear"
 	for _ in $(seq 1 60); do
 		dev=$(findfs "$fstab_src" 2>/dev/null) || dev=""
 		if [ -n "$dev" ] && [ -b "$dev" ]; then
-			echo "/data device ($dev) is available"
+			log "/data device ($dev) is available"
 			return 0
 		fi
 		sleep 1
 	done
-	echo "Timed out waiting for /data device ($fstab_src)"
+	log "Timed out waiting for /data device ($fstab_src)"
 	return 1
 }
 
@@ -241,7 +241,7 @@ EOF
 
 function complete_pg_upgrade {
 	if [ -f /tmp/pg-upgrade-status ]; then
-		echo "Upgrade job already started. Bailing."
+		log "Upgrade job already started. Bailing."
 		exit 0
 	fi
 
@@ -261,11 +261,11 @@ function complete_pg_upgrade {
 		# `nofail` in /etc/fstab makes `mount -a` exit with a code of 0 even when the volume is absent
 		# In the offchance of the volume not being mounted or detected, explicitly fail here
 		if ! mountpoint -q /data; then
-			echo "FATAL: /data is not a mountpoint"
+			log "FATAL: /data is not a mountpoint"
 			exit 1
 		fi
 	else
-		echo "Skipping mount -a -v"
+		log "Skipping mount -a -v"
 	fi
 
 	# copying custom configurations
@@ -425,14 +425,14 @@ case $# in
 0) ;;
 1)
 	if ! declare -F "$1" >/dev/null; then
-		echo "Error: unknown function $1" >&2
+		log "Error: unknown function $1" >&2
 		exit 1
 	fi
 	$1
 	exit
 	;;
 *)
-	echo "Error: $(basename "$0") takes 0 args or a function to call, got $*" >&2
+	log "Error: $(basename "$0") takes 0 args or a function to call, got $*" >&2
 	exit 1
 	;;
 esac

--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/complete.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/complete.sh
@@ -398,7 +398,7 @@ function start_vacuum_analyze {
 }
 
 function analyze_partitioned_tables {
-	local rc=0 db stmts dbs
+	local rc=0 db conn oid oids dbs
 	# Capture the list (vs substituting into the for-list) so a failed enumeration can't trip the ERR trap inside the subshell and overwrite the status file
 	dbs=$(run_sql -X -p 5432 -A -t -c "select datname from pg_database where datallowconn") || return 1
 	# Iterate by line, not by word — datnames can contain spaces and glob characters
@@ -406,18 +406,25 @@ function analyze_partitioned_tables {
 		if [ -z "$db" ]; then
 			continue
 		fi
-		stmts=$(run_sql -X -p 5432 -d "$db" -A -t -c "select format('ANALYZE %I.%I;', n.nspname, c.relname) from pg_class c join pg_namespace n on n.oid = c.relnamespace where c.relkind = 'p' and not exists (select from pg_statistic s where s.starelid = c.oid)") || {
+		# Never pass a raw datname to -d: psql reads a value containing '=' as a conninfo string, so a database named `host=... dbname=...` would redirect this root-launched connection off-box
+		conn=$(conninfo_for_db "$db")
+		# Enumerate integer OIDs only, never names: line-based iteration would split a relation name containing a newline mid-statement (same pattern as refresh_collation.sh). Parents that already have stats are skipped so retries don't redo finished work
+		oids=$(run_sql -X -p 5432 -d "$conn" -A -t -c "select c.oid from pg_class c where c.relkind = 'p' and not exists (select from pg_statistic s where s.starelid = c.oid)") || {
 			rc=1
 			continue
 		}
-		if [ -n "$stmts" ]; then
-			# The instance is serving traffic by now: fail fast into the retry rather than queue behind a customer lock (autovacuum's ANALYZE cancels itself for us), and cap runaway many-leaf recursion rather than grind against live traffic
-			{
-				echo "set lock_timeout = '10s';"
-				echo "set statement_timeout = '10min';"
-				echo "$stmts"
-			} | run_sql -X -p 5432 -d "$db" -v ON_ERROR_STOP=1 || rc=1
-		fi
+		# One psql call per parent: batching them under ON_ERROR_STOP=1 lets the first failing parent strand every later parent in this database, and the retry then re-fails on that same parent forever
+		while IFS= read -r oid; do
+			case "$oid" in
+			'' | *[!0-9]*) continue ;;
+			esac
+			# The ANALYZE statement is built and run server-side (format %I + \gexec) so object names never round-trip through the shell. A parent dropped since enumeration yields zero rows — \gexec then runs nothing, which is the right outcome. The instance is serving traffic by now: fail fast rather than queue behind a customer lock (autovacuum's ANALYZE cancels itself for us), and cap runaway many-leaf recursion rather than grind against live traffic
+			run_sql -X -p 5432 -d "$conn" -v ON_ERROR_STOP=1 <<-EOSQL || rc=1
+				set lock_timeout = '10s';
+				set statement_timeout = '10min';
+				select format('ANALYZE %I.%I', n.nspname, c.relname) from pg_class c join pg_namespace n on n.oid = c.relnamespace where c.oid = $oid and c.relkind = 'p' \gexec
+			EOSQL
+		done <<<"$oids"
 	done <<<"$dbs"
 	return $rc
 }

--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/complete.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/complete.sh
@@ -47,11 +47,21 @@ function cleanup {
 	exit "$EXIT_CODE"
 }
 
+# Callers invoke this as the left operand of ||, which suppresses set -e for the
+# whole function body — and a subshell with set -e re-enabled does not restore it
+# (verified on bash 3.2 and 5.3), so a mid-function failure would be reported as
+# success. Failures are instead tracked explicitly in rc, like analyze_partitioned_tables.
 function execute_extension_upgrade_patches {
+	local rc=0
 	if [ -f "/var/lib/postgresql/extension/wrappers--0.3.1--0.4.1.sql" ] && [ ! -f "/usr/share/postgresql/15/extension/wrappers--0.3.0--0.4.1.sql" ]; then
-		cp /var/lib/postgresql/extension/wrappers--0.3.1--0.4.1.sql /var/lib/postgresql/extension/wrappers--0.3.0--0.4.1.sql
-		ln -s /var/lib/postgresql/extension/wrappers--0.3.0--0.4.1.sql /usr/share/postgresql/15/extension/wrappers--0.3.0--0.4.1.sql
+		# Only link once the copy landed; a dangling symlink is worse than no symlink
+		if cp /var/lib/postgresql/extension/wrappers--0.3.1--0.4.1.sql /var/lib/postgresql/extension/wrappers--0.3.0--0.4.1.sql; then
+			ln -s /var/lib/postgresql/extension/wrappers--0.3.0--0.4.1.sql /usr/share/postgresql/15/extension/wrappers--0.3.0--0.4.1.sql || rc=1
+		else
+			rc=1
+		fi
 	fi
+	return $rc
 }
 
 function execute_wrappers_patch {
@@ -122,9 +132,14 @@ EOF
 	run_sql -c "$UPDATE_WRAPPERS_SERVER_OPTIONS_QUERY"
 }
 
+# See the note on execute_extension_upgrade_patches for why failures are tracked
+# in rc rather than left to set -e. Each patch is independent, so a failure records
+# rc and the remaining patches still get applied.
 function execute_patches {
+	local rc=0
+
 	# Patch pg_net grants
-	PG_NET_ENABLED=$(run_sql -A -t -c "select count(*) > 0 from pg_extension where extname = 'pg_net';")
+	PG_NET_ENABLED=$(run_sql -A -t -c "select count(*) > 0 from pg_extension where extname = 'pg_net';") || rc=1
 
 	if [ "$PG_NET_ENABLED" = "t" ]; then
 		PG_NET_GRANT_QUERY=$(
@@ -145,11 +160,11 @@ function execute_patches {
 EOF
 		)
 
-		run_sql -c "$PG_NET_GRANT_QUERY"
+		run_sql -c "$PG_NET_GRANT_QUERY" || rc=1
 	fi
 
 	# Patching pg_cron ownership as it resets during upgrade
-	HAS_PG_CRON_OWNED_BY_POSTGRES=$(run_sql -A -t -c "select count(*) > 0 from pg_extension where extname = 'pg_cron' and extowner::regrole::text = 'postgres';")
+	HAS_PG_CRON_OWNED_BY_POSTGRES=$(run_sql -A -t -c "select count(*) > 0 from pg_extension where extname = 'pg_cron' and extowner::regrole::text = 'postgres';") || rc=1
 
 	if [ "$HAS_PG_CRON_OWNED_BY_POSTGRES" = "t" ]; then
 		RECREATE_PG_CRON_QUERY=$(
@@ -168,13 +183,13 @@ EOF
 EOF
 		)
 
-		run_sql -c "$RECREATE_PG_CRON_QUERY"
+		run_sql -c "$RECREATE_PG_CRON_QUERY" || rc=1
 	fi
 
 	# Patching pgmq ownership as it resets during upgrade
-	HAS_PGMQ=$(run_sql -A -t -c "select count(*) > 0 from pg_extension where extname = 'pgmq';")
+	HAS_PGMQ=$(run_sql -A -t -c "select count(*) > 0 from pg_extension where extname = 'pgmq';") || rc=1
 	if [ "$HAS_PGMQ" = "t" ]; then
-		run_sql -c "update pg_extension set extowner = 'postgres'::regrole where extname = 'pgmq';"
+		run_sql -c "update pg_extension set extowner = 'postgres'::regrole where extname = 'pgmq';" || rc=1
 	fi
 
 	# Patch to handle upgrading to pgsodium-less Vault
@@ -218,7 +233,7 @@ EOF
     \$\$;
 EOF
 	)
-	run_sql -c "$REENCRYPT_VAULT_SECRETS_QUERY"
+	run_sql -c "$REENCRYPT_VAULT_SECRETS_QUERY" || rc=1
 
 	GRANT_PREDEFINED_ROLES_TO_POSTGRES_QUERY=$(
 		cat <<EOF
@@ -236,7 +251,9 @@ EOF
     \$\$;
 EOF
 	)
-	run_sql -c "$GRANT_PREDEFINED_ROLES_TO_POSTGRES_QUERY"
+	run_sql -c "$GRANT_PREDEFINED_ROLES_TO_POSTGRES_QUERY" || rc=1
+
+	return $rc
 }
 
 function complete_pg_upgrade {

--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/complete.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/complete.sh
@@ -393,7 +393,8 @@ function start_vacuum_analyze {
 	if [ "$jobs" -lt 1 ]; then
 		jobs=1
 	fi
-	PGOPTIONS='-c vacuum_cost_delay=0 -c lock_timeout=10s' vacuumdb --all --analyze-in-stages -j "$jobs" -U supabase_admin -h localhost -p 5432
+	# --skip-locked rather than a lock_timeout: a lock-timeout error aborts the whole staged all-databases run, and the retry restarts from stage 1 — overwriting finer stats an earlier attempt already wrote with stage 1's coarse target=1. Skipping just the locked table preserves every other table's progress
+	PGOPTIONS='-c vacuum_cost_delay=0' vacuumdb --all --analyze-in-stages --skip-locked -j "$jobs" -U supabase_admin -h localhost -p 5432
 }
 
 function analyze_partitioned_tables {

--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
@@ -77,8 +77,8 @@ fi
 
 if [ -n "$IS_CI" ]; then
 	PGBINOLD="$(pg_config --bindir)"
-	echo "Running in CI mode; using pg_config bindir: $PGBINOLD"
-	echo "PGVERSION: $PGVERSION"
+	log "Running in CI mode; using pg_config bindir: $PGBINOLD"
+	log "PGVERSION: $PGVERSION"
 fi
 
 OLD_BOOTSTRAP_USER=$(run_sql -A -t -c "select rolname from pg_authid where oid = 10;")
@@ -92,11 +92,11 @@ cleanup() {
 	fi
 
 	if [ "$UPGRADE_STATUS" = "failed" ]; then
-		echo "Upgrade job failed. Cleaning up and exiting."
+		log "Upgrade job failed. Cleaning up and exiting."
 	fi
 
 	if [ -d "${MOUNT_POINT}/pgdata/pg_upgrade_output.d/" ]; then
-		echo "Copying pg_upgrade output to /var/log"
+		log "Copying pg_upgrade output to /var/log"
 		cp -R "${MOUNT_POINT}/pgdata/pg_upgrade_output.d/" /var/log/ || true
 		chown -R postgres:postgres /var/log/pg_upgrade_output.d/
 		chmod -R 0750 /var/log/pg_upgrade_output.d/
@@ -117,7 +117,7 @@ cleanup() {
 		fi
 	fi
 
-	echo "Restarting postgresql"
+	log "Restarting postgresql"
 	if [ -z "$IS_CI" ]; then
 		systemctl enable postgresql
 		retry 5 systemctl restart postgresql
@@ -127,18 +127,18 @@ cleanup() {
 
 	retry 8 pg_isready -h localhost -U supabase_admin
 
-	echo "Re-enabling extensions"
+	log "Re-enabling extensions"
 	if [ -f $POST_UPGRADE_EXTENSION_SCRIPT ]; then
 		retry 5 run_sql -f $POST_UPGRADE_EXTENSION_SCRIPT
 	fi
 
-	echo "Removing SUPERUSER grant from postgres"
+	log "Removing SUPERUSER grant from postgres"
 	retry 5 run_sql -c "ALTER USER postgres WITH NOSUPERUSER;"
 
-	echo "Resetting postgres database connection limit"
+	log "Resetting postgres database connection limit"
 	retry 5 run_sql -c "ALTER DATABASE postgres CONNECTION LIMIT -1;"
 
-	echo "Making sure postgres still has access to pg_shadow"
+	log "Making sure postgres still has access to pg_shadow"
 	cat <<EOF >>$POST_UPGRADE_POSTGRES_PERMS_SCRIPT
 DO \$\$
 begin
@@ -155,7 +155,7 @@ EOF
 	fi
 
 	if [ -z "$IS_CI" ] && [ -z "$IS_LOCAL_UPGRADE" ]; then
-		echo "Unmounting data disk from ${MOUNT_POINT}"
+		log "Unmounting data disk from ${MOUNT_POINT}"
 		# check_free_space (and other pre-mount failures) can trigger this trap before
 		# $MOUNT_POINT is ever mounted. Without || true, set -e aborts cleanup() right here
 		# under retry's non-zero exit, so UPGRADE_STATUS is never written and the status file
@@ -167,7 +167,7 @@ EOF
 	if [ -z "$IS_CI" ]; then
 		exit "$EXIT_CODE"
 	else
-		echo "CI run complete with code ${EXIT_CODE}. Exiting."
+		log "CI run complete with code ${EXIT_CODE}. Exiting."
 		exit "$EXIT_CODE"
 	fi
 }
@@ -199,7 +199,7 @@ EOF
 	for EXTENSION in "${EXTENSIONS_TO_DISABLE[@]}"; do
 		EXTENSION_ENABLED=$(run_sql -A -t -c "SELECT EXISTS(SELECT 1 FROM pg_extension WHERE extname = '${EXTENSION}');")
 		if [ "$EXTENSION_ENABLED" = "t" ]; then
-			echo "Disabling extension ${EXTENSION}"
+			log "Disabling extension ${EXTENSION}"
 			run_sql -c "DROP EXTENSION IF EXISTS ${EXTENSION} CASCADE;"
 			cat <<EOF >>$POST_UPGRADE_EXTENSION_SCRIPT
 DO \$\$
@@ -280,7 +280,7 @@ function initiate_upgrade {
 		rm -rf /tmp/pg_upgrade_bin/
 	fi
 
-	echo "1. Extracting pg_upgrade binaries"
+	log "1. Extracting pg_upgrade binaries"
 	mkdir -p "/tmp/pg_upgrade_bin"
 	tar zxf "/tmp/persistent/pg_upgrade_bin.tar.gz" -C "/tmp/pg_upgrade_bin"
 
@@ -293,17 +293,17 @@ function initiate_upgrade {
 		if [ "$IS_NIX_BASED_SYSTEM" = "false" ]; then
 			if [ ! -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
 				if ! command -v nix >/dev/null; then
-					echo "1.1. Nix is not installed; installing."
+					log "1.1. Nix is not installed; installing."
 
 					if [ -f "$NIX_INSTALLER_PACKAGE_PATH" ]; then
-						echo "1.1.1. Installing Nix using the provided installer"
+						log "1.1.1. Installing Nix using the provided installer"
 						tar -xzf "$NIX_INSTALLER_PACKAGE_PATH" -C /tmp/persistent/
 						chmod +x "$NIX_INSTALLER_PATH"
 						"$NIX_INSTALLER_PATH" install --no-confirm \
 							--extra-conf "substituters = https://cache.nixos.org https://nix-postgres-artifacts.s3.amazonaws.com" \
 							--extra-conf "trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7VF/hWMjhYleiaLI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
 					else
-						echo "1.1.1. Installing Nix using the official installer"
+						log "1.1.1. Installing Nix using the official installer"
 						sh <(curl -L https://releases.nixos.org/nix/nix-2.34.6/install) --yes --daemon --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
 extra-experimental-features = nix-command flakes
 extra-substituters = https://nix-postgres-artifacts.s3.amazonaws.com
@@ -311,12 +311,12 @@ extra-trusted-public-keys = nix-postgres-artifacts:dGZlQOvKcNEjvT7QEAJbcV6b6uk7V
 EXTRA_NIX_CONF
 					fi
 				else
-					echo "1.1. Nix is installed; moving on."
+					log "1.1. Nix is installed; moving on."
 				fi
 			fi
 		fi
 
-		echo "1.2. Fetching store path for flake revision: $NIX_FLAKE_VERSION"
+		log "1.2. Fetching store path for flake revision: $NIX_FLAKE_VERSION"
 		# shellcheck disable=SC1091
 		source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
 		nix --version
@@ -329,7 +329,7 @@ EXTRA_NIX_CONF
 		elif [ "$ARCH" = "x86_64" ]; then
 			SYSTEM="x86_64-linux"
 		else
-			echo "ERROR: Unsupported architecture: $ARCH"
+			log "ERROR: Unsupported architecture: $ARCH"
 			exit 1
 		fi
 
@@ -337,23 +337,23 @@ EXTRA_NIX_CONF
 		# Each postgres version has its own catalog file: {git_sha}-psql_{version}.json
 		CATALOG_S3="s3://supabase-internal-artifacts/nix-catalog/${NIX_FLAKE_VERSION}-psql_${PGVERSION}-${SYSTEM}.json"
 		CATALOG_LOCAL="/tmp/nix-catalog-${NIX_FLAKE_VERSION}-psql_${PGVERSION}-${SYSTEM}.json"
-		echo "Fetching catalog from: $CATALOG_S3"
+		log "Fetching catalog from: $CATALOG_S3"
 
 		if ! aws s3 cp "$CATALOG_S3" "$CATALOG_LOCAL" --region ap-southeast-1; then
-			echo "ERROR: Failed to fetch catalog from $CATALOG_S3"
+			log "ERROR: Failed to fetch catalog from $CATALOG_S3"
 			exit 1
 		fi
 
 		STORE_PATH=$(jq -r ".\"${SYSTEM}\"" "$CATALOG_LOCAL")
 
 		if [ -z "$STORE_PATH" ] || [ "$STORE_PATH" = "null" ]; then
-			echo "ERROR: Could not find store path in catalog for ${SYSTEM}"
-			echo "Catalog contents:"
+			log "ERROR: Could not find store path in catalog for ${SYSTEM}"
+			log "Catalog contents:"
 			jq . "$CATALOG_LOCAL"
 			exit 1
 		fi
 
-		echo "Store path: $STORE_PATH"
+		log "Store path: $STORE_PATH"
 
 		# Realize the closure from the binary cache.
 		#
@@ -377,9 +377,9 @@ EXTRA_NIX_CONF
 				break
 			fi
 			if [ "$attempt" -lt 3 ]; then
-				echo "WARNING: nix-store -r attempt ${attempt}/3 for $STORE_PATH failed or stalled (>=120s + up to 10s kill grace); retrying"
+				log "WARNING: nix-store -r attempt ${attempt}/3 for $STORE_PATH failed or stalled (>=120s + up to 10s kill grace); retrying"
 			else
-				echo "ERROR: nix-store -r failed after 3 attempts for $STORE_PATH"
+				log "ERROR: nix-store -r failed after 3 attempts for $STORE_PATH"
 			fi
 		done
 		[ "$nix_store_ok" = "true" ]
@@ -412,20 +412,20 @@ EXTRA_NIX_CONF
 	cd /tmp/pg_upgrade/
 
 	# Fixing erros generated by previous dpkg executions (package upgrades et co)
-	echo "2. Fixing potential errors generated by dpkg"
-	echo "2.1 Killing off any old hanging apt-get processes"
+	log "2. Fixing potential errors generated by dpkg"
+	log "2.1 Killing off any old hanging apt-get processes"
 	# One hour is old enough to be bad
-	pkill -f apt-get --older 3600 2>/dev/null || echo "No hanging apt-get processes found"
+	pkill -f apt-get --older 3600 2>/dev/null || log "No hanging apt-get processes found"
 	DEBIAN_FRONTEND=noninteractive dpkg --configure -a --force-confold || true # handle errors generated by dpkg
 
 	# Needed for PostGIS, since it's compiled with Protobuf-C support now
-	echo "3. Installing libprotobuf-c1 and libicu66 if missing"
+	log "3. Installing libprotobuf-c1 and libicu66 if missing"
 	if [[ ! "$(apt list --installed libprotobuf-c1 | grep "installed")" ]]; then
 		apt-get -o DPkg::Lock::Timeout=600 update -y                # wait up to 10 minutes for any dpkg locks to clear before updating package lists
 		apt --fix-broken install -y libprotobuf-c1 libicu66 || true # apt has builtin 2 minute wait lock
 	fi
 
-	echo "4. Setup locale if required"
+	log "4. Setup locale if required"
 	if ! grep -q "^en_US.UTF-8" /etc/locale.gen; then
 		echo "en_US.UTF-8 UTF-8" >>/etc/locale.gen
 	fi
@@ -436,7 +436,7 @@ EXTRA_NIX_CONF
 
 	if [ -z "$IS_CI" ] && [ -z "$IS_LOCAL_UPGRADE" ]; then
 		# DATABASE_UPGRADE_DATA_MIGRATION_DEVICE_NAME = '/dev/xvdp' can be derived from the worker mount
-		echo "5. Determining block device to mount"
+		log "5. Determining block device to mount"
 		# lsb release
 		UBUNTU_VERSION=$(lsb_release -rs)
 		# install amazon disk utilities if not present on 24.04
@@ -458,16 +458,16 @@ EXTRA_NIX_CONF
 
 		# Fallback to lsblk if ebsnvme-id is not available or no mapping found, pre ubuntu 20.04
 		if [ -z "${BLOCK_DEVICE:-}" ]; then
-			echo "No block device found using ebsnvme-id, falling back to lsblk"
+			log "No block device found using ebsnvme-id, falling back to lsblk"
 			# awk NF==3 prints lines with exactly 3 fields, which are the block devices currently not mounted anywhere
 			# excluding nvme0 since it is the root disk
 			BLOCK_DEVICE=$(lsblk -dprno name,size,mountpoint,type | grep "disk" | grep -v "nvme0" | awk 'NF==3 { print $1; exit }') # exit ensures we grab the first only
 		fi
 
-		echo "Block device found: $BLOCK_DEVICE"
+		log "Block device found: $BLOCK_DEVICE"
 
 		mkdir -p "$MOUNT_POINT"
-		echo "6. Mounting block device"
+		log "6. Mounting block device"
 
 		sleep 5
 		e2fsck -pf "$BLOCK_DEVICE"
@@ -487,14 +487,14 @@ EXTRA_NIX_CONF
 		chmod 600 /etc/postgresql-custom/pgsodium_root.key
 	fi
 
-	echo "7. Disabling extensions and generating post-upgrade script"
+	log "7. Disabling extensions and generating post-upgrade script"
 	handle_extensions
 
-	echo "8.1. Granting SUPERUSER to postgres user"
+	log "8.1. Granting SUPERUSER to postgres user"
 	run_sql -c "ALTER USER postgres WITH SUPERUSER;"
 
 	if [ "$OLD_BOOTSTRAP_USER" = "postgres" ]; then
-		echo "8.2. Swap postgres & supabase_admin roles as we're upgrading a project with postgres as bootstrap user"
+		log "8.2. Swap postgres & supabase_admin roles as we're upgrading a project with postgres as bootstrap user"
 		swap_postgres_and_supabase_admin
 	fi
 
@@ -510,7 +510,7 @@ EXTRA_NIX_CONF
 		export LD_LIBRARY_PATH="${PGLIBNEW}"
 	fi
 
-	echo "9. Creating new data directory, initializing database"
+	log "9. Creating new data directory, initializing database"
 	chown -R postgres:postgres "$MOUNT_POINT/"
 	rm -rf "${PGDATANEW:?}/"
 
@@ -576,7 +576,7 @@ EOF
 		GRN_PLUGINS_DIR=/var/lib/postgresql/.nix-profile/lib/groonga/plugins LC_ALL=en_US.UTF-8 LC_CTYPE=$SERVER_LC_CTYPE LC_COLLATE=$SERVER_LC_COLLATE LANGUAGE=en_US.UTF-8 LANG=en_US.UTF-8 LOCALE_ARCHIVE=/usr/lib/locale/locale-archive su -pc "$UPGRADE_COMMAND --check" -s "$SHELL" postgres
 	fi
 
-	echo "10. Stopping postgres; running pg_upgrade"
+	log "10. Stopping postgres; running pg_upgrade"
 	# Extra work to ensure postgres is actually stopped
 	#  Mostly needed for PG12 projects with odd systemd unit behavior
 	if [ -z "$IS_CI" ]; then
@@ -599,7 +599,7 @@ EOF
 	fi
 
 	# copying custom configurations
-	echo "11. Copying custom configurations"
+	log "11. Copying custom configurations"
 	mkdir -p "$MOUNT_POINT/conf"
 	cp -R /etc/postgresql-custom/* "$MOUNT_POINT/conf/"
 	# removing supautils config as to allow the latest one provided by the latest image to be used
@@ -610,12 +610,12 @@ EOF
 	rm -f "$MOUNT_POINT/conf/wal-g.conf"
 
 	# copy sql files generated by pg_upgrade
-	echo "12. Copying sql files generated by pg_upgrade"
+	log "12. Copying sql files generated by pg_upgrade"
 	mkdir -p "$MOUNT_POINT/sql"
 	cp /tmp/pg_upgrade/*.sql "$MOUNT_POINT/sql/" || true
 	chown -R postgres:postgres "$MOUNT_POINT/sql/"
 
-	echo "13. Cleaning up"
+	log "13. Cleaning up"
 	cleanup "complete"
 }
 
@@ -624,7 +624,7 @@ trap cleanup ERR
 echo "running" >/tmp/pg-upgrade-status
 if [ -z "$IS_CI" ] && [ -z "$IS_LOCAL_UPGRADE" ]; then
 	initiate_upgrade >>"$LOG_FILE" 2>&1 &
-	echo "Upgrade initiate job completed"
+	log "Upgrade initiate job completed"
 else
 	rm -f /tmp/pg-upgrade-status
 	initiate_upgrade


### PR DESCRIPTION
Build on https://github.com/supabase/postgres/pull/2356 to address outstanding code review comments.

- Finishes the migration to the `log` utility for all remaining scripts
- Replaces global lock timeout with `--skip-locked` on vacuumdb
- One `run_sql` call per statement with inline timeout, instead of batch
- `set -e` suppression in `execute_{,extension_upgrade_}patches`
- conninfo string sanitization


INDATA-1218