### PR TITLE
site-extensions-update: don't assume nix-store/nix-env are on PATH

### DIFF
--- a/nix/packages/extension-catalog.nix
+++ b/nix/packages/extension-catalog.nix
@@ -150,7 +150,10 @@
         # Downloads paths and installs them as an env into the profile, replacing all existing ones.
         site-extensions-update = pkgs.writeShellApplication {
           name = "site-extensions-update";
-          runtimeInputs = [ self'.packages.site-extensions-resolve ];
+          runtimeInputs = [
+            self'.packages.site-extensions-resolve
+            pkgs.nix
+          ];
           text = ''
             manifest="''${1:?Usage: $0 path-to/pg-extensions.json}"
             profile="''${NIX_PROFILE:-/nix/var/nix/profiles/site-extensions}"


### PR DESCRIPTION
writeShellApplication's wrapped PATH only covers declared runtimeInputs (site-extensions-resolve) — nix-store/nix-env were bare, relying on ambient PATH. Every other nix invocation in this repo either sources nix-daemon.sh or hardcodes an absolute path; this didn't. Adds pkgs.nix to runtimeInputs.