### PR TITLE
Revert PostgREST bump to v14.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ This is the same PostgreSQL build that powers [Supabase](https://supabase.io), b
 | Goodie | Version | Description |
 | ------------- | :-------------: | ------------- |
 | [PgBouncer](https://www.pgbouncer.org/) | [1.19.0](http://www.pgbouncer.org/changelog.html#pgbouncer-119x) | Set up Connection Pooling. |
-| [PostgREST](https://postgrest.org/en/stable/) | [v14.17](https://github.com/PostgREST/postgrest/releases/tag/v14.17) | Instantly transform your database into an RESTful API. |
+| [PostgREST](https://postgrest.org/en/stable/) | [v14.15](https://github.com/PostgREST/postgrest/releases/tag/v14.15) | Instantly transform your database into an RESTful API. |
 | [WAL-G](https://github.com/wal-g/wal-g#wal-g) | [v2.0.1](https://github.com/wal-g/wal-g/releases/tag/v2.0.1) | Tool for physical database backup and recovery. | -->
 
 

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -11,9 +11,9 @@ postgres_major:
 # This is the source of truth for Postgres versions used in the Dockerfiles, and
 # is used to derive image tags and base images in the release matrix.
 postgres_release:
-  postgresorioledb-17: "17.9.0.015-orioledb"
-  postgres17: "17.6.1.162"
-  postgres15: "15.14.1.162"
+  postgresorioledb-17: "17.9.0.016-orioledb"
+  postgres17: "17.6.1.163"
+  postgres15: "15.14.1.163"
 # Docker release matrix — base images built first, layered images built on top.
 # tag and base_tag are derived at build time from postgres_release via release_key.
 # tag_suffix is appended to the release version to form the final image tag.

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -11,9 +11,9 @@ postgres_major:
 # This is the source of truth for Postgres versions used in the Dockerfiles, and
 # is used to derive image tags and base images in the release matrix.
 postgres_release:
-  postgresorioledb-17: "17.9.0.016-orioledb"
-  postgres17: "17.6.1.163"
-  postgres15: "15.14.1.163"
+  postgresorioledb-17: "17.9.0.015-orioledb"
+  postgres17: "17.6.1.162"
+  postgres15: "15.14.1.162"
 # Docker release matrix — base images built first, layered images built on top.
 # tag and base_tag are derived at build time from postgres_release via release_key.
 # tag_suffix is appended to the release version to form the final image tag.
@@ -126,14 +126,14 @@ pgbouncer_release: 1.25.1
 pgbouncer_artifacts:
   url: "https://www.pgbouncer.org/downloads/files/{{ pgbouncer_release }}/pgbouncer-{{ pgbouncer_release }}.tar.gz"
   checksum: sha256:6e566ae92fe3ef7f6a1b9e26d6049f7d7ca39c40e29e7b38f6d5500ae15d8465
-postgrest_release: "14.17" # keep this as an *explicit* string, otherwise gets treated as yaml float which will likely only lead to tears
+postgrest_release: "14.15" # keep this as an *explicit* string, otherwise gets treated as yaml float which will likely only lead to tears
 postgrest_artifacts:
   amd64:
     url: "https://github.com/PostgREST/postgrest/releases/download/v{{ postgrest_release }}/postgrest-v{{ postgrest_release }}-linux-static-x86-64.tar.xz"
-    checksum: sha256:d6e13926457487c99b77366d795dcfa32700554d08d418131d9a4ea3f6ca25e3
+    checksum: sha256:4e78c7f065a6c36f350c7177f5fa9bb77ea380c67b8bf40f2fc9130d857678dc
   arm64:
     url: "https://github.com/PostgREST/postgrest/releases/download/v{{ postgrest_release }}/postgrest-v{{ postgrest_release }}-ubuntu-aarch64.tar.xz"
-    checksum: sha256:e9a5671caff9cea25ea002c906638ac1cefbb612a3a1cbf3ecfbe92072fef871
+    checksum: sha256:1eb007298c1536ba865e741da7eece6fba6db3da904c599abd15d9c3debe6c2f
   signingkey:
     url: "https://www.postgresql.org/media/keys/ACCC4CF8.asc"
     checksum: sha256:0144068502a1eddd2a0280ede10ef607d1ec592ce819940991203941564e8e76


### PR DESCRIPTION
## What kind of change does this PR introduce?

Reverts PostgREST bump until it's included in https://github.com/supabase/cli/pkgs/container/postgrest