### PR TITLE
chore: bump postgres_release to cut fresh AMIs (includes #2399)

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -11,9 +11,9 @@ postgres_major:
 # This is the source of truth for Postgres versions used in the Dockerfiles, and
 # is used to derive image tags and base images in the release matrix.
 postgres_release:
-  postgresorioledb-17: "17.9.0.019-orioledb"
-  postgres17: "17.6.1.166"
-  postgres15: "15.14.1.166"
+  postgresorioledb-17: "17.9.0.020-orioledb"
+  postgres17: "17.6.1.167"
+  postgres15: "15.14.1.167"
 # Docker release matrix — base images built first, layered images built on top.
 # tag and base_tag are derived at build time from postgres_release via release_key.
 # tag_suffix is appended to the release version to form the final image tag.


### PR DESCRIPTION
Bumps `postgres_release` by 1 (lockstep) so a fresh AMI is cut that includes the migration + `after-create.sql` changes from #2399.

- `postgres15`: `15.14.1.166` → `15.14.1.167`
- `postgres17`: `17.6.1.166` → `17.6.1.167`
- `postgresorioledb-17`: `17.9.0.019-orioledb` → `17.9.0.020-orioledb`

Same pattern as #2349 (which cut the AMI for #2334).