### PR TITLE
feat: clean up ami build so that nix closures handle installs

### DIFF
--- a/.github/workflows/testinfra-ami-build.yml
+++ b/.github/workflows/testinfra-ami-build.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     outputs:
       postgres_versions: ${{ steps.set-versions.outputs.postgres_versions }}
+      targets: ${{ steps.set-versions.outputs.targets }}
     steps:
       - name: Checkout Repo
         uses: supabase/postgres/.github/actions/shared-checkout@HEAD
@@ -33,8 +34,20 @@ jobs:
       - name: Set PostgreSQL versions
         id: set-versions
         run: |
-          VERSIONS=$(nix run nixpkgs#yq-go -- -o=json -I=0 '.postgres_major' ansible/vars.yml)
+          # On pull requests, build a single representative leg (PG 17 on
+          # arm64) instead of the full version × arch matrix. The full
+          # matrix still runs on merge_group, workflow_dispatch, and the
+          # release AMI workflow, so every combination is covered before
+          # anything ships.
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+            VERSIONS='["17"]'
+            TARGETS='[{"arch":"arm64","instance_type":"c6g.4xlarge","runner":"blacksmith-2vcpu-ubuntu-2404-arm"}]'
+          else
+            VERSIONS=$(nix run nixpkgs#yq-go -- -o=json -I=0 '.postgres_major' ansible/vars.yml)
+            TARGETS='[{"arch":"amd64","instance_type":"c6i.4xlarge","runner":"blacksmith-2vcpu-ubuntu-2404"},{"arch":"arm64","instance_type":"c6g.4xlarge","runner":"blacksmith-2vcpu-ubuntu-2404-arm"}]'
+          fi
           echo "postgres_versions=$VERSIONS" >> "$GITHUB_OUTPUT"
+          echo "targets=$TARGETS" >> "$GITHUB_OUTPUT"
 
   test-ami-nix:
     needs: gen-matrix
@@ -42,13 +55,7 @@ jobs:
       fail-fast: false
       matrix:
         postgres_version: ${{ fromJson(needs.gen-matrix.outputs.postgres_versions) }}
-        target:
-          - arch: amd64
-            instance_type: c6i.4xlarge
-            runner: blacksmith-2vcpu-ubuntu-2404
-          - arch: arm64
-            instance_type: c6g.4xlarge
-            runner: blacksmith-2vcpu-ubuntu-2404-arm
+        target: ${{ fromJson(needs.gen-matrix.outputs.targets) }}
     runs-on: ${{ matrix.target.runner }}
     timeout-minutes: 150
 

--- a/amazon-amd64-nix.pkr.hcl
+++ b/amazon-amd64-nix.pkr.hcl
@@ -210,11 +210,6 @@ build {
     destination = "/tmp"
   }
 
-  provisioner "file" {
-    source      = "migrations"
-    destination = "/tmp"
-  }
-
   # Copy ansible playbook
   provisioner "shell" {
     inline = ["mkdir /tmp/ansible-playbook"]

--- a/amazon-arm64-nix.pkr.hcl
+++ b/amazon-arm64-nix.pkr.hcl
@@ -210,11 +210,6 @@ build {
     destination = "/tmp"
   }
 
-  provisioner "file" {
-    source      = "migrations"
-    destination = "/tmp"
-  }
-
   # Copy ansible playbook
   provisioner "shell" {
     inline = ["mkdir /tmp/ansible-playbook"]

--- a/ebssurrogate/scripts/chroot-bootstrap-nix.sh
+++ b/ebssurrogate/scripts/chroot-bootstrap-nix.sh
@@ -172,7 +172,12 @@ function update_install_packages {
 		echo "FATAL: Failed to update package lists with any mirror tier"
 		exit 1
 	fi
-	apt-get "${APT_OPTIONS[@]}" --yes dist-upgrade
+	# Use the fallback wrapper: a package can be superseded between index and
+	# pool sync on a mirror (404 on fetch), which needs a re-update + retry.
+	if ! apt_install_with_fallback "${APT_OPTIONS[@]}" --yes dist-upgrade; then
+		echo "FATAL: Failed to dist-upgrade"
+		exit 1
+	fi
 
 	# Do not configure grub during package install
 	if [[ $ARCH == amd64 ]]; then
@@ -206,7 +211,10 @@ function update_install_packages {
 	fi
 
 	# apt upgrade
-	apt-get upgrade -y
+	if ! apt_install_with_fallback upgrade -y; then
+		echo "FATAL: Failed to upgrade packages"
+		exit 1
+	fi
 
 	# Install OpenSSH and other packages
 	add-apt-repository --yes universe

--- a/ebssurrogate/scripts/cleanup.sh
+++ b/ebssurrogate/scripts/cleanup.sh
@@ -54,23 +54,12 @@ rm -f /root/.ssh/authorized_keys /etc/ssh/*key*
 touch /etc/ssh/revoked_keys
 chmod 600 /etc/ssh/revoked_keys
 
-# Securely erase the unused portion of the filesystem
-cat <<-EOF
-	Writing zeros to the remaining disk space to securely erase the unused portion of the file system.
-	Depending on your disk size this may take several minutes.
-	The secure erase will complete successfully when you see:
-	    dd: writing to '/zerofile': No space left on device
-	Beginning secure erase now
-EOF
-
-dd if=/dev/zero of=/zerofile &
-PID=$!
-while [ -d /proc/$PID ]; do
-	printf "."
-	sleep 5
-done
-sync
-rm /zerofile
+# Note: the upstream DigitalOcean version of this script zero-fills the free
+# space here ("secure erase"). That is intentionally removed for the AMI
+# build: EBS snapshots only store written blocks, so zero-filling rewrites
+# the entire root volume serially (slow) and inflates the snapshot with
+# blocks of zeros (bigger artifact), while the freshly-debootstrapped image
+# holds no secrets to erase.
 sync
 cat /dev/null >/var/log/lastlog
 cat /dev/null >/var/log/wtmp

--- a/ebssurrogate/scripts/surrogate-bootstrap-nix.sh
+++ b/ebssurrogate/scripts/surrogate-bootstrap-nix.sh
@@ -102,6 +102,16 @@ function waitfor_boot_finished {
 	done
 }
 
+# A package can be superseded between a mirror's index and pool sync (404 on
+# fetch); refresh the package lists and retry once before giving up.
+function apt_install_with_retry {
+	if ! apt-get install -y "$@"; then
+		echo "apt-get install failed; refreshing package lists and retrying once..."
+		apt_update_with_fallback
+		apt-get install -y "$@"
+	fi
+}
+
 function install_packages {
 	# Setup Ansible on host VM
 	if ! apt_update_with_fallback; then
@@ -109,7 +119,7 @@ function install_packages {
 		exit 1
 	fi
 
-	apt-get install software-properties-common -y
+	apt_install_with_retry software-properties-common
 	# TODO (darora): temporarily disabling while Launchpad is under ddos attack and very frequently timing out
 	# add-apt-repository --yes --update ppa:ansible/ansible
 
@@ -118,10 +128,10 @@ function install_packages {
 		exit 1
 	fi
 
-	apt-get install ansible -y
+	apt_install_with_retry ansible
 	ansible-galaxy collection install community.general
 
-	apt-get install -y \
+	apt_install_with_retry \
 		gdisk \
 		e2fsprogs \
 		debootstrap \

--- a/ebssurrogate/scripts/surrogate-bootstrap-nix.sh
+++ b/ebssurrogate/scripts/surrogate-bootstrap-nix.sh
@@ -269,9 +269,6 @@ function setup_chroot_environment {
 	chmod 644 /tmp/apparmor_profiles/*
 	cp -r /tmp/apparmor_profiles /mnt/tmp/
 
-	# Copy migrations
-	cp -r /tmp/migrations /mnt/tmp/
-
 	# Copy the bootstrap script into place and execute inside chroot
 	cp /tmp/chroot-bootstrap-nix.sh /mnt/tmp/chroot-bootstrap-nix.sh
 	chroot /mnt /tmp/chroot-bootstrap-nix.sh

--- a/nix/packages/build-ami.nix
+++ b/nix/packages/build-ami.nix
@@ -17,7 +17,6 @@ let
       fileset = lib.fileset.unions [
         (root + "/ebssurrogate")
         (root + "/ansible")
-        (root + "/migrations")
         (root + "/amazon-amd64-nix.pkr.hcl")
         (root + "/amazon-arm64-nix.pkr.hcl")
         (root + "/development-amd64.vars.pkr.hcl")
@@ -90,7 +89,10 @@ writeShellApplication {
         "Name=state,Values=available"
         "Name=tag:inputHash,Values=$INPUT_HASH"
         "Name=tag:postgresVersion,Values=$POSTGRES_VERSION-stage1"
-        "Name=tag:sourceSha,Values=$GIT_SHA" # This is set by packer via the git-head-version var which is always passed in by the build-ami action
+        # sourceSha is still tagged on the AMI for traceability, but is
+        # intentionally not part of the cache key: inputHash already
+        # content-addresses everything that affects stage 1, so requiring a
+        # matching commit SHA only defeated the cache on every push.
       )
 
       local ami_output


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature: part of CE-76 (https://linear.app/supabase/issue/CE-76/investigate-an-additional-snapshot-volume-option-for-postgres-upgrades)

## What is the current behavior?

AMI is the source of truth for all builds

## What is the new behavior?

AMI is built without being tagged to a git commit. We now build the AMI but we can handle installs via nix closures so that individual components can be updated via nix (using Salt)

## Additional context

This is purely early exploration into assisting with speeding up build times and selfishly improving the upgrade process so that automated minor downtime upgrades are easier to implement