### PR TITLE
feat(pgctld): bump to b0d11a0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
     "multigres": {
       "flake": false,
       "locked": {
-        "lastModified": 1785349416,
-        "narHash": "sha256-rHIfalPF5+P7innXfoP4cIH4EqzIMVP5qepGYb/iJpA=",
+        "lastModified": 1788278524,
+        "narHash": "sha256-7+Mt4T55oxmSd9UoSvir4Z2JzLm6ggVvzH9sgZWGx7E=",
         "owner": "multigres",
         "repo": "multigres",
-        "rev": "b713432298450dd0095498193e86d9f9a9f2c348",
+        "rev": "b0d11a0125275333187a1502e952c2655c594b0f",
         "type": "github"
       },
       "original": {

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -74,7 +74,7 @@
           overlayfs-on-package = pkgs.callPackage ./overlayfs-on-package.nix { };
           packer = pkgs.callPackage ./packer.nix { inherit inputs; };
           pg-activity = inputs.nixpkgs.legacyPackages.${pkgs.stdenv.hostPlatform.system}.pg_activity;
-          pg-backrest = inputs.nixpkgs.legacyPackages.${pkgs.stdenv.hostPlatform.system}.pgbackrest;
+          pg-backrest = pkgs.callPackage ./pg-backrest.nix { };
           pgctld = pkgs.callPackage ./pgctld.nix {
             multigres-src = inputs.multigres;
           };

--- a/nix/packages/pg-backrest.nix
+++ b/nix/packages/pg-backrest.nix
@@ -1,0 +1,23 @@
+{
+  fetchurl,
+  pgbackrest,
+}:
+pgbackrest.overrideAttrs (
+  finalAttrs: prevAttrs: {
+    version = "2.59.1";
+
+    # Deliberately the release tarball rather than fetchFromGitHub. As of 2.59.0
+    # upstream's .gitattributes marks /src/build as export-ignore, so the GitHub
+    # tag archive omits the code-generation tooling *and* the generated sources
+    # *and* the "dist" marker file — it simply cannot be built (meson fails with
+    # "File build/common/regExp.c does not exist").
+    src = fetchurl {
+      url = "https://github.com/pgbackrest/pgbackrest/releases/download/release/${finalAttrs.version}/pgbackrest-${finalAttrs.version}.tar.gz";
+      hash = "sha256-HNUir8M7j/hG74jFXcI4cXyciBek9sp8n2SIfenHQC0=";
+    };
+
+    # 2.59.0 adds an optional libsystemd dependency for systemd notify support.
+    # Nonexistent on darwin.
+    mesonFlags = (prevAttrs.mesonFlags or [ ]) ++ [ "-Dlibsystemd=disabled" ];
+  }
+)

--- a/nix/packages/pg-backrest.nix
+++ b/nix/packages/pg-backrest.nix
@@ -1,6 +1,9 @@
 {
   fetchurl,
+  lib,
   pgbackrest,
+  stdenv,
+  systemdLibs,
 }:
 pgbackrest.overrideAttrs (
   finalAttrs: prevAttrs: {
@@ -18,6 +21,10 @@ pgbackrest.overrideAttrs (
 
     # 2.59.0 adds an optional libsystemd dependency for systemd notify support.
     # Nonexistent on darwin.
-    mesonFlags = (prevAttrs.mesonFlags or [ ]) ++ [ "-Dlibsystemd=disabled" ];
+    buildInputs =
+      (prevAttrs.buildInputs or [ ]) ++ lib.optional stdenv.hostPlatform.isLinux systemdLibs;
+    mesonFlags = (prevAttrs.mesonFlags or [ ]) ++ [
+      (lib.mesonEnable "libsystemd" stdenv.hostPlatform.isLinux)
+    ];
   }
 )

--- a/nix/packages/pg-backrest.nix
+++ b/nix/packages/pg-backrest.nix
@@ -1,5 +1,5 @@
 {
-  fetchurl,
+  fetchFromGitHub,
   lib,
   pgbackrest,
   stdenv,
@@ -9,14 +9,11 @@ pgbackrest.overrideAttrs (
   finalAttrs: prevAttrs: {
     version = "2.59.1";
 
-    # Deliberately the release tarball rather than fetchFromGitHub. As of 2.59.0
-    # upstream's .gitattributes marks /src/build as export-ignore, so the GitHub
-    # tag archive omits the code-generation tooling *and* the generated sources
-    # *and* the "dist" marker file — it simply cannot be built (meson fails with
-    # "File build/common/regExp.c does not exist").
-    src = fetchurl {
-      url = "https://github.com/pgbackrest/pgbackrest/releases/download/release/${finalAttrs.version}/pgbackrest-${finalAttrs.version}.tar.gz";
-      hash = "sha256-HNUir8M7j/hG74jFXcI4cXyciBek9sp8n2SIfenHQC0=";
+    src = fetchFromGitHub {
+      owner = "pgbackrest";
+      repo = "pgbackrest";
+      rev = "release/${finalAttrs.version}";
+      hash = "sha256-bCHjIQ0WIlvjGg1b4jNwWKzxLg+YIDswKx/Jt6EwAdQ=";
     };
 
     # 2.59.0 adds an optional libsystemd dependency for systemd notify support.

--- a/nix/packages/pgctld.nix
+++ b/nix/packages/pgctld.nix
@@ -17,7 +17,7 @@ buildGo126Module {
   '';
   # Tests require a running PostgreSQL instance (integration tests); skip in sandbox.
   doCheck = false;
-  vendorHash = "sha256-oRP1ZvRmE8eqYmJIuZSad3/BVicmAFkBJ4qSaiD6F0E=";
+  vendorHash = "sha256-J8Yjnwkwmk6kL0qsyGUgak9O26daYzly/1GwEwYn0IU=";
 
   meta = {
     description = "PostgreSQL control daemon for Multigres cluster lifecycle management";


### PR DESCRIPTION
Latest Multigres deployment now uses pgbackrest 2.59.1, potentially causing backups to fail.

Bump the thang.