### PR TITLE
fix: harden search_path in amcheck after-create.sql

### DIFF
--- a/ansible/files/postgresql_extension_custom_scripts/amcheck/after-create.sql
+++ b/ansible/files/postgresql_extension_custom_scripts/amcheck/after-create.sql
@@ -4,13 +4,13 @@ declare
   saved_search_path text := (select current_setting('search_path'));
   r record;
 begin
-  perform set_config('search_path', '', true);
+  perform set_config('search_path', 'pg_catalog, pg_temp', true);
 
   for r in
     select p.oid::regprocedure as sig
-      from pg_depend d
-      join pg_proc p on p.oid = d.objid and d.classid = 'pg_proc'::regclass
-      join pg_extension e on e.oid = d.refobjid
+      from pg_catalog.pg_depend d
+      join pg_catalog.pg_proc p on p.oid = d.objid and d.classid = 'pg_proc'::regclass
+      join pg_catalog.pg_extension e on e.oid = d.refobjid
      where e.extname = 'amcheck' and d.deptype = 'e'
   loop
     execute format('grant execute on routine %s to postgres', r.sig);


### PR DESCRIPTION
search_path='' still lets pg_temp shadow unqualified pg_depend/pg_proc/pg_extension. Use pg_catalog, pg_temp + qualify refs.