### PR TITLE
feat: add orioledb debug symbols

### DIFF
--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -951,6 +951,7 @@
             postgresql_17_debug
             postgresql_17_src
             ;
+          psql_orioledb-17_exts_orioledb_debug = self'.legacyPackages.psql_orioledb-17.exts.orioledb.debug;
         };
     };
 }

--- a/nix/ext/orioledb.nix
+++ b/nix/ext/orioledb.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
   buildPhase = ''
     make USE_PGXS=1 ORIOLEDB_PATCHSET_VERSION=20
   '';
+  separateDebugInfo = true;
   installPhase = ''
     runHook preInstall
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add separateDebugInfo to `nix/ext/orioledb.nix` so `orioledb.so`'s debug symbols are preserved in a separate output instead of being stripped, and expose it as an opt-in `psql_orioledb-17_debug` package (Linux-only, mirroring the `postgresql_*_debug` convention). Also add it under `legacyPackages` so it gets picked up by the CI cache-push matrix and built into the nix binary cache.

## What is the current behavior?

There are no orioledb debug symbols

## What is the new behavior?

orioledb debug symbols are available as an opt-in package

## Additional context

https://linear.app/supabase/issue/ORI-146/add-support-for-orioledb-debug-symbols