### PR TITLE
ci: gate nix linux packages on required glibc <= 2.31

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -73,6 +73,9 @@ jobs:
         uses: ./.github/actions/nix-build-retry
         with:
           attr: .#${{ matrix.attr }}
+      - name: Check glibc floor
+        if: ${{ matrix.attr != '' }}
+        run: ./scripts/check-glibc-floor.sh "${{ matrix.attr }}"
 
   nix-build-checks-aarch64-linux:
     name: >-
@@ -192,6 +195,9 @@ jobs:
         uses: ./.github/actions/nix-build-retry
         with:
           attr: .#${{ matrix.attr }}
+      - name: Check glibc floor
+        if: ${{ matrix.attr != '' }}
+        run: ./scripts/check-glibc-floor.sh "${{ matrix.attr }}"
 
   nix-build-checks-x86_64-linux:
     name: >-

--- a/scripts/check-glibc-floor.sh
+++ b/scripts/check-glibc-floor.sh
@@ -4,15 +4,17 @@ set -Eeu -o pipefail
 
 MAX_ALLOWED="2.31"
 
-FLOOR=$(find -L result -type f -exec objdump -T {} \; 2>/dev/null \
-  | grep -oE 'GLIBC_[0-9.]+' | sed 's/GLIBC_//' | sort -V | tail -1)
+HIT=$(find -L result -type f -exec sh -c \
+  'objdump -T "$1" 2>/dev/null | grep -oE "GLIBC_[0-9.]+" | sed -E "s#GLIBC_([0-9.]+)#\1 $1#"' _ {} \; \
+  | sort -V | tail -1)
 
-if [ -z "$FLOOR" ]; then
+if [ -z "$HIT" ]; then
   exit 0
 fi
 
+FLOOR=${HIT%% *}
 echo "glibc floor: $FLOOR (max allowed: $MAX_ALLOWED)"
 if [ "$(printf '%s\n%s' "$MAX_ALLOWED" "$FLOOR" | sort -V | tail -1)" != "$MAX_ALLOWED" ]; then
-  echo "::error::glibc floor $FLOOR exceeds max allowed $MAX_ALLOWED in ${1:-result}"
+  echo "::error::glibc floor $HIT exceeds max allowed $MAX_ALLOWED in ${1:-result}"
   exit 1
 fi

--- a/scripts/check-glibc-floor.sh
+++ b/scripts/check-glibc-floor.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Fails if any file in ./result requires a glibc symbol version above MAX_ALLOWED.
+set -Eeu -o pipefail
+
+MAX_ALLOWED="2.31"
+
+FLOOR=$(find -L result -type f -exec objdump -T {} \; 2>/dev/null \
+  | grep -oE 'GLIBC_[0-9.]+' | sed 's/GLIBC_//' | sort -V | tail -1)
+
+if [ -z "$FLOOR" ]; then
+  exit 0
+fi
+
+echo "glibc floor: $FLOOR (max allowed: $MAX_ALLOWED)"
+if [ "$(printf '%s\n%s' "$MAX_ALLOWED" "$FLOOR" | sort -V | tail -1)" != "$MAX_ALLOWED" ]; then
+  echo "::error::glibc floor $FLOOR exceeds max allowed $MAX_ALLOWED in ${1:-result}"
+  exit 1
+fi

--- a/scripts/check-glibc-floor.sh
+++ b/scripts/check-glibc-floor.sh
@@ -5,16 +5,16 @@ set -Eeu -o pipefail
 MAX_ALLOWED="2.31"
 
 HIT=$(find -L result -type f -exec sh -c \
-  'objdump -T "$1" 2>/dev/null | grep -oE "GLIBC_[0-9.]+" | sed -E "s#GLIBC_([0-9.]+)#\1 $1#"' _ {} \; \
-  | sort -V | tail -1)
+	'objdump -T "$1" 2>/dev/null | grep -oE "GLIBC_[0-9.]+" | sed -E "s#GLIBC_([0-9.]+)#\1 $1#"' _ {} \; |
+	sort -V | tail -1)
 
 if [ -z "$HIT" ]; then
-  exit 0
+	exit 0
 fi
 
 FLOOR=${HIT%% *}
 echo "glibc floor: $FLOOR (max allowed: $MAX_ALLOWED)"
 if [ "$(printf '%s\n%s' "$MAX_ALLOWED" "$FLOOR" | sort -V | tail -1)" != "$MAX_ALLOWED" ]; then
-  echo "::error::glibc floor $HIT exceeds max allowed $MAX_ALLOWED in ${1:-result}"
-  exit 1
+	echo "::error::glibc floor $HIT exceeds max allowed $MAX_ALLOWED in ${1:-result}"
+	exit 1
 fi


### PR DESCRIPTION
### Why?

Supautils is `dlopen`ed into running postgresql and resolves `glibc` from the one that is already loaded. So it needs to be compatible with old `glibc`. See https://github.com/supabase/postgres/pull/2436

### What

Adds a step to both Linux package matrix jobs that scans every built `legacyPackages.*` artifact for `objdump -T` GLIBC symbol versions and fails if any exceed 2.31 (Ubuntu 20.04 / Debian 11 floor).

## Test plan
- [ ] CI run on this PR exercises the new step across the Linux package matrix

MPG-126