### PR TITLE
change locale provider to builtin as default

### DIFF
--- a/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
+++ b/ansible/files/admin_api_scripts/pg_upgrade_scripts/initiate.sh
@@ -537,7 +537,7 @@ EXTRA_NIX_CONF
 
 	if [ "$IS_NIX_UPGRADE" = "true" ]; then
 		if [[ ${PGVERSION%%.*} -ge 16 ]]; then
-			LC_ALL=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 LC_COLLATE=en_US.UTF-8 LANGUAGE=en_US.UTF-8 LANG=en_US.UTF-8 LOCALE_ARCHIVE=/usr/lib/locale/locale-archive su -c ". /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh && $PGBINNEW/initdb --allow-group-access $CHECKSUM_FLAG --encoding=$SERVER_ENCODING --locale-provider=icu --icu-locale=en_US.UTF-8 -L $PGSHARENEW -D $PGDATANEW/ --username=supabase_admin" -s "$SHELL" postgres
+			LC_ALL=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 LC_COLLATE=en_US.UTF-8 LANGUAGE=en_US.UTF-8 LANG=en_US.UTF-8 LOCALE_ARCHIVE=/usr/lib/locale/locale-archive su -c ". /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh && $PGBINNEW/initdb --allow-group-access $CHECKSUM_FLAG --encoding=$SERVER_ENCODING --locale-provider=builtin --builtin-locale=C.UTF-8 -L $PGSHARENEW -D $PGDATANEW/ --username=supabase_admin" -s "$SHELL" postgres
 		else
 			LC_ALL=en_US.UTF-8 LC_CTYPE=$SERVER_LC_CTYPE LC_COLLATE=$SERVER_LC_COLLATE LANGUAGE=en_US.UTF-8 LANG=en_US.UTF-8 LOCALE_ARCHIVE=/usr/lib/locale/locale-archive su -c ". /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh && $PGBINNEW/initdb --allow-group-access $CHECKSUM_FLAG --encoding=$SERVER_ENCODING --lc-collate=$SERVER_LC_COLLATE --lc-ctype=$SERVER_LC_CTYPE -L $PGSHARENEW -D $PGDATANEW/ --username=supabase_admin" -s "$SHELL" postgres
 		fi

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -6,6 +6,12 @@
       ansible.builtin.set_fact:
         platform: "{{ 'amd64' if ansible_facts['architecture'] == 'x86_64' else 'arm64' }}"
 
+    - name: Set is_psql boolean facts
+      ansible.builtin.set_fact:
+        is_psql_oriole: "{{ psql_version in ['psql_orioledb-17'] }}"
+        is_psql_17: "{{ psql_version in ['psql_17'] }}"
+        is_psql_15: "{{ psql_version in ['psql_15'] }}"
+
     - import_tasks: tasks/setup-system.yml
   vars_files:
     - ./vars.yml

--- a/ansible/tasks/setup-postgres.yml
+++ b/ansible/tasks/setup-postgres.yml
@@ -205,7 +205,7 @@
     - name: Set default initdb arguments
       when: not is_psql_15
       ansible.builtin.set_fact:
-        initdb_pg_version_args: "-o --encoding=UTF-8 -o --locale-provider=icu -o --icu-locale=en_US.UTF-8"
+        initdb_pg_version_args: "-o --encoding=UTF-8 -o --locale-provider=builtin -o --builtin-locale=C.UTF-8"
 
     - name: Initialize the database stage2
       become: true

--- a/ansible/tasks/setup-postgres.yml
+++ b/ansible/tasks/setup-postgres.yml
@@ -193,27 +193,25 @@
         passno: "2"
         state: mounted
 
