### PR TITLE
supautils and gatekeeper: prepare for deploy

### DIFF
--- a/nix/ext/patches/supautils-strtol-glibc-compat.patch
+++ b/nix/ext/patches/supautils-strtol-glibc-compat.patch
@@ -1,14 +1,12 @@
 diff --git a/src/constrained_extensions.c b/src/constrained_extensions.c
-index 18e5aee..4eced0b 100644
+index 18e5aee..64757d7 100644
 --- a/src/constrained_extensions.c
 +++ b/src/constrained_extensions.c
-@@ -9,6 +9,22 @@
+@@ -9,6 +9,20 @@
  #include "constrained_extensions.h"
  #include "utils.h"
  
-+// Modern glibc's inlined atoi() calls __isoc23_strtol@GLIBC_2.38 instead of
-+// strtol. That symbol doesn't exist on older hosts, so resolve plain
-+// strtol@GLIBC_2.17 (its only version node) directly instead.
++// atoi's inlined strtol resolves to __isoc23_strtol@GLIBC_2.38; pin strtol@GLIBC_2.17 instead.
 +#if defined(__linux__) && defined(__GLIBC__)
 +extern void *dlvsym(void *handle, const char *symbol, const char *version);
 +__asm__(".symver dlvsym,dlvsym@GLIBC_2.17");

