### PR TITLE
test: remove redundant schema existence checks

### DIFF
--- a/migrations/tests/database/exists.sql
+++ b/migrations/tests/database/exists.sql
@@ -1,9 +1,0 @@
-
-SELECT has_schema('public');
-SELECT has_schema('auth');
-SELECT has_schema('pgbouncer');
-SELECT has_schema('extensions');
-SELECT has_schema('graphql');
-SELECT has_schema('graphql_public');
-SELECT has_schema('realtime');
-SELECT has_schema('storage');

--- a/migrations/tests/database/test.sql
+++ b/migrations/tests/database/test.sql
@@ -1,3 +1,1 @@
-
-\ir exists.sql
 \ir privs.sql


### PR DESCRIPTION
## Summary

- remove the redundant `has_schema` assertions from the migration pgTAP suite
- keep `migrations/tests/database/test.sql` focused on the remaining database privilege checks

The eight schemas are already covered by the Nix regression suite with stronger object/ACL snapshots:

- `public`, `graphql_public`, and `realtime`: schema/default ACL rows in `roles.sql` / `roles.out`
- `auth`: namespace owner and object snapshots in `auth.sql` / `auth.out`
- `pgbouncer`: namespace owner, function, and privilege snapshots in `pgbouncer.sql` / `pgbouncer.out`
- `extensions`: installed extension rows joined through `pg_namespace` in `extensions_schema.sql` / `extensions_schema.out`
- `graphql`: direct `graphql.resolve(...)` calls in `pg_graphql.sql`
- `storage`: namespace owner, table, function, and ACL snapshots in `storage.sql` / `storage.out`

## Testing

- focused migration database pgTAP path in `supabase/postgres:17.6.1.107`: 17/17 assertions passed
- `git diff --check`

The complete `migrations/tests/test.sql` was also attempted in the same image, but the unmodified PostGIS extension setup failed before the changed database test include at `pagc_normalize_address`: `function parse_address(character varying) does not exist`.

Fixes #1561
