### PR TITLE
DO NOT MERGE: scratch — unique-tagged build for amcheck smoke test

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -11,9 +11,9 @@ postgres_major:
 # This is the source of truth for Postgres versions used in the Dockerfiles, and
 # is used to derive image tags and base images in the release matrix.
 postgres_release:
-  postgresorioledb-17: "17.9.0.022-orioledb"
-  postgres17: "17.6.1.169"
-  postgres15: "15.14.1.169"
+  postgresorioledb-17: "17.9.0.022am-orioledb"
+  postgres17: "17.6.1.169am"
+  postgres15: "15.14.1.169am"
 # Docker release matrix — base images built first, layered images built on top.
 # tag and base_tag are derived at build time from postgres_release via release_key.
 # tag_suffix is appended to the release version to form the final image tag.


### PR DESCRIPTION
Scratch branch off #2240's (now version-collision-fixed) head, only bumps \`ansible/vars.yml\` with an \`am\` suffix so this build's AMI is uniquely tagged for smoke testing without colliding with any real release tag.

Do not merge. Delete once the smoke test is done.