### PR TITLE
fix: raise default max_replication_slots from 5 to 10 in the postgres AMI

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ This is the same PostgreSQL build that powers [Supabase](https://supabase.io), b
 - ✅ Postgres [postgresql-17.6](https://www.postgresql.org/docs/17/index.html)
 - ✅ Postgres [orioledb-postgresql-17_11](https://github.com/orioledb/orioledb)
 - ✅ Ubuntu 24.04 (Noble Numbat).
-- ✅ [wal_level](https://www.postgresql.org/docs/current/runtime-config-wal.html) = logical and [max_replication_slots](https://www.postgresql.org/docs/current/runtime-config-replication.html) = 5. Ready for replication.
+- ✅ [wal_level](https://www.postgresql.org/docs/current/runtime-config-wal.html) = logical and [max_replication_slots](https://www.postgresql.org/docs/current/runtime-config-replication.html) = 10. Ready for replication.
 - ✅ [Large Systems Extensions](https://github.com/aws/aws-graviton-getting-started#building-for-graviton-and-graviton2). Enabled for ARM images.
 ## Extensions
 

--- a/ansible/files/postgresql_config/postgresql.conf.j2
+++ b/ansible/files/postgresql_config/postgresql.conf.j2
@@ -296,7 +296,7 @@ checkpoint_flush_after = 256kB		# measured in pages, 0 disables
 
 max_wal_senders = 10		# max number of walsender processes
 				# (change requires restart)
-max_replication_slots = 5	# max number of replication slots
+max_replication_slots = 10	# max number of replication slots
 				# (change requires restart)
 #wal_keep_size = 0		# in megabytes; 0 disables
 max_slot_wal_keep_size = 512    # in megabytes; -1 disables

--- a/nix/tools/update_readme.nu
+++ b/nix/tools/update_readme.nu
@@ -229,7 +229,7 @@ def update_readme [] {
     let features_content = [
         ($pg_versions | each {|version| create_version_link $version} | str join "\n")
         "- ✅ Ubuntu 24.04 (Noble Numbat)."
-        "- ✅ [wal_level](https://www.postgresql.org/docs/current/runtime-config-wal.html) = logical and [max_replication_slots](https://www.postgresql.org/docs/current/runtime-config-replication.html) = 5. Ready for replication."
+        "- ✅ [wal_level](https://www.postgresql.org/docs/current/runtime-config-wal.html) = logical and [max_replication_slots](https://www.postgresql.org/docs/current/runtime-config-replication.html) = 10. Ready for replication."
         "- ✅ [Large Systems Extensions](https://github.com/aws/aws-graviton-getting-started#building-for-graviton-and-graviton2). Enabled for ARM images."
     ]
 


### PR DESCRIPTION
## Summary

The AMI's postgresql.conf template caps `max_replication_slots` at 5, overriding PostgreSQL's own upstream default of 10. This is a single shared pool covering both logical and physical replication slots, so Realtime, customer logical replication, and physical read-replica slots all draw from the same ceiling. Raises the default to 10 to match upstream and give more headroom before that ceiling is hit.

---

<details>
<summary>Details</summary>

- `ansible/files/postgresql_config/postgresql.conf.j2` — `max_replication_slots` 5 → 10, matching `max_wal_senders` (already 10 in this same file) and PostgreSQL's own upstream default.

Surfaced while reviewing supabase/platform#35057 (physical replication slots for read replicas): every read replica now permanently consumes one of these slots on its primary. Only 31 projects fleet-wide currently override this key, meaning almost every project is capped at the AMI's default — a project running Realtime plus a couple of read replicas plus any customer logical replication is already at or near 5.

Only affects newly-provisioned instances going forward; existing instances keep their current setting until their next config regeneration/restart (`max_replication_slots` is `postmaster`-context).

</details>

---

<details>
<summary>Testing</summary>

- Single-line config default change, no logic touched
- No other reference to this default exists elsewhere in the repo (`grep -rn max_replication_slots`)

</details>

---

Resolves INDATA-1301