### PR TITLE
chore: Make `postgresql.env` optional in `database-optimizations.service`

### DIFF
--- a/ansible/files/database-optimizations.service
+++ b/ansible/files/database-optimizations.service
@@ -3,7 +3,7 @@ Description=Postgresql optimizations
 
 [Service]
 Type=oneshot
-EnvironmentFile=/etc/environment.d/postgresql.env
+EnvironmentFile=-/etc/environment.d/postgresql.env
 # we do not want failures from these commands to cause downstream service startup to fail
 ExecStart=-/opt/supabase-admin-api optimize db --destination-config-file-path /etc/postgresql-custom/generated-optimizations.conf
 ExecStart=-/opt/supabase-admin-api optimize pgbouncer --destination-config-file-path /etc/pgbouncer-custom/generated-optimizations.ini


### PR DESCRIPTION
## What kind of change does this PR introduce?

Make `postgresql.env` optional in `database-optimizations.service`, because we deploy it with `salt` as well. In older images we can have a setup which doesn't have `postgresql.env`.

## What is the current behavior?

Currently  `postgresql.env` is non-optional.

## What is the new behavior?

Make `postgresql.env` optional in `database-optimizations.service`

## Additional context

https://github.com/supabase/salt/pull/788