### PR TITLE
Drop extra nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -134,15 +134,16 @@
     "nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1760472641,
-        "narHash": "sha256-BuKtM7Vr5EcxBXxUENBQPlOBwmNd5mkTRkSmlJi/iQ4=",
+        "lastModified": 1783987836,
+        "narHash": "sha256-UkRzz0meYeuSQt5rQodwfiSe1If+5JojDP7Kxk0beXM=",
         "owner": "NixOS",
         "repo": "nix",
-        "rev": "4041bfdb401ad6d1c31a292fab90392254be506a",
+        "rev": "aa2613fa02ca6199fe0ebf61a0f7f6d781d32a47",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "2.35-maintenance",
         "repo": "nix",
         "type": "github"
       }
@@ -196,17 +197,19 @@
           "flake-parts"
         ],
         "nix": "nix",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "treefmt-nix": [
           "treefmt-nix"
         ]
       },
       "locked": {
-        "lastModified": 1760478325,
-        "narHash": "sha256-hA+NOH8KDcsuvH7vJqSwk74PyZP3MtvI/l+CggZcnTc=",
+        "lastModified": 1787481553,
+        "narHash": "sha256-ONwaWBw8TYSCExNr1VBqLcKNaA2/plPbG3w4nM6l5+w=",
         "owner": "nix-community",
         "repo": "nix-eval-jobs",
-        "rev": "daa42f9e9c84aeff1e325dd50fda321f53dfd02c",
+        "rev": "01972e4e77f7d2317401cfe9f6c836d79d0ade93",
         "type": "github"
       },
       "original": {
@@ -237,15 +240,15 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 315532800,
-        "narHash": "sha256-vhAtaRMIQiEghARviANBmSnhGz9Qf2IQJ+nQgsDXnVs=",
-        "rev": "c12c63cd6c5eb34c7b4c3076c6a99e00fcab86ec",
+        "lastModified": 1767379071,
+        "narHash": "sha256-3xDI4xtzovwqE/eAxCwmXxUqBg6Yoam2L1u0IwRNhW4=",
+        "rev": "fb7944c166a3b630f177938e478f0378e64ce108",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.11pre877036.c12c63cd6c5e/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.05pre921484.fb7944c166a3/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://nixos.org/channels/nixpkgs-unstable/nixexprs.tar.xz"
+        "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
       }
     },
     "nixpkgs-lib": {
@@ -263,19 +266,6 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1767379071,
-        "narHash": "sha256-3xDI4xtzovwqE/eAxCwmXxUqBg6Yoam2L1u0IwRNhW4=",
-        "rev": "fb7944c166a3b630f177938e478f0378e64ce108",
-        "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.05pre921484.fb7944c166a3/nixexprs.tar.xz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
-      }
-    },
     "root": {
       "inputs": {
         "devshell": "devshell",
@@ -287,7 +277,7 @@
         "nix-editor": "nix-editor",
         "nix-eval-jobs": "nix-eval-jobs",
         "nix2container": "nix2container",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay",
         "treefmt-nix": "treefmt-nix"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -263,22 +263,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-oldstable": {
-      "locked": {
-        "lastModified": 1712666087,
-        "narHash": "sha256-WwjUkWsjlU8iUImbivlYxNyMB1L5YVqE8QotQdL9jWc=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "a76c4553d7e741e17f289224eda135423de0491d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "a76c4553d7e741e17f289224eda135423de0491d",
-        "type": "github"
-      }
-    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1767379071,
@@ -304,7 +288,6 @@
         "nix-eval-jobs": "nix-eval-jobs",
         "nix2container": "nix2container",
         "nixpkgs": "nixpkgs_2",
-        "nixpkgs-oldstable": "nixpkgs-oldstable",
         "rust-overlay": "rust-overlay",
         "treefmt-nix": "treefmt-nix"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -23,9 +23,6 @@
     nix-eval-jobs.url = "github:nix-community/nix-eval-jobs";
     nix2container.inputs.nixpkgs.follows = "nixpkgs";
     nix2container.url = "github:nlewo/nix2container";
-    # Pin to a specific nixpkgs version that has compatible v8 and curl versions
-    # for extensions that require older package versions
-    nixpkgs-oldstable.url = "github:NixOS/nixpkgs/a76c4553d7e741e17f289224eda135423de0491d";
     nixpkgs.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
     rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
     rust-overlay.url = "github:oxalica/rust-overlay";

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,7 @@
     nix-editor.inputs.utils.follows = "flake-utils";
     nix-editor.url = "github:snowfallorg/nix-editor";
     nix-eval-jobs.inputs.flake-parts.follows = "flake-parts";
+    nix-eval-jobs.inputs.nixpkgs.follows = "nixpkgs";
     nix-eval-jobs.inputs.treefmt-nix.follows = "treefmt-nix";
     nix-eval-jobs.url = "github:nix-community/nix-eval-jobs";
     nix2container.inputs.nixpkgs.follows = "nixpkgs";

--- a/nix/ext/plv8/default.nix
+++ b/nix/ext/plv8/default.nix
@@ -40,17 +40,16 @@ let
   numberOfVersionsBuilt = builtins.length versionsBuilt;
   packages = builtins.attrValues (lib.mapAttrs (name: value: build name value.hash) versionsToUse);
 
-  # plv8 3.1 requires an older version of v8 (we cannot use nodejs.libv8)
-  v8 = v8_oldstable;
-
   # Build function for individual versions
   build =
     version: hash:
+    let
+      # plv8 3.1 requires an older version of v8
+      old = lib.versionOlder version "3.2";
+      v8 = if old then v8_oldstable else nodejs_20.libv8;
+    in
     stdenv.mkDerivation (finalAttrs: {
       inherit pname version;
-      #version = "3.1.10";
-
-      v8 = (if (builtins.compareVersions "3.1.10" version >= 0) then v8 else nodejs_20.libv8);
 
       src = fetchFromGitHub {
         owner = "plv8";
@@ -64,7 +63,7 @@ let
         # https://github.com/plv8/plv8/pull/505 (rejected)
         ./0001-build-Allow-using-V8-from-system-${version}.patch
       ]
-      ++ lib.optionals (builtins.compareVersions "3.1.10" version >= 0) [
+      ++ lib.optionals old [
         # Apply https://github.com/plv8/plv8/pull/552/ patch to fix extension upgrade problems
         ./0001-fix-upgrade-related-woes-with-GUC-redefinitions-${version}.patch
       ];
@@ -78,8 +77,8 @@ let
       ];
 
       buildInputs = [
-        (if (builtins.compareVersions "3.1.10" version >= 0) then v8 else nodejs_20.libv8)
         postgresql
+        v8
       ];
 
       buildFlags = [ "all" ];
@@ -163,9 +162,7 @@ let
         fi
 
         # plv8 3.2.x removed support for coffeejs and livescript
-        EXTENSIONS=(${
-          if (builtins.compareVersions "3.1.10" version >= 0) then "plv8 plcoffee plls" else "plv8"
-        })
+        EXTENSIONS=(${if old then "plv8 plcoffee plls" else "plv8"})
         for ext in "''${EXTENSIONS[@]}" ; do
           cp $ext--${version}.sql $out/share/postgresql/extension
           install -Dm644 $ext.control $out/share/postgresql/extension/$ext--${version}.control
@@ -207,10 +204,10 @@ let
         description = "V8 Engine Javascript Procedural Language add-on for PostgreSQL";
         homepage = "https://plv8.github.io/";
         platforms = [
-          "x86_64-linux"
-          "aarch64-linux"
           "aarch64-darwin"
+          "aarch64-linux"
           "x86_64-darwin"
+          "x86_64-linux"
         ];
         license = licenses.postgresql;
       };

--- a/nix/ext/plv8/default.nix
+++ b/nix/ext/plv8/default.nix
@@ -13,7 +13,7 @@
   buildEnv,
   nodejs_20,
   libcxx,
-  v8_oldstable,
+  v8_9_7_106,
   latestOnly ? false,
 }:
 
@@ -46,7 +46,7 @@ let
     let
       # plv8 3.1 requires an older version of v8
       old = lib.versionOlder version "3.2";
-      v8 = if old then v8_oldstable else nodejs_20.libv8;
+      v8 = if old then v8_9_7_106 else nodejs_20.libv8;
     in
     stdenv.mkDerivation (finalAttrs: {
       inherit pname version;

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -6,23 +6,17 @@
       _module.args.pkgs = import inputs.nixpkgs {
         inherit system;
         config.allowUnfree = true;
-        permittedInsecurePackages = [ "v8-9.7.106.18" ];
+        config.permittedInsecurePackages = [
+          "curl-8.6.0"
+          "v8-9.7.106.18"
+        ];
         overlays = [
           (import inputs.rust-overlay)
           self.overlays.default
-          (
-            let
-              # Provide older versions of packages required by some extensions
-              oldstable = import inputs.nixpkgs-oldstable {
-                inherit system;
-                config.allowUnfree = true;
-              };
-            in
-            _final: _prev: {
-              curl_8_6 = oldstable.curl;
-              v8_oldstable = oldstable.v8;
-            }
-          )
+          (_final: _prev: {
+            curl_8_6 = _prev.callPackage ./packages/curl-8_6 { };
+            v8_9_7_106 = _prev.callPackage ./packages/v8-9_7_106 { };
+          })
           inputs.devshell.overlays.default
         ];
       };

--- a/nix/packages/curl-8_6/default.nix
+++ b/nix/packages/curl-8_6/default.nix
@@ -1,0 +1,36 @@
+{
+  curl,
+  fetchurl,
+}:
+
+let
+  version = "8.6.0";
+in
+curl.overrideAttrs (old: {
+  inherit version;
+
+  src = fetchurl {
+    urls = [
+      "https://curl.se/download/curl-${version}.tar.xz"
+      "https://github.com/curl/curl/releases/download/curl-${
+        builtins.replaceStrings [ "." ] [ "_" ] version
+      }/curl-${version}.tar.xz"
+    ];
+    hash = "sha256-PM1V2Rr5UWU534BiX4GMc03G8uz5utozx2dl6ZEh2xU=";
+  };
+
+  configureFlags = builtins.filter (
+    flag:
+    !builtins.elem flag [
+      # these flags don't exist in curl 8.6 so would fail the configure when supplied
+      "--with-nghttp3"
+      "--with-ngtcp2"
+    ]
+  ) old.configureFlags;
+
+  meta = old.meta // {
+    knownVulnerabilities = [
+      "curl 8.6.0 is outdated and has multiple publicly known vulnerabilities"
+    ];
+  };
+})

--- a/nix/packages/v8-9_7_106/clang-21.patch
+++ b/nix/packages/v8-9_7_106/clang-21.patch
@@ -1,0 +1,412 @@
+# Clang 21 promotes -Wenum-constexpr-conversion to a hard error.
+# V8 9.7's BitField stores the maximum unsigned field value in T, which is invalid when T is a narrow enum.
+# Keep kMax in the unsigned storage type and validate typed values through is_valid instead of comparing them directly with kMax.
+#
+# The removed source-position DCHECKs remain enforced by BitField::update, which calls encode and checks is_valid in debug builds.
+diff --git a/src/base/bit-field.h b/src/base/bit-field.h
+index 7b2796e..3fbfd0d 100644
+--- a/src/base/bit-field.h
++++ b/src/base/bit-field.h
+@@ -40,14 +40,14 @@ class BitField final {
+   static constexpr U kNumValues = U{1} << kSize;
+ 
+   // Value for the field with all bits set.
+-  static constexpr T kMax = static_cast<T>(kNumValues - 1);
++  static constexpr U kMax = kNumValues - 1;
+ 
+   template <class T2, int size2>
+   using Next = BitField<T2, kShift + kSize, size2, U>;
+ 
+   // Tells whether the provided value fits into the bit field.
+   static constexpr bool is_valid(T value) {
+-    return (static_cast<U>(value) & ~static_cast<U>(kMax)) == 0;
++    return (static_cast<U>(value) & ~kMax) == 0;
+   }
+ 
+   // Returns a type U with the bit field value encoded.
+diff --git a/src/objects/feedback-vector.h b/src/objects/feedback-vector.h
+index 0fcb97f..d5fc9c1 100644
+--- a/src/objects/feedback-vector.h
++++ b/src/objects/feedback-vector.h
+@@ -203,10 +203,10 @@ class FeedbackVector
+  public:
+   NEVER_READ_ONLY_SPACE
+   DEFINE_TORQUE_GENERATED_FEEDBACK_VECTOR_FLAGS()
+-  STATIC_ASSERT(OptimizationMarker::kLastOptimizationMarker <
+-                OptimizationMarkerBits::kMax);
+-  STATIC_ASSERT(OptimizationTier::kLastOptimizationTier <
+-                OptimizationTierBits::kMax);
++  STATIC_ASSERT(OptimizationMarkerBits::is_valid(
++      OptimizationMarker::kLastOptimizationMarker));
++  STATIC_ASSERT(OptimizationTierBits::is_valid(
++      OptimizationTier::kLastOptimizationTier));
+ 
+   static const bool kFeedbackVectorMaybeOptimizedCodeIsStoreRelease = true;
+   using TorqueGeneratedFeedbackVector<FeedbackVector,
+diff --git a/src/objects/js-date-time-format.h b/src/objects/js-date-time-format.h
+index 9c5b2f9..e7bed60 100644
+--- a/src/objects/js-date-time-format.h
++++ b/src/objects/js-date-time-format.h
+@@ -105,23 +105,23 @@ class JSDateTimeFormat
+   // Bit positions in |flags|.
+   DEFINE_TORQUE_GENERATED_JS_DATE_TIME_FORMAT_FLAGS()
+ 
+-  STATIC_ASSERT(HourCycle::kUndefined <= HourCycleBits::kMax);
+-  STATIC_ASSERT(HourCycle::kH11 <= HourCycleBits::kMax);
+-  STATIC_ASSERT(HourCycle::kH12 <= HourCycleBits::kMax);
+-  STATIC_ASSERT(HourCycle::kH23 <= HourCycleBits::kMax);
+-  STATIC_ASSERT(HourCycle::kH24 <= HourCycleBits::kMax);
++  STATIC_ASSERT(HourCycleBits::is_valid(HourCycle::kUndefined));
++  STATIC_ASSERT(HourCycleBits::is_valid(HourCycle::kH11));
++  STATIC_ASSERT(HourCycleBits::is_valid(HourCycle::kH12));
++  STATIC_ASSERT(HourCycleBits::is_valid(HourCycle::kH23));
++  STATIC_ASSERT(HourCycleBits::is_valid(HourCycle::kH24));
+ 
+-  STATIC_ASSERT(DateTimeStyle::kUndefined <= DateStyleBits::kMax);
+-  STATIC_ASSERT(DateTimeStyle::kFull <= DateStyleBits::kMax);
+-  STATIC_ASSERT(DateTimeStyle::kLong <= DateStyleBits::kMax);
+-  STATIC_ASSERT(DateTimeStyle::kMedium <= DateStyleBits::kMax);
+-  STATIC_ASSERT(DateTimeStyle::kShort <= DateStyleBits::kMax);
++  STATIC_ASSERT(DateStyleBits::is_valid(DateTimeStyle::kUndefined));
++  STATIC_ASSERT(DateStyleBits::is_valid(DateTimeStyle::kFull));
++  STATIC_ASSERT(DateStyleBits::is_valid(DateTimeStyle::kLong));
++  STATIC_ASSERT(DateStyleBits::is_valid(DateTimeStyle::kMedium));
++  STATIC_ASSERT(DateStyleBits::is_valid(DateTimeStyle::kShort));
+ 
+-  STATIC_ASSERT(DateTimeStyle::kUndefined <= TimeStyleBits::kMax);
+-  STATIC_ASSERT(DateTimeStyle::kFull <= TimeStyleBits::kMax);
+-  STATIC_ASSERT(DateTimeStyle::kLong <= TimeStyleBits::kMax);
+-  STATIC_ASSERT(DateTimeStyle::kMedium <= TimeStyleBits::kMax);
+-  STATIC_ASSERT(DateTimeStyle::kShort <= TimeStyleBits::kMax);
++  STATIC_ASSERT(TimeStyleBits::is_valid(DateTimeStyle::kUndefined));
++  STATIC_ASSERT(TimeStyleBits::is_valid(DateTimeStyle::kFull));
++  STATIC_ASSERT(TimeStyleBits::is_valid(DateTimeStyle::kLong));
++  STATIC_ASSERT(TimeStyleBits::is_valid(DateTimeStyle::kMedium));
++  STATIC_ASSERT(TimeStyleBits::is_valid(DateTimeStyle::kShort));
+ 
+   DECL_ACCESSORS(icu_locale, Managed<icu::Locale>)
+   DECL_ACCESSORS(icu_simple_date_format, Managed<icu::SimpleDateFormat>)
+diff --git a/src/objects/js-display-names-inl.h b/src/objects/js-display-names-inl.h
+index d5c5553..da2605a 100644
+--- a/src/objects/js-display-names-inl.h
++++ b/src/objects/js-display-names-inl.h
+@@ -25,7 +25,7 @@ ACCESSORS(JSDisplayNames, internal, Managed<DisplayNamesInternal>,
+ TQ_OBJECT_CONSTRUCTORS_IMPL(JSDisplayNames)
+ 
+ inline void JSDisplayNames::set_style(Style style) {
+-  DCHECK_GE(StyleBits::kMax, style);
++  DCHECK(StyleBits::is_valid(style));
+   set_flags(StyleBits::update(flags(), style));
+ }
+ 
+@@ -34,7 +34,7 @@ inline JSDisplayNames::Style JSDisplayNames::style() const {
+ }
+ 
+ inline void JSDisplayNames::set_fallback(Fallback fallback) {
+-  DCHECK_GE(FallbackBit::kMax, fallback);
++  DCHECK(FallbackBit::is_valid(fallback));
+   set_flags(FallbackBit::update(flags(), fallback));
+ }
+ 
+@@ -44,7 +44,7 @@ inline JSDisplayNames::Fallback JSDisplayNames::fallback() const {
+ 
+ inline void JSDisplayNames::set_language_display(
+     LanguageDisplay language_display) {
+-  DCHECK_GE(LanguageDisplayBit::kMax, language_display);
++  DCHECK(LanguageDisplayBit::is_valid(language_display));
+   set_flags(LanguageDisplayBit::update(flags(), language_display));
+ }
+ 
+diff --git a/src/objects/js-display-names.h b/src/objects/js-display-names.h
+index 373b826..cd7a8dd 100644
+--- a/src/objects/js-display-names.h
++++ b/src/objects/js-display-names.h
+@@ -79,13 +79,13 @@ class JSDisplayNames
+   // Bit positions in |flags|.
+   DEFINE_TORQUE_GENERATED_JS_DISPLAY_NAMES_FLAGS()
+ 
+-  STATIC_ASSERT(Style::kLong <= StyleBits::kMax);
+-  STATIC_ASSERT(Style::kShort <= StyleBits::kMax);
+-  STATIC_ASSERT(Style::kNarrow <= StyleBits::kMax);
+-  STATIC_ASSERT(Fallback::kCode <= FallbackBit::kMax);
+-  STATIC_ASSERT(Fallback::kNone <= FallbackBit::kMax);
+-  STATIC_ASSERT(LanguageDisplay::kDialect <= LanguageDisplayBit::kMax);
+-  STATIC_ASSERT(LanguageDisplay::kStandard <= LanguageDisplayBit::kMax);
++  STATIC_ASSERT(StyleBits::is_valid(Style::kLong));
++  STATIC_ASSERT(StyleBits::is_valid(Style::kShort));
++  STATIC_ASSERT(StyleBits::is_valid(Style::kNarrow));
++  STATIC_ASSERT(FallbackBit::is_valid(Fallback::kCode));
++  STATIC_ASSERT(FallbackBit::is_valid(Fallback::kNone));
++  STATIC_ASSERT(LanguageDisplayBit::is_valid(LanguageDisplay::kDialect));
++  STATIC_ASSERT(LanguageDisplayBit::is_valid(LanguageDisplay::kStandard));
+ 
+   DECL_ACCESSORS(internal, Managed<DisplayNamesInternal>)
+ 
+diff --git a/src/objects/js-list-format-inl.h b/src/objects/js-list-format-inl.h
+index e7e0384..34d7ee0 100644
+--- a/src/objects/js-list-format-inl.h
++++ b/src/objects/js-list-format-inl.h
+@@ -27,7 +27,7 @@ ACCESSORS(JSListFormat, icu_formatter, Managed<icu::ListFormatter>,
+           kIcuFormatterOffset)
+ 
+ inline void JSListFormat::set_style(Style style) {
+-  DCHECK_GE(StyleBits::kMax, style);
++  DCHECK(StyleBits::is_valid(style));
+   int hints = flags();
+   hints = StyleBits::update(hints, style);
+   set_flags(hints);
+@@ -38,7 +38,7 @@ inline JSListFormat::Style JSListFormat::style() const {
+ }
+ 
+ inline void JSListFormat::set_type(Type type) {
+-  DCHECK_GE(TypeBits::kMax, type);
++  DCHECK(TypeBits::is_valid(type));
+   int hints = flags();
+   hints = TypeBits::update(hints, type);
+   set_flags(hints);
+diff --git a/src/objects/js-list-format.h b/src/objects/js-list-format.h
+index 123f9e4..aeaae7f 100644
+--- a/src/objects/js-list-format.h
++++ b/src/objects/js-list-format.h
+@@ -86,12 +86,12 @@ class JSListFormat
+   // Bit positions in |flags|.
+   DEFINE_TORQUE_GENERATED_JS_LIST_FORMAT_FLAGS()
+ 
+-  STATIC_ASSERT(Style::LONG <= StyleBits::kMax);
+-  STATIC_ASSERT(Style::SHORT <= StyleBits::kMax);
+-  STATIC_ASSERT(Style::NARROW <= StyleBits::kMax);
+-  STATIC_ASSERT(Type::CONJUNCTION <= TypeBits::kMax);
+-  STATIC_ASSERT(Type::DISJUNCTION <= TypeBits::kMax);
+-  STATIC_ASSERT(Type::UNIT <= TypeBits::kMax);
++  STATIC_ASSERT(StyleBits::is_valid(Style::LONG));
++  STATIC_ASSERT(StyleBits::is_valid(Style::SHORT));
++  STATIC_ASSERT(StyleBits::is_valid(Style::NARROW));
++  STATIC_ASSERT(TypeBits::is_valid(Type::CONJUNCTION));
++  STATIC_ASSERT(TypeBits::is_valid(Type::DISJUNCTION));
++  STATIC_ASSERT(TypeBits::is_valid(Type::UNIT));
+ 
+   DECL_PRINTER(JSListFormat)
+ 
+diff --git a/src/objects/js-plural-rules-inl.h b/src/objects/js-plural-rules-inl.h
+index fb4a97e..f31723f 100644
+--- a/src/objects/js-plural-rules-inl.h
++++ b/src/objects/js-plural-rules-inl.h
+@@ -30,7 +30,7 @@ ACCESSORS(JSPluralRules, icu_number_formatter,
+           kIcuNumberFormatterOffset)
+ 
+ inline void JSPluralRules::set_type(Type type) {
+-  DCHECK_LE(type, TypeBit::kMax);
++  DCHECK(TypeBit::is_valid(type));
+   int hints = flags();
+   hints = TypeBit::update(hints, type);
+   set_flags(hints);
+diff --git a/src/objects/js-plural-rules.h b/src/objects/js-plural-rules.h
+index bd0bfe6..079b9b8 100644
+--- a/src/objects/js-plural-rules.h
++++ b/src/objects/js-plural-rules.h
+@@ -62,8 +62,8 @@ class JSPluralRules
+   // Bit positions in |flags|.
+   DEFINE_TORQUE_GENERATED_JS_PLURAL_RULES_FLAGS()
+ 
+-  STATIC_ASSERT(Type::CARDINAL <= TypeBit::kMax);
+-  STATIC_ASSERT(Type::ORDINAL <= TypeBit::kMax);
++  STATIC_ASSERT(TypeBit::is_valid(Type::CARDINAL));
++  STATIC_ASSERT(TypeBit::is_valid(Type::ORDINAL));
+ 
+   DECL_ACCESSORS(icu_plural_rules, Managed<icu::PluralRules>)
+   DECL_ACCESSORS(icu_number_formatter,
+diff --git a/src/objects/js-relative-time-format-inl.h b/src/objects/js-relative-time-format-inl.h
+index 4afdaa3..5de591d 100644
+--- a/src/objects/js-relative-time-format-inl.h
++++ b/src/objects/js-relative-time-format-inl.h
+@@ -27,7 +27,7 @@ ACCESSORS(JSRelativeTimeFormat, icu_formatter,
+           Managed<icu::RelativeDateTimeFormatter>, kIcuFormatterOffset)
+ 
+ inline void JSRelativeTimeFormat::set_numeric(Numeric numeric) {
+-  DCHECK_GE(NumericBit::kMax, numeric);
++  DCHECK(NumericBit::is_valid(numeric));
+   int hints = flags();
+   hints = NumericBit::update(hints, numeric);
+   set_flags(hints);
+diff --git a/src/objects/js-relative-time-format.h b/src/objects/js-relative-time-format.h
+index 444082c..80ecc05 100644
+--- a/src/objects/js-relative-time-format.h
++++ b/src/objects/js-relative-time-format.h
+@@ -77,8 +77,8 @@ class JSRelativeTimeFormat
+   // Bit positions in |flags|.
+   DEFINE_TORQUE_GENERATED_JS_RELATIVE_TIME_FORMAT_FLAGS()
+ 
+-  STATIC_ASSERT(Numeric::AUTO <= NumericBit::kMax);
+-  STATIC_ASSERT(Numeric::ALWAYS <= NumericBit::kMax);
++  STATIC_ASSERT(NumericBit::is_valid(Numeric::AUTO));
++  STATIC_ASSERT(NumericBit::is_valid(Numeric::ALWAYS));
+ 
+   DECL_PRINTER(JSRelativeTimeFormat)
+ 
+diff --git a/src/objects/js-segment-iterator-inl.h b/src/objects/js-segment-iterator-inl.h
+index 979a1c7..b02c22e 100644
+--- a/src/objects/js-segment-iterator-inl.h
++++ b/src/objects/js-segment-iterator-inl.h
+@@ -29,7 +29,7 @@ ACCESSORS(JSSegmentIterator, unicode_string, Managed<icu::UnicodeString>,
+ 
+ inline void JSSegmentIterator::set_granularity(
+     JSSegmenter::Granularity granularity) {
+-  DCHECK_GE(GranularityBits::kMax, granularity);
++  DCHECK(GranularityBits::is_valid(granularity));
+   int hints = flags();
+   hints = GranularityBits::update(hints, granularity);
+   set_flags(hints);
+diff --git a/src/objects/js-segment-iterator.h b/src/objects/js-segment-iterator.h
+index bcbc22d..665bb6f 100644
+--- a/src/objects/js-segment-iterator.h
++++ b/src/objects/js-segment-iterator.h
+@@ -55,9 +55,9 @@ class JSSegmentIterator
+   // Bit positions in |flags|.
+   DEFINE_TORQUE_GENERATED_JS_SEGMENT_ITERATOR_FLAGS()
+ 
+-  STATIC_ASSERT(JSSegmenter::Granularity::GRAPHEME <= GranularityBits::kMax);
+-  STATIC_ASSERT(JSSegmenter::Granularity::WORD <= GranularityBits::kMax);
+-  STATIC_ASSERT(JSSegmenter::Granularity::SENTENCE <= GranularityBits::kMax);
++  STATIC_ASSERT(GranularityBits::is_valid(JSSegmenter::Granularity::GRAPHEME));
++  STATIC_ASSERT(GranularityBits::is_valid(JSSegmenter::Granularity::WORD));
++  STATIC_ASSERT(GranularityBits::is_valid(JSSegmenter::Granularity::SENTENCE));
+ 
+   TQ_OBJECT_CONSTRUCTORS(JSSegmentIterator)
+ };
+diff --git a/src/objects/js-segmenter-inl.h b/src/objects/js-segmenter-inl.h
+index e674426..b7a3f5c 100644
+--- a/src/objects/js-segmenter-inl.h
++++ b/src/objects/js-segmenter-inl.h
+@@ -26,7 +26,7 @@ ACCESSORS(JSSegmenter, icu_break_iterator, Managed<icu::BreakIterator>,
+           kIcuBreakIteratorOffset)
+ 
+ inline void JSSegmenter::set_granularity(Granularity granularity) {
+-  DCHECK_GE(GranularityBits::kMax, granularity);
++  DCHECK(GranularityBits::is_valid(granularity));
+   int hints = flags();
+   hints = GranularityBits::update(hints, granularity);
+   set_flags(hints);
+diff --git a/src/objects/js-segmenter.h b/src/objects/js-segmenter.h
+index 512625d..4e4f29b 100644
+--- a/src/objects/js-segmenter.h
++++ b/src/objects/js-segmenter.h
+@@ -65,9 +65,9 @@ class JSSegmenter : public TorqueGeneratedJSSegmenter<JSSegmenter, JSObject> {
+   // Bit positions in |flags|.
+   DEFINE_TORQUE_GENERATED_JS_SEGMENTER_FLAGS()
+ 
+-  STATIC_ASSERT(Granularity::GRAPHEME <= GranularityBits::kMax);
+-  STATIC_ASSERT(Granularity::WORD <= GranularityBits::kMax);
+-  STATIC_ASSERT(Granularity::SENTENCE <= GranularityBits::kMax);
++  STATIC_ASSERT(GranularityBits::is_valid(Granularity::GRAPHEME));
++  STATIC_ASSERT(GranularityBits::is_valid(Granularity::WORD));
++  STATIC_ASSERT(GranularityBits::is_valid(Granularity::SENTENCE));
+ 
+   DECL_PRINTER(JSSegmenter)
+ 
+diff --git a/src/objects/js-segments-inl.h b/src/objects/js-segments-inl.h
+index 37fc496..5ca0f94 100644
+--- a/src/objects/js-segments-inl.h
++++ b/src/objects/js-segments-inl.h
+@@ -28,7 +28,7 @@ ACCESSORS(JSSegments, unicode_string, Managed<icu::UnicodeString>,
+           kUnicodeStringOffset)
+ 
+ inline void JSSegments::set_granularity(JSSegmenter::Granularity granularity) {
+-  DCHECK_GE(GranularityBits::kMax, granularity);
++  DCHECK(GranularityBits::is_valid(granularity));
+   int hints = flags();
+   hints = GranularityBits::update(hints, granularity);
+   set_flags(hints);
+diff --git a/src/objects/js-segments.h b/src/objects/js-segments.h
+index 30c387f..bdeda87 100644
+--- a/src/objects/js-segments.h
++++ b/src/objects/js-segments.h
+@@ -59,9 +59,9 @@ class JSSegments : public TorqueGeneratedJSSegments<JSSegments, JSObject> {
+   // Bit positions in |flags|.
+   DEFINE_TORQUE_GENERATED_JS_SEGMENT_ITERATOR_FLAGS()
+ 
+-  STATIC_ASSERT(JSSegmenter::Granularity::GRAPHEME <= GranularityBits::kMax);
+-  STATIC_ASSERT(JSSegmenter::Granularity::WORD <= GranularityBits::kMax);
+-  STATIC_ASSERT(JSSegmenter::Granularity::SENTENCE <= GranularityBits::kMax);
++  STATIC_ASSERT(GranularityBits::is_valid(JSSegmenter::Granularity::GRAPHEME));
++  STATIC_ASSERT(GranularityBits::is_valid(JSSegmenter::Granularity::WORD));
++  STATIC_ASSERT(GranularityBits::is_valid(JSSegmenter::Granularity::SENTENCE));
+ 
+   TQ_OBJECT_CONSTRUCTORS(JSSegments)
+ };
+diff --git a/src/objects/map.h b/src/objects/map.h
+index 4e19915..5fd4dc9 100644
+--- a/src/objects/map.h
++++ b/src/objects/map.h
+@@ -303,8 +303,8 @@ class Map : public TorqueGeneratedMap<Map, HeapObject> {
+   static const int kSlackTrackingCounterStart = 7;
+   static const int kSlackTrackingCounterEnd = 1;
+   static const int kNoSlackTracking = 0;
+-  STATIC_ASSERT(kSlackTrackingCounterStart <=
+-                Bits3::ConstructionCounterBits::kMax);
++  STATIC_ASSERT(Bits3::ConstructionCounterBits::is_valid(
++      kSlackTrackingCounterStart));
+ 
+   // Inobject slack tracking is the way to reclaim unused inobject space.
+   //
+diff --git a/src/objects/scope-info.h b/src/objects/scope-info.h
+index 11c06a7..b92fdb3 100644
+--- a/src/objects/scope-info.h
++++ b/src/objects/scope-info.h
+@@ -274,7 +274,7 @@ class ScopeInfo : public TorqueGeneratedScopeInfo<ScopeInfo, HeapObject> {
+   };
+ 
+   STATIC_ASSERT(LanguageModeSize == 1 << LanguageModeBit::kSize);
+-  STATIC_ASSERT(kLastFunctionKind <= FunctionKindBits::kMax);
++  STATIC_ASSERT(FunctionKindBits::is_valid(kLastFunctionKind));
+ 
+   bool IsEmpty() const;
+ 
+diff --git a/src/objects/shared-function-info.h b/src/objects/shared-function-info.h
+index e701587..ee328eb 100644
+--- a/src/objects/shared-function-info.h
++++ b/src/objects/shared-function-info.h
+@@ -627,12 +627,12 @@ class SharedFunctionInfo
+   class BodyDescriptor;
+ 
+   // Bailout reasons must fit in the DisabledOptimizationReason bitfield.
+-  STATIC_ASSERT(BailoutReason::kLastErrorMessage <=
+-                DisabledOptimizationReasonBits::kMax);
++  STATIC_ASSERT(DisabledOptimizationReasonBits::is_valid(
++      BailoutReason::kLastErrorMessage));
+ 
+-  STATIC_ASSERT(kLastFunctionKind <= FunctionKindBits::kMax);
+-  STATIC_ASSERT(FunctionSyntaxKind::kLastFunctionSyntaxKind <=
+-                FunctionSyntaxKindBits::kMax);
++  STATIC_ASSERT(FunctionKindBits::is_valid(kLastFunctionKind));
++  STATIC_ASSERT(FunctionSyntaxKindBits::is_valid(
++      FunctionSyntaxKind::kLastFunctionSyntaxKind));
+ 
+   // Sets the bytecode in {shared}'s DebugInfo as the bytecode to
+   // be returned by following calls to GetActiveBytecodeArray. Stores a
+diff --git a/src/codegen/source-position.h b/src/codegen/source-position.h
+--- a/src/codegen/source-position.h
++++ b/src/codegen/source-position.h
+@@ -99,23 +99,19 @@ class SourcePosition final {
+   }
+   void SetExternalLine(int line) {
+     DCHECK(IsExternal());
+-    DCHECK(line <= ExternalLineField::kMax - 1);
+     value_ = ExternalLineField::update(value_, line);
+   }
+   void SetExternalFileId(int file_id) {
+     DCHECK(IsExternal());
+-    DCHECK(file_id <= ExternalFileIdField::kMax - 1);
+     value_ = ExternalFileIdField::update(value_, file_id);
+   }
+ 
+   void SetScriptOffset(int script_offset) {
+     DCHECK(IsJavaScript());
+-    DCHECK(script_offset <= ScriptOffsetField::kMax - 2);
+     DCHECK_GE(script_offset, kNoSourcePosition);
+     value_ = ScriptOffsetField::update(value_, script_offset + 1);
+   }
+   void SetInliningId(int inlining_id) {
+-    DCHECK(inlining_id <= InliningIdField::kMax - 2);
+     DCHECK_GE(inlining_id, kNotInlined);
+     value_ = InliningIdField::update(value_, inlining_id + 1);
+   }

--- a/nix/packages/v8-9_7_106/darwin.patch
+++ b/nix/packages/v8-9_7_106/darwin.patch
@@ -1,0 +1,22 @@
+diff --git a/toolchain/gcc_toolchain.gni b/toolchain/gcc_toolchain.gni
+index 80e2a362a..df138c87b 100644
+--- a/build/toolchain/gcc_toolchain.gni
++++ b/build/toolchain/gcc_toolchain.gni
+@@ -355,6 +355,8 @@ template("gcc_toolchain") {
+         # AIX does not support either -D (deterministic output) or response
+         # files.
+         command = "$ar -X64 {{arflags}} -r -c -s {{output}} {{inputs}}"
++      } else if (current_os == "mac") {
++        command = "$ar {{arflags}} -r -c -s {{output}} {{inputs}}"
+       } else {
+         rspfile = "{{output}}.rsp"
+         rspfile_content = "{{inputs}}"
+@@ -546,7 +548,7 @@ template("gcc_toolchain") {
+ 
+       start_group_flag = ""
+       end_group_flag = ""
+-      if (current_os != "aix") {
++      if (current_os != "aix" && current_os != "mac") {
+         # the "--start-group .. --end-group" feature isn't available on the aix ld.
+         start_group_flag = "-Wl,--start-group"
+         end_group_flag = "-Wl,--end-group "

--- a/nix/packages/v8-9_7_106/default.nix
+++ b/nix/packages/v8-9_7_106/default.nix
@@ -1,0 +1,227 @@
+{
+  stdenv,
+  lib,
+  fetchgit,
+  gn,
+  ninja,
+  python3,
+  glib,
+  pkg-config,
+  icu,
+  xcbuild,
+  fetchpatch,
+  llvmPackages,
+  symlinkJoin,
+}:
+
+# Copied from nixpkgs revision f311b2493888dbf499e769c8015de9b40e4d590d.
+
+let
+  version = "9.7.106.18";
+  v8Src = fetchgit {
+    url = "https://chromium.googlesource.com/v8/v8";
+    rev = version;
+    sha256 = "0cb3w733w1xn6zq9dsr43nx6llcg9hrmb2dkxairarj9c0igpzyh";
+  };
+
+  git_url = "https://chromium.googlesource.com";
+
+  # This data is from the DEPS file in the root of a V8 checkout.
+  deps = {
+    "base/trace_event/common" = fetchgit {
+      url = "${git_url}/chromium/src/base/trace_event/common.git";
+      rev = "7f36dbc19d31e2aad895c60261ca8f726442bfbb";
+      sha256 = "01b2fhbxznqbakxv42ivrzg6w8l7i9yrd9nf72d6p5xx9dm993j4";
+    };
+    "build" = fetchgit {
+      url = "${git_url}/chromium/src/build.git";
+      rev = "cf325916d58a194a935c26a56fcf6b525d1e2bf4";
+      sha256 = "1ix4h1cpx9bvgln8590xh7lllhsd9w1hd5k9l1gx5yxxrmywd3s4";
+    };
+    "third_party/googletest/src" = fetchgit {
+      url = "${git_url}/external/github.com/google/googletest.git";
+      rev = "16f637fbf4ffc3f7a01fa4eceb7906634565242f";
+      sha256 = "11012k3c3mxzdwcw2iparr9lrckafpyhqzclsj26hmfbgbdi0rrh";
+    };
+    "third_party/icu" = fetchgit {
+      url = "${git_url}/chromium/deps/icu.git";
+      rev = "eedbaf76e49d28465d9119b10c30b82906e606ff";
+      sha256 = "0mppvx7wf9zlqjsfaa1cf06brh1fjb6nmiib0lhbb9hd55mqjdjj";
+    };
+    "third_party/zlib" = fetchgit {
+      url = "${git_url}/chromium/src/third_party/zlib.git";
+      rev = "6da1d53b97c89b07e47714d88cab61f1ce003c68";
+      sha256 = "0v7ylmbwfwv6w6wp29qdf77kjjnfr2xzin08n0v1yvbhs01h5ppy";
+    };
+    "third_party/jinja2" = fetchgit {
+      url = "${git_url}/chromium/src/third_party/jinja2.git";
+      rev = "ee69aa00ee8536f61db6a451f3858745cf587de6";
+      sha256 = "1fsnd5h0gisfp8bdsfd81kk5v4mkqf8z368c7qlm1qcwc4ri4x7a";
+    };
+    "third_party/markupsafe" = fetchgit {
+      url = "${git_url}/chromium/src/third_party/markupsafe.git";
+      rev = "1b882ef6372b58bfd55a3285f37ed801be9137cd";
+      sha256 = "1jnjidbh03lhfaawimkjxbprmsgz4snr0jl06630dyd41zkdw5kr";
+    };
+  };
+
+  # See `gn_version` in DEPS.
+  gnSrc = fetchgit {
+    url = "https://gn.googlesource.com/gn";
+    rev = "8926696a4186279489cc2b8d768533e61bba73d7";
+    sha256 = "1084lnyb0a1khbgjvak05fcx6jy973wqvsf77n0alxjys18sg2yk";
+  };
+
+  myGn = gn.overrideAttrs (_oldAttrs: {
+    version = "for-v8";
+    src = gnSrc;
+    configurePhase = ''
+      runHook preConfigure
+
+      python build/gen.py --no-last-commit-position
+      cat > out/last_commit_position.h << EOF
+      #ifndef OUT_LAST_COMMIT_POSITION_H_
+      #define OUT_LAST_COMMIT_POSITION_H_
+
+      #define LAST_COMMIT_POSITION_NUM 1942
+      #define LAST_COMMIT_POSITION "1942 (8926696)"
+
+      #endif  // OUT_LAST_COMMIT_POSITION_H_
+      EOF
+
+      runHook postConfigure
+    '';
+  });
+in
+stdenv.mkDerivation rec {
+  pname = "v8";
+  inherit version;
+
+  doCheck = true;
+
+  patches =
+    lib.optional stdenv.hostPlatform.isDarwin ./darwin.patch
+    ++ lib.optional stdenv.cc.isClang ./clang-21.patch
+    ++ lib.optional stdenv.cc.isGNU (fetchpatch {
+      # gcc-13 build fix for mixxign <cstdint> includes
+      name = "gcc-13.patch";
+      url = "https://chromium.googlesource.com/v8/v8/+/c2792e58035fcbaa16d0cb70998852fbeb5df4cc^!?format=TEXT";
+      decode = "base64 -d";
+      hash = "sha256-hoPAkSaCmzXflPFXaKUwVPLECMpt6N6/8m8mBSTAHbU=";
+    });
+
+  src = v8Src;
+
+  postUnpack = ''
+    ${lib.concatStringsSep "\n" (
+      lib.mapAttrsToList (n: v: ''
+        mkdir -p $sourceRoot/${n}
+        cp -r ${v}/* $sourceRoot/${n}
+      '') deps
+    )}
+    chmod u+w -R .
+  '';
+
+  postPatch = ''
+    ${lib.optionalString stdenv.hostPlatform.isAarch64 ''
+      substituteInPlace build/toolchain/linux/BUILD.gn \
+        --replace 'toolprefix = "aarch64-linux-gnu-"' 'toolprefix = ""'
+    ''}
+    ${lib.optionalString stdenv.hostPlatform.isDarwin ''
+      substituteInPlace build/config/compiler/compiler.gni \
+        --replace 'strip_absolute_paths_from_debug_symbols = true' \
+                  'strip_absolute_paths_from_debug_symbols = false'
+      substituteInPlace build/config/compiler/BUILD.gn \
+        --replace 'current_toolchain == host_toolchain || !use_xcode_clang' \
+                  'false'
+      substituteInPlace third_party/zlib/zutil.h \
+        --replace '#if defined(MACOS) || defined(TARGET_OS_MAC)' \
+                  '#if defined(MACOS)'
+      substituteInPlace build/config/compiler/BUILD.gn \
+        --replace "-Wl,-fatal_warnings" ""
+    ''}
+    touch build/config/gclient_args.gni
+    sed '1i#include <utility>' -i src/heap/cppgc/prefinalizer-handler.h # gcc12
+  '';
+
+  llvmCcAndBintools = symlinkJoin {
+    name = "llvmCcAndBintools";
+    paths = [
+      stdenv.cc
+      llvmPackages.llvm
+    ];
+  };
+
+  gnFlags = [
+    "use_custom_libcxx=false"
+    "is_clang=${lib.boolToString stdenv.cc.isClang}"
+    "use_sysroot=false"
+    # "use_system_icu=true"
+    "clang_use_chrome_plugins=false"
+    "is_component_build=false"
+    "v8_use_external_startup_data=false"
+    "v8_monolithic=true"
+    "is_debug=true"
+    "is_official_build=false"
+    "treat_warnings_as_errors=false"
+    "v8_enable_i18n_support=true"
+    "use_gold=false"
+    # ''custom_toolchain="//build/toolchain/linux/unbundle:default"''
+    ''host_toolchain="//build/toolchain/linux/unbundle:default"''
+    ''v8_snapshot_toolchain="//build/toolchain/linux/unbundle:default"''
+  ]
+  ++ lib.optional stdenv.cc.isClang ''clang_base_path="${llvmCcAndBintools}"''
+  ++ lib.optional stdenv.hostPlatform.isDarwin "use_lld=false";
+
+  env.NIX_CFLAGS_COMPILE = "-O2";
+  FORCE_MAC_SDK_MIN = stdenv.hostPlatform.sdkVer or "10.12";
+
+  nativeBuildInputs = [
+    myGn
+    ninja
+    pkg-config
+    python3
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    xcbuild
+    llvmPackages.llvm
+    python3.pkgs.setuptools
+  ];
+  buildInputs = [
+    glib
+    icu
+  ];
+
+  ninjaFlags = [
+    ":d8"
+    "v8_monolith"
+  ];
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    install -D d8 $out/bin/d8
+    install -D -m644 obj/libv8_monolith.a $out/lib/libv8.a
+    install -D -m644 icudtl.dat $out/share/v8/icudtl.dat
+    ln -s libv8.a $out/lib/libv8_monolith.a
+    cp -r ../../include $out
+
+    mkdir -p $out/lib/pkgconfig
+    cat > $out/lib/pkgconfig/v8.pc << EOF
+    Name: v8
+    Description: V8 JavaScript Engine
+    Version: ${version}
+    Libs: -L$out/lib -lv8 -pthread
+    Cflags: -I$out/include
+    EOF
+  '';
+
+  meta = with lib; {
+    homepage = "https://v8.dev/";
+    description = "Google's open source JavaScript engine";
+    mainProgram = "d8";
+    platforms = platforms.unix;
+    license = licenses.bsd3;
+    knownVulnerabilities = [ "Severely outdated with multiple publicly known vulnerabilities" ];
+  };
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

We have 3 copies of nixpkgs in our flake, 2 are used in our outputs and the other is for nix-eval-jobs.

## What is the new behavior?

Only one nixpkgs.

## Additional context

Dropping unnecessary nixpkgs is nice for a few reasons the most obvious is less needs to be fetch and copied into the store at build time so has some benefits there. The big benefit is in dropping nixpkgs-oldstable which was used for curl v8.6 and v8, but that also ends up "duplicating" all the dependencies (libc + others) with the rest of the tree. Nix handles that fine but bloats our final image. Instead of whole nixpkgs and deps we can just build those old packages on our new nixpkgs and get the functionality without the bloat.