### PR TITLE
ci: publish site-env catalogs, extend release path filter

### DIFF
--- a/.github/workflows/ami-release-nix.yml
+++ b/.github/workflows/ami-release-nix.yml
@@ -11,6 +11,7 @@ on:
       - flake.lock
       - flake.nix
       - nix/packages/build-ami.nix
+      - nix/**
   workflow_dispatch:
 
 permissions:
@@ -202,6 +203,24 @@ jobs:
             --content-type "application/json"
 
           echo "Catalog uploaded to ${CATALOG_S3}"
+
+      - name: Update site-env catalogs
+        run: |
+          GIT_SHA="${{ steps.resolve-git-sha.outputs.sha }}"
+          SYSTEM=$(nix eval --impure --raw --expr 'builtins.currentSystem')
+
+          SITE_ENV_PATH=$(nix eval --raw ".#site-env-${POSTGRES_MAJOR_VERSION}.outPath")
+          jq -n --arg sys "$SYSTEM" --arg path "$SITE_ENV_PATH" '{($sys): $path}' > /tmp/site-env-catalog.json
+          aws s3 cp /tmp/site-env-catalog.json \
+            "s3://${{ secrets.SHARED_AWS_ARTIFACTS_BUCKET }}/nix-catalog/${GIT_SHA}-site-env_${POSTGRES_MAJOR_VERSION}-${SYSTEM}.json" \
+            --content-type "application/json"
+
+          # Generic across majors, so every matrix leg publishes the same content for its arch.
+          SITE_UPDATE_PATH=$(nix eval --raw ".#site-update.outPath")
+          jq -n --arg sys "$SYSTEM" --arg path "$SITE_UPDATE_PATH" '{($sys): $path}' > /tmp/site-update-catalog.json
+          aws s3 cp /tmp/site-update-catalog.json \
+            "s3://${{ secrets.SHARED_AWS_ARTIFACTS_BUCKET }}/nix-catalog/${GIT_SHA}-site-update-${SYSTEM}.json" \
+            --content-type "application/json"
 
       - name: Create release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0


### PR DESCRIPTION
Extends `ami-release-nix.yml`'s existing catalog step (same jq/bucket/role as the live `psql_<major>` catalog) to also publish `site-env-<major>` and `site-update` catalogs. Adds `nix/**` to the release trigger path filter.

DO NOT MERGE - WIP. Depends on #2424 (site-update) existing so `.#site-update.outPath` resolves.

MPG-15