--- a/nix/ext/patches/supautils-strtol-glibc-compat.patch
+++ b/nix/ext/patches/supautils-strtol-glibc-compat.patch
@@ -1,0 +1,29 @@
+diff --git a/src/constrained_extensions.c b/src/constrained_extensions.c
+index 18e5aee..d5172a3 100644
+--- a/src/constrained_extensions.c
++++ b/src/constrained_extensions.c
+@@ -9,6 +9,24 @@
+ #include "constrained_extensions.h"
+ #include "utils.h"
+ 
++// Force GLIBC_2.17 (atoi's inlined strtol, dlsym/dlvsym) for older-glibc hosts.
++#if defined(__linux__) && defined(__GLIBC__)
++extern void *dlvsym(void *handle, const char *symbol, const char *version);
++extern void *dlsym(void *handle, const char *symbol);
++__asm__(".symver dlvsym,dlvsym@GLIBC_2.17");
++__asm__(".symver dlsym,dlsym@GLIBC_2.17");
++static int
++_supautils_compat_atoi(const char *nptr)
++{
++    long (*fn)(const char *, char **, int) =
++        (long (*)(const char *, char **, int)) dlvsym((void *) 0, "strtol", "GLIBC_2.17");
++    if (!fn)
++        fn = (long (*)(const char *, char **, int)) dlsym((void *) 0, "strtol");
++    return fn ? (int) fn(nptr, NULL, 10) : 0;
++}
++#define atoi(a) _supautils_compat_atoi(a)
++#endif
++
+ static JSON_ACTION_RETURN_TYPE json_array_start(void *state) {
+   json_constrained_extension_parse_state *parse = state;
+ 

--- a/nix/ext/patches/supautils-strtol-glibc-compat.patch
+++ b/nix/ext/patches/supautils-strtol-glibc-compat.patch
@@ -1,20 +1,27 @@
 diff --git a/src/constrained_extensions.c b/src/constrained_extensions.c
-index 18e5aee..64757d7 100644
+index 18e5aee..cdfb63f 100644
 --- a/src/constrained_extensions.c
 +++ b/src/constrained_extensions.c
-@@ -9,6 +9,20 @@
+@@ -9,6 +9,27 @@
  #include "constrained_extensions.h"
  #include "utils.h"
  
-+// atoi's inlined strtol resolves to __isoc23_strtol@GLIBC_2.38; pin strtol@GLIBC_2.17 instead.
-+#if defined(__linux__) && defined(__GLIBC__)
++// atoi's inlined strtol resolves to __isoc23_strtol@GLIBC_2.38; pin strtol's oldest
++// version node instead (2.2.5 on x86_64, 2.17 on aarch64, which glibc added support
++// for at 2.17, so it has no earlier tag).
++#if defined(__linux__) && defined(__GLIBC__) && (defined(__x86_64__) || defined(__aarch64__))
++#  if defined(__x86_64__)
++#    define SUPAUTILS_GLIBC_COMPAT_VER "GLIBC_2.2.5"
++#  else
++#    define SUPAUTILS_GLIBC_COMPAT_VER "GLIBC_2.17"
++#  endif
 +extern void *dlvsym(void *handle, const char *symbol, const char *version);
-+__asm__(".symver dlvsym,dlvsym@GLIBC_2.17");
++__asm__(".symver dlvsym,dlvsym@" SUPAUTILS_GLIBC_COMPAT_VER);
 +static int
 +_supautils_compat_atoi(const char *nptr)
 +{
 +    long (*fn)(const char *, char **, int) =
-+        (long (*)(const char *, char **, int)) dlvsym((void *) 0, "strtol", "GLIBC_2.17");
++        (long (*)(const char *, char **, int)) dlvsym((void *) 0, "strtol", SUPAUTILS_GLIBC_COMPAT_VER);
 +    return fn ? (int) fn(nptr, NULL, 10) : 0;
 +}
 +#define atoi(a) _supautils_compat_atoi(a)

--- a/nix/ext/patches/supautils-strtol-glibc-compat.patch
+++ b/nix/ext/patches/supautils-strtol-glibc-compat.patch
@@ -1,24 +1,22 @@
 diff --git a/src/constrained_extensions.c b/src/constrained_extensions.c
-index 18e5aee..d5172a3 100644
+index 18e5aee..4eced0b 100644
 --- a/src/constrained_extensions.c
 +++ b/src/constrained_extensions.c
-@@ -9,6 +9,24 @@
+@@ -9,6 +9,22 @@
  #include "constrained_extensions.h"
  #include "utils.h"
  
-+// Force GLIBC_2.17 (atoi's inlined strtol, dlsym/dlvsym) for older-glibc hosts.
++// Modern glibc's inlined atoi() calls __isoc23_strtol@GLIBC_2.38 instead of
++// strtol. That symbol doesn't exist on older hosts, so resolve plain
++// strtol@GLIBC_2.17 (its only version node) directly instead.
 +#if defined(__linux__) && defined(__GLIBC__)
 +extern void *dlvsym(void *handle, const char *symbol, const char *version);
-+extern void *dlsym(void *handle, const char *symbol);
 +__asm__(".symver dlvsym,dlvsym@GLIBC_2.17");
-+__asm__(".symver dlsym,dlsym@GLIBC_2.17");
 +static int
 +_supautils_compat_atoi(const char *nptr)
 +{
 +    long (*fn)(const char *, char **, int) =
 +        (long (*)(const char *, char **, int)) dlvsym((void *) 0, "strtol", "GLIBC_2.17");
-+    if (!fn)
-+        fn = (long (*)(const char *, char **, int)) dlsym((void *) 0, "strtol");
 +    return fn ? (int) fn(nptr, NULL, 10) : 0;
 +}
 +#define atoi(a) _supautils_compat_atoi(a)

--- a/nix/ext/supautils.nix
+++ b/nix/ext/supautils.nix
@@ -12,12 +12,16 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ postgresql ];
 
+  dontStrip = true;
+
   src = fetchFromGitHub {
     owner = "supabase";
     repo = pname;
     rev = "refs/tags/v${version}";
     hash = "sha256-O2zVVVf2OFTCc4BYHuGJ67odU0TwMnTJQuz9uk+a4/0=";
   };
+
+  patches = [ ./patches/supautils-strtol-glibc-compat.patch ];
 
   installPhase = ''
     mkdir -p $out/lib


### PR DESCRIPTION
Match build of production supautils (from supautils releases) more closely, so we can deploy it from here.

- downgrade to GLIBC <= 2.31; this is required because supautils is `dlopen`ed into old postgres with old glibc
- strip RPATH from supautils.so and gatekeeper's pam_jit_pg.so: both are dlopen'd into a process (postgres, PAM) that already links glibc, so a nix-store glibc RPATH is unnecessary and risks a version mismatch
- don't strip debug symbols, but output them as a separate package
- minimize runtime closure size

Related MPG-17