### PR TITLE
chore: disable track_utility before statements with passwords

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -11,9 +11,9 @@ postgres_major:
 # This is the source of truth for Postgres versions used in the Dockerfiles, and
 # is used to derive image tags and base images in the release matrix.
 postgres_release:
-  postgresorioledb-17: "17.9.0.016-orioledb"
-  postgres17: "17.6.1.163"
-  postgres15: "15.14.1.163"
+  postgresorioledb-17: "17.9.0.017-orioledb"
+  postgres17: "17.6.1.164"
+  postgres15: "15.14.1.164"
 # Docker release matrix — base images built first, layered images built on top.
 # tag and base_tag are derived at build time from postgres_release via release_key.
 # tag_suffix is appended to the release version to form the final image tag.

--- a/migrations/db/migrate.sh
+++ b/migrations/db/migrate.sh
@@ -29,6 +29,7 @@ fi
 db=$(cd -- "$(dirname -- "$0")" >/dev/null 2>&1 && pwd)
 if [ -z "${USE_DBMATE:-}" ]; then
 	psql -v ON_ERROR_STOP=1 --no-password --no-psqlrc -U supabase_admin <<EOSQL
+set pg_stat_statements.track_utility = off;
 do \$\$
 begin
   -- postgres role is pre-created during AMI build
@@ -36,14 +37,15 @@ begin
     create role postgres superuser login password '$PGPASSWORD';
     alter database postgres owner to postgres;
   end if;
-end \$\$
+end \$\$;
+reset pg_stat_statements.track_utility;
 EOSQL
 	# run init scripts as postgres user
 	for sql in "$db"/init-scripts/*.sql; do
 		echo "$0: running $sql"
 		psql -v ON_ERROR_STOP=1 --no-password --no-psqlrc -U postgres -f "$sql"
 	done
-	psql -v ON_ERROR_STOP=1 --no-password --no-psqlrc -U postgres -c "ALTER USER supabase_admin WITH PASSWORD '$PGPASSWORD'"
+	psql -v ON_ERROR_STOP=1 --no-password --no-psqlrc -U postgres -c "SET pg_stat_statements.track_utility = off; ALTER USER supabase_admin WITH PASSWORD '$PGPASSWORD'; RESET pg_stat_statements.track_utility;"
 	# run migrations as super user - postgres user demoted in post-setup
 	for sql in "$db"/migrations/*.sql; do
 		echo "$0: running $sql"
@@ -51,12 +53,14 @@ EOSQL
 	done
 else
 	psql -v ON_ERROR_STOP=1 --no-password --no-psqlrc -U supabase_admin <<EOSQL
+  set pg_stat_statements.track_utility = off;
   create role postgres superuser login password '$PGPASSWORD';
   alter database postgres owner to postgres;
+  reset pg_stat_statements.track_utility;
 EOSQL
 	# run init scripts as postgres user
 	DBMATE_MIGRATIONS_DIR="$db/init-scripts" DATABASE_URL="postgres://postgres:$connect" dbmate --no-dump-schema migrate
-	psql -v ON_ERROR_STOP=1 --no-password --no-psqlrc -U postgres -c "ALTER USER supabase_admin WITH PASSWORD '$PGPASSWORD'"
+	psql -v ON_ERROR_STOP=1 --no-password --no-psqlrc -U postgres -c "SET pg_stat_statements.track_utility = off; ALTER USER supabase_admin WITH PASSWORD '$PGPASSWORD'; RESET pg_stat_statements.track_utility;"
 	# run migrations as super user - postgres user demoted in post-setup
 	DBMATE_MIGRATIONS_DIR="$db/migrations" DATABASE_URL="postgres://supabase_admin:$connect" dbmate --no-dump-schema migrate
 fi
@@ -65,7 +69,7 @@ fi
 postinit="/etc/postgresql.schema.sql"
 if [ -e "$postinit" ]; then
 	echo "$0: running $postinit"
-	psql -v ON_ERROR_STOP=1 --no-password --no-psqlrc -U supabase_admin -f "$postinit"
+	psql -v ON_ERROR_STOP=1 --no-password --no-psqlrc -U supabase_admin -c "SET pg_stat_statements.track_utility = off;" -f "$postinit" -c "RESET pg_stat_statements.track_utility;"
 fi
 
 # once done with everything, reset stats from init

--- a/nix/tools/postgresql_schema.sql
+++ b/nix/tools/postgresql_schema.sql
@@ -1,5 +1,6 @@
 ALTER DATABASE postgres SET "app.settings.jwt_secret" TO  'my_jwt_secret_which_is_not_so_secret';
 ALTER DATABASE postgres SET "app.settings.jwt_exp" TO 3600;
+SET pg_stat_statements.track_utility = off;
 ALTER USER supabase_admin WITH PASSWORD 'postgres';
 ALTER USER postgres WITH PASSWORD 'postgres';
 ALTER USER authenticator WITH PASSWORD 'postgres';
@@ -9,4 +10,5 @@ ALTER USER supabase_storage_admin WITH PASSWORD 'postgres';
 ALTER USER supabase_replication_admin WITH PASSWORD 'postgres';
 ALTER USER supabase_etl_admin WITH PASSWORD 'postgres';
 ALTER ROLE supabase_read_only_user WITH PASSWORD 'postgres';
+RESET pg_stat_statements.track_utility;
 ALTER ROLE supabase_admin SET search_path TO "$user",public,auth,extensions;


### PR DESCRIPTION
`pg_stat_statements.track_utility` is disabled before running statements with passwords.