### PR TITLE
ansible: Bump versions to get new AMIs built

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -11,9 +11,9 @@ postgres_major:
 # This is the source of truth for Postgres versions used in the Dockerfiles, and
 # is used to derive image tags and base images in the release matrix.
 postgres_release:
-  postgresorioledb-17: "17.9.0.016-orioledb"
-  postgres17: "17.6.1.163"
-  postgres15: "15.14.1.163"
+  postgresorioledb-17: "17.9.0.017-orioledb"
+  postgres17: "17.6.1.164"
+  postgres15: "15.14.1.164"
 # Docker release matrix — base images built first, layered images built on top.
 # tag and base_tag are derived at build time from postgres_release via release_key.
 # tag_suffix is appended to the release version to form the final image tag.


### PR DESCRIPTION
#2371 reverted the postgrest bump but did not bump version to get ami built.