### PR TITLE
AMI: Setup swap at stage2 not stage1

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -212,3 +212,8 @@
       become: yes
       shell: |
         sudo -u ubuntu bash -c ". /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh && nix-collect-garbage -d"
+
+    - name: Setup Swap
+      when: stage2 and not qemu
+      become: yes
+      import_tasks: tasks/stage2/setup-swap.yml

--- a/ansible/tasks/setup-tuned.yml
+++ b/ansible/tasks/setup-tuned.yml
@@ -185,43 +185,6 @@
         value: '10'
       become: true
 
-    - name: 'tuned - Enable zswap if swap is present'  # noqa: name[casing]
-      when: ansible_facts['swaptotal_mb'] > 0
-      block:
-        - name: 'tuned - Decrease the kernel swappiness'  # noqa: name[casing]
-          community.general.ini_file:
-            create: true
-            group: 'root'
-            mode: '0644'
-            no_extra_spaces: true
-            option: 'vm.swappiness'
-            path: '/etc/tuned/profiles/postgresql/tuned.conf'
-            section: 'sysctl'
-            state: 'present'
-            value: '10'
-          become: true
-
-        - name: 'tuned - Load zstd compressor module'  # noqa: name[casing]
-          community.general.modprobe:
-            name: 'zstd'
-            persistent: 'present'
-            state: 'present'
-          become: true
-
-        - name: 'tuned - Configure and enable zswap'  # noqa: name[casing]
-          ansible.builtin.shell:
-            cmd: "echo {{ zswap_item['value'] }}  > /sys/module/zswap/parameters/{{ zswap_item['param'] }}"
-          changed_when: true
-          loop:
-            - param: 'compressor'
-              value: 'zstd'
-            - param: 'max_pool_percent'
-              value: '10'
-            - param: 'enabled'
-              value: 'Y'
-          loop_control:
-            loop_var: 'zswap_item'
-
     - name: 'tuned - Activate the tuned service'  # noqa: name[casing]
       ansible.builtin.systemd_service:
         daemon_reload: true

--- a/ansible/tasks/stage2/setup-swap.yml
+++ b/ansible/tasks/stage2/setup-swap.yml
@@ -1,0 +1,49 @@
+- name: Allocate and format swapfile
+  ansible.builtin.shell: |
+    fallocate -l 1G /swapfile
+    chmod 600 /swapfile
+    mkswap /swapfile
+  args:
+    creates: /swapfile
+
+- name: Add swapfile to fstab
+  ansible.posix.mount:
+    src: /swapfile
+    path: none
+    fstype: swap
+    opts: sw
+    dump: "0"
+    passno: "0"
+    state: present
+
+- name: 'tuned - Decrease the kernel swappiness'  # noqa: name[casing]
+  community.general.ini_file:
+    create: true
+    group: 'root'
+    mode: '0644'
+    no_extra_spaces: true
+    option: 'vm.swappiness'
+    path: '/etc/tuned/profiles/postgresql/tuned.conf'
+    section: 'sysctl'
+    state: 'present'
+    value: '10'
+
+- name: 'tuned - Load zstd compressor module'  # noqa: name[casing]
+  community.general.modprobe:
+    name: 'zstd'
+    persistent: 'present'
+    state: 'present'
+
+- name: 'tuned - Configure and enable zswap'  # noqa: name[casing]
+  ansible.builtin.shell:
+    cmd: "echo {{ zswap_item['value'] }}  > /sys/module/zswap/parameters/{{ zswap_item['param'] }}"
+  changed_when: true
+  loop:
+    - param: 'compressor'
+      value: 'zstd'
+    - param: 'max_pool_percent'
+      value: '10'
+    - param: 'enabled'
+      value: 'Y'
+  loop_control:
+    loop_var: 'zswap_item'

--- a/ebssurrogate/scripts/surrogate-bootstrap-nix.sh
+++ b/ebssurrogate/scripts/surrogate-bootstrap-nix.sh
@@ -202,23 +202,14 @@ function format_and_mount_rootfs {
 	mount -o defaults,discard /dev/xvdh /mnt/data
 }
 
-function create_swapfile {
-	fallocate -l 1G /mnt/swapfile
-	chmod 600 /mnt/swapfile
-	mkswap /mnt/swapfile
-}
-
 function format_build_partition {
 	mkfs.ext4 -O ^has_journal /dev/xvdc
 }
 # Create fstab
 function create_fstab {
-	local FMT="%-42s %-11s %-5s %-17s %-5s %s" ROOT_LINE DATA_LINE SWAP_LINE
+	local FMT="%-42s %-11s %-5s %-17s %-5s %s" ROOT_LINE DATA_LINE
 	ROOT_LINE=$(findmnt -no SOURCE /mnt | xargs blkid -o export | awk -v FMT="$FMT" '/^UUID=/ { printf(FMT, $0, "/", "ext4", "defaults,discard", "0", "1" ) }')
 	DATA_LINE=$(findmnt -no SOURCE /mnt/data | xargs blkid -o export | awk -v FMT="$FMT" '/^UUID=/ { printf(FMT, $0, "/data", "ext4", "defaults,discard", "0", "2" ) }')
-
-	# shellcheck disable=SC2059
-	SWAP_LINE=$(printf "$FMT" "/swapfile" "none" "swap" "sw" "0" "0")
 
 	local EFI_LINE=""
 	if [[ $ARCH == arm64 ]]; then
@@ -231,7 +222,6 @@ function create_fstab {
 		echo "$ROOT_LINE"
 		[ -n "$EFI_LINE" ] && echo "$EFI_LINE"
 		echo "$DATA_LINE"
-		echo "$SWAP_LINE"
 	} >/mnt/etc/fstab
 }
 
@@ -387,7 +377,6 @@ function clean_system {
 	rm -rf /mnt/root/.vpython*
 	rm -rf /mnt/root/go
 	rm -rf /mnt/usr/share/doc
-
 }
 
 # Unmount bind mounts
@@ -419,7 +408,6 @@ waitfor_boot_finished
 install_packages
 device_partition_mappings
 format_and_mount_rootfs
-create_swapfile
 format_build_partition
 setup_chroot_environment
 execute_playbook


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

For AMI builds we setup 1G swap in stage1 which takes up 10% of the disk during stage2. 

## What is the new behavior?

Swap space is allocated/setup at the end of stage2's ansible run.

## Additional context

The swap space isn't really necessary on these c6 machines with 32G of ram. We do end up running right up to the brink of available disk during builds/installs before cleaning out caches/gc and could put that 1G to better use there.