### PR TITLE
site-env-update: skip realize+set when profile already current

### DIFF
--- a/nix/packages/site-env.nix
+++ b/nix/packages/site-env.nix
@@ -49,6 +49,7 @@
             "$catalog" --region ap-southeast-1
 
           path="$(jq -er --arg s "$system" '.[$s]' "$catalog")"
+          [[ "$(readlink -f /nix/var/nix/profiles/site)" == "$path" ]] && exit 0
           nix-dl "$path"
           nix-env --profile /nix/var/nix/profiles/site --set "$path"
         '';


### PR DESCRIPTION
Split out of #2424. Skips redundant realize+set when the site profile already points at the target path.