### PR TITLE
fix: revoke CREATEROLE from supabase_auth_admin

### DIFF
--- a/migrations/db/init-scripts/00000000000001-auth-schema.sql
+++ b/migrations/db/init-scripts/00000000000001-auth-schema.sql
@@ -109,7 +109,7 @@ $$ language sql stable;
 GRANT USAGE ON SCHEMA auth TO anon, authenticated, service_role;
 
 -- Supabase super admin
-CREATE USER supabase_auth_admin NOINHERIT CREATEROLE LOGIN NOREPLICATION;
+CREATE USER supabase_auth_admin NOINHERIT NOCREATEROLE LOGIN NOREPLICATION;
 GRANT ALL PRIVILEGES ON SCHEMA auth TO supabase_auth_admin;
 GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA auth TO supabase_auth_admin;
 GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA auth TO supabase_auth_admin;

--- a/migrations/db/migrations/20260821154147_revoke_createrole_from_auth_admin.sql
+++ b/migrations/db/migrations/20260821154147_revoke_createrole_from_auth_admin.sql
@@ -1,0 +1,4 @@
+-- migrate:up
+alter role supabase_auth_admin nocreaterole;
+
+-- migrate:down

--- a/nix/tests/expected/roles.out
+++ b/nix/tests/expected/roles.out
@@ -45,7 +45,7 @@ order by rolname;
  postgres                   | t             | t           | f        | t          | t           | t              |           -1 | t            | 
  service_role               | f             | f           | f        | t          | f           | f              |           -1 | t            | 
  supabase_admin             | t             | t           | t        | t          | t           | t              |           -1 | t            | 
- supabase_auth_admin        | t             | t           | f        | f          | f           | f              |           -1 | f            | 
+ supabase_auth_admin        | f             | t           | f        | f          | f           | f              |           -1 | f            | 
  supabase_etl_admin         | f             | t           | f        | t          | f           | t              |           -1 | t            | 
  supabase_functions_admin   | t             | t           | f        | f          | f           | f              |           -1 | f            | 
  supabase_privileged_role   | f             | f           | f        | t          | f           | f              |           -1 | f            | 

--- a/nix/tests/expected/z_multigres-orioledb-17_roles.out
+++ b/nix/tests/expected/z_multigres-orioledb-17_roles.out
@@ -42,7 +42,7 @@ order by rolname;
  postgres                   | t             | t           | f        | t          | t           | t              |           -1 | t            | 
  service_role               | f             | f           | f        | t          | f           | f              |           -1 | t            | 
  supabase_admin             | t             | t           | t        | t          | t           | t              |           -1 | t            | 
- supabase_auth_admin        | t             | t           | f        | f          | f           | f              |           -1 | f            | 
+ supabase_auth_admin        | f             | t           | f        | f          | f           | f              |           -1 | f            | 
  supabase_etl_admin         | f             | t           | f        | t          | f           | t              |           -1 | t            | 
  supabase_functions_admin   | t             | t           | f        | f          | f           | f              |           -1 | f            | 
  supabase_privileged_role   | f             | f           | f        | t          | f           | f              |           -1 | f            | 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix (security hardening — privilege scoping)

## What is the current behavior?
`supabase_auth_admin` is created with `CREATEROLE` privilege in the base init script and no subsequent migration ever revokes it.

Fixes #1518

## What is the new behavior?
`supabase_auth_admin` is created with `NOCREATEROLE` on fresh installs. A new migration revokes the privilege on existing installs.

The auth service (GoTrue) never issues any `CREATE ROLE` statements at runtime — confirmed by grepping the entire supabase/auth source (`grep -rn "CREATE ROLE|CREATEROLE" --include="*.go"` excluding tests and vendor) — zero hits. The privilege appears vestigial.

Golden files updated accordingly (`roles.out`, `z_multigres-orioledb-17_roles.out`).

## Additional context
Scoped to `supabase_auth_admin` only as a first, auditable step. `supabase_functions_admin`, `supabase_storage_admin`, and `dashboard_user` have the same pattern — happy to follow up with a separate PR for those once this lands.

`-- migrate:down` left empty, matching the convention of recent privilege-only migrations (`20250205060043`, `20250421084701`). Did not run the full Nix regression suite locally — would want CI to confirm before merge.