-    - name: Initialize the database stage2 (NOT PG17 NOR PG17-OrioleDB)
-      when: psql_version not in ['psql_17', 'psql_orioledb-17']
-      become: true
-      become_user: 'postgres'
-      ansible.builtin.command:
-        cmd: /usr/lib/postgresql/bin/pg_ctl -D /var/lib/postgresql/data initdb -o "--allow-group-access" -o "--username=supabase_admin" -o "--data-checksums"
-      environment:
-        LANG: en_US.UTF-8
-        LANGUAGE: en_US.UTF-8
-        LC_ALL: en_US.UTF-8
-        LC_CTYPE: en_US.UTF-8
-        LOCALE_ARCHIVE: /usr/lib/locale/locale-archive
-      vars:
-        ansible_command_timeout: 60
+    - name: Set common initdb arguments
+      ansible.builtin.set_fact:
+        initdb_common_args: -o --allow-group-access -o --username=supabase_admin -o --data-checksums
 
-    - name: Initialize the database stage2 (PG17 OR PG17-OrioleDB)
-      when: psql_version in ['psql_17', 'psql_orioledb-17']
+    - name: Set PG15 initdb arguments
+      when: is_psql_15
+      ansible.builtin.set_fact:
+        initdb_pg_version_args: ""
+
+    - name: Set default initdb arguments
+      when: not is_psql_15
+      ansible.builtin.set_fact:
+        initdb_pg_version_args: "-o --encoding=UTF-8 -o --locale-provider=icu -o --icu-locale=en_US.UTF-8"
+
+    - name: Initialize the database stage2
       become: true
-      become_user: 'postgres'
+      become_user: postgres
       ansible.builtin.command:
-        cmd: /usr/lib/postgresql/bin/pg_ctl -D /var/lib/postgresql/data initdb -o "--allow-group-access" -o "--username=supabase_admin" -o "--locale-provider=icu" -o "--encoding=UTF-8" -o "--icu-locale=en_US.UTF-8" -o "--data-checksums"
+        cmd: /usr/lib/postgresql/bin/pg_ctl -D /var/lib/postgresql/data initdb {{ initdb_common_args}} {{ initdb_pg_version_args }}
       environment:
         LANG: en_US.UTF-8
         LANGUAGE: en_US.UTF-8

--- a/ansible/tasks/setup-postgres.yml
+++ b/ansible/tasks/setup-postgres.yml
@@ -110,10 +110,6 @@
 
     - name: configure pam
       block:
-        - name: Check if psql_version is psql_15
-          ansible.builtin.set_fact:
-            is_psql_15: "{{ psql_version in ['psql_15'] }}"
-
         - name: create placeholder pam config
           when: not is_psql_15
           file:

--- a/ansible/tasks/stage2-setup-postgres.yml
+++ b/ansible/tasks/stage2-setup-postgres.yml
@@ -1,11 +1,5 @@
 - name: Check psql_version and modify supautils.conf and postgresql.conf if necessary
   block:
-    - name: Check if psql_version is psql_orioledb-17 and if psql_version is psql_15 or psql_17
-      ansible.builtin.set_fact:
-        is_psql_oriole: "{{ psql_version in ['psql_orioledb-17'] }}"
-        is_psql_17: "{{ psql_version in ['psql_17'] }}"
-        is_psql_15: "{{ psql_version in ['psql_15'] }}"
-
     - name: Execute tasks when (is_psql_oriole or is_psql_17) and stage2
       when: stage2 and (is_psql_oriole or is_psql_17)
       become: true
@@ -134,10 +128,6 @@
 
     - name: setup gatekeeper
       block:
-        - name: Check if psql_version is psql_15
-          ansible.builtin.set_fact:
-            is_psql_15: "{{ psql_version == 'psql_15' }}"
-
         - name: Install gatekeeper if not pg15
           when: stage2 and not is_psql_15
           block:


### PR DESCRIPTION
Switch to builtin locale provider and C.UTF-8 locale as the default for PG17+, PG15 and OrioleDB stay at current provider/locale (PG15 because builtin is not available, OrioleDB is incompatible for now).