### PR TITLE
ci: fix yq not found in manual QEMU build dispatch

### DIFF
--- a/.github/workflows/qemu-image-build.yml
+++ b/.github/workflows/qemu-image-build.yml
@@ -45,15 +45,6 @@ jobs:
       - name: Checkout Repo
         uses: supabase/postgres/.github/actions/shared-checkout@HEAD
 
-      - name: Run checks if triggered manually
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: |
-          SUFFIX=$(nix run nixpkgs#yq -- ".postgres_release[\"postgres${{ matrix.postgres_version }}\"]" ansible/vars.yml | sed -E 's/[0-9\.]+(.*)$/\1/')
-          if [[ -z $SUFFIX ]] ; then
-            echo "Version must include non-numeric characters if built manually."
-            exit 1
-          fi
-
       - name: enable KVM support
         run: |
           sudo chown runner /dev/kvm
@@ -66,6 +57,15 @@ jobs:
 
       - name: Install Nix
         uses: ./.github/actions/nix-install-ephemeral
+
+      - name: Run checks if triggered manually
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          SUFFIX=$(nix run nixpkgs#yq -- ".postgres_release[\"postgres${{ matrix.postgres_version }}\"]" ansible/vars.yml | sed -E 's/[0-9\.]+(.*)$/\1/')
+          if [[ -z $SUFFIX ]] ; then
+            echo "Version must include non-numeric characters if built manually."
+            exit 1
+          fi
 
       - name: Resolve git sha
         id: resolve-git-sha

--- a/.github/workflows/qemu-image-build.yml
+++ b/.github/workflows/qemu-image-build.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Run checks if triggered manually
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
-          SUFFIX=$(yq ".postgres_release[\"postgres${{ matrix.postgres_version }}\"]" ansible/vars.yml | sed -E 's/[0-9\.]+(.*)$/\1/')
+          SUFFIX=$(nix run nixpkgs#yq -- ".postgres_release[\"postgres${{ matrix.postgres_version }}\"]" ansible/vars.yml | sed -E 's/[0-9\.]+(.*)$/\1/')
           if [[ -z $SUFFIX ]] ; then
             echo "Version must include non-numeric characters if built manually."
             exit 1


### PR DESCRIPTION
Manual-dispatch version guard used bare `yq`, not on PATH. Use `nix run nixpkgs#yq` like the rest of the workflow.

CI error: https://github.com/supabase/postgres/actions/runs/34145617748/job/101816959683