### PR TITLE
DO NOT MERGE: scratch — unique version strings to test amcheck AMI on green

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -11,9 +11,9 @@ postgres_major:
 # This is the source of truth for Postgres versions used in the Dockerfiles, and
 # is used to derive image tags and base images in the release matrix.
 postgres_release:
-  postgresorioledb-17: "17.9.0.900-orioledb"
-  postgres17: "17.6.1.900"
-  postgres15: "15.14.1.900"
+  postgresorioledb-17: "17.9.0.021-orioledb-amchecktest"
+  postgres17: "17.6.1.168-amchecktest"
+  postgres15: "15.14.1.168-amchecktest"
 # Docker release matrix — base images built first, layered images built on top.
 # tag and base_tag are derived at build time from postgres_release via release_key.
 # tag_suffix is appended to the release version to form the final image tag.

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -11,9 +11,9 @@ postgres_major:
 # This is the source of truth for Postgres versions used in the Dockerfiles, and
 # is used to derive image tags and base images in the release matrix.
 postgres_release:
-  postgresorioledb-17: "17.9.0.021-orioledb-amchecktest"
-  postgres17: "17.6.1.168-amchecktest"
-  postgres15: "15.14.1.168-amchecktest"
+  postgresorioledb-17: "17.9.0.999am-orioledb"
+  postgres17: "17.6.1.999am"
+  postgres15: "15.14.1.999am"
 # Docker release matrix — base images built first, layered images built on top.
 # tag and base_tag are derived at build time from postgres_release via release_key.
 # tag_suffix is appended to the release version to form the final image tag.

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -11,9 +11,9 @@ postgres_major:
 # This is the source of truth for Postgres versions used in the Dockerfiles, and
 # is used to derive image tags and base images in the release matrix.
 postgres_release:
-  postgresorioledb-17: "17.9.0.021-orioledb"
-  postgres17: "17.6.1.168"
-  postgres15: "15.14.1.168"
+  postgresorioledb-17: "17.9.0.900-orioledb"
+  postgres17: "17.6.1.900"
+  postgres15: "15.14.1.900"
 # Docker release matrix — base images built first, layered images built on top.
 # tag and base_tag are derived at build time from postgres_release via release_key.
 # tag_suffix is appended to the release version to form the final image tag.


### PR DESCRIPTION
Scratch/throwaway branch off #2240's head, only changes `ansible/vars.yml` `postgres_release` to append a `-amchecktest` suffix to each version string. Exists purely so `ami-release-nix.yml` can be triggered on a uniquely-tagged build, which is then registered on green (via \`supadev create-project ... --version <this PR URL>\`) to test amcheck surviving a real 15→17 upgrade, without colliding with #2240's own release version tags.

**Do not merge.** Delete once the AMI test is done